### PR TITLE
Improve description of non-deterministic channels in the basic training

### DIFF
--- a/docs/basic_training/cache_and_resume.md
+++ b/docs/basic_training/cache_and_resume.md
@@ -249,7 +249,7 @@ Channel
 
 #### Non-deterministic input channels
 
-While dataflow channel ordering is guaranteed (i.e. data is read in the same order in which it’s written in the channel), a process can declare as input two or more channels each of which is the output of a **different** process, the overall input ordering is not consistent over different executions.
+While dataflow channel ordering is guaranteed (i.e. data is read in the same order in which it’s written in the channel), a process can declare as input two or more channels each of which is the output of a **different** process. Due to the parallel execution of these processes, the ordering of the elements in the input channels of the downstream process is not consistent over different executions.
 
 In practical terms, consider the following snippet:
 


### PR DESCRIPTION
I tried to improve it without changing much of the original structure, but I think this is a good opportunity to rewrite this part (and mention the `fair` directive)