### PR TITLE
Add links to cacheing blog posts

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -73,25 +73,27 @@ In order to keep consistency in translations, every language should have a trans
 ## Merging
 
 Aiming at a more comprehensive git history, pull request commits will be [squashed](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) with a commit message outlining:
-  - What file(s)/page(s) the PR translated (preferably, 1 PR per file)
-  - What training material the translated file(s)/page(s) is/are part of
-  - What language it was translated into
+
+-   What file(s)/page(s) the PR translated (preferably, 1 PR per file)
+-   What training material the translated file(s)/page(s) is/are part of
+-   What language it was translated into
 
 The squashing is done by the maintainers of the GitHub repository, so if you're doing a contribution, you don't have to worry about that. This practice gives more freedom/space for contributors to get into more detail in their commit title/message without having to add the info outlined above. For example:
 
 PR: Translate to Brazilian Portuguese the Tower section of the basic training
-  - Commit #1: Add missing translations to sections 1 and 2
-  - Commit #2: Add translated image to section 3
-  - Commit #3: Translate sections 4, 5 and 6
+
+-   Commit #1: Add missing translations to sections 1 and 2
+-   Commit #2: Add translated image to section 3
+-   Commit #3: Translate sections 4, 5 and 6
 
 Squashed commit to merge:
 
 ```
 Translate to Brazilian Portuguese the Tower section of the Basic Training
 
-  - Add missing translations to sections 1 and 2 
+  - Add missing translations to sections 1 and 2
   - Add translated image to section 3
-  - Translate sections 4, 5 and 6 
+  - Translate sections 4, 5 and 6
 ```
 
 It doesn't have to explicitly state every single commit in the PR.

--- a/docs/basic_training/cache_and_resume.md
+++ b/docs/basic_training/cache_and_resume.md
@@ -205,12 +205,10 @@ Being able to resume workflows is a key feature of Nextflow, but it doesn't alwa
 !!! tip
 
     To learn more details about the resume mechanism and how to troubleshoot please refer the following three blog posts:
-    
+
      1. [Demystefying Nextflow resume](https://www.nextflow.io/blog/2019/demystifying-nextflow-resume.html)
      2. [Troubleshooting Nextflow resume](https://www.nextflow.io/blog/2019/troubleshooting-nextflow-resume.html)
      3. [Analyzing caching behavior of pipelines](https://nextflow.io/blog/2022/caching-behavior-analysis.html)
-    
-
 
 #### Input file changed
 

--- a/docs/basic_training/cache_and_resume.md
+++ b/docs/basic_training/cache_and_resume.md
@@ -200,11 +200,17 @@ Finally, the `-t` option enables the creation of a basic custom provenance repor
 
 ## Resume troubleshooting
 
+Being able to resume workflows is a key feature of Nextflow, but it doesn't always work as you expect. In this section we go through a few common reasons why Nextflow may be ignoring your cached results.
+
 !!! tip
 
-    To learn more details about the resume mechanism and how to troubleshoot please refer the following three blog posts (i) [Demystefying Nextflow resume](https://www.nextflow.io/blog/2019/demystifying-nextflow-resume.html), (ii) [Troubleshooting Nextflow resume](https://www.nextflow.io/blog/2019/troubleshooting-nextflow-resume.html) and (iii) [Analyzing caching behavior of pipelines](https://nextflow.io/blog/2022/caching-behavior-analysis.html)
+    To learn more details about the resume mechanism and how to troubleshoot please refer the following three blog posts:
     
-If your workflow execution is not resumed as expected with one or more tasks being unexpectedly re-executed each time, these may be the most likely causes:
+     1. [Demystefying Nextflow resume](https://www.nextflow.io/blog/2019/demystifying-nextflow-resume.html)
+     2. [Troubleshooting Nextflow resume](https://www.nextflow.io/blog/2019/troubleshooting-nextflow-resume.html)
+     3. [Analyzing caching behavior of pipelines](https://nextflow.io/blog/2022/caching-behavior-analysis.html)
+    
+
 
 #### Input file changed
 

--- a/docs/basic_training/cache_and_resume.md
+++ b/docs/basic_training/cache_and_resume.md
@@ -204,7 +204,7 @@ Being able to resume workflows is a key feature of Nextflow, but it doesn't alwa
 
 !!! tip
 
-    To learn more details about the resume mechanism and how to troubleshoot please refer the following three blog posts:
+    To learn more details about the resume mechanism and how to troubleshoot please refer to the following three blog posts:
 
      1. [Demystifying Nextflow resume](https://www.nextflow.io/blog/2019/demystifying-nextflow-resume.html)
      2. [Troubleshooting Nextflow resume](https://www.nextflow.io/blog/2019/troubleshooting-nextflow-resume.html)

--- a/docs/basic_training/cache_and_resume.md
+++ b/docs/basic_training/cache_and_resume.md
@@ -200,6 +200,10 @@ Finally, the `-t` option enables the creation of a basic custom provenance repor
 
 ## Resume troubleshooting
 
+!!! tip
+
+    To learn more details about the resume mechanism and how to troubleshoot please refer the following three blog posts (i) [Demystefying Nextflow resume](https://www.nextflow.io/blog/2019/demystifying-nextflow-resume.html), (ii) [Troubleshooting Nextflow resume](https://www.nextflow.io/blog/2019/troubleshooting-nextflow-resume.html) and (iii) [Analyzing caching behavior of pipelines](https://nextflow.io/blog/2022/caching-behavior-analysis.html)
+    
 If your workflow execution is not resumed as expected with one or more tasks being unexpectedly re-executed each time, these may be the most likely causes:
 
 #### Input file changed

--- a/docs/basic_training/cache_and_resume.md
+++ b/docs/basic_training/cache_and_resume.md
@@ -206,7 +206,7 @@ Being able to resume workflows is a key feature of Nextflow, but it doesn't alwa
 
     To learn more details about the resume mechanism and how to troubleshoot please refer the following three blog posts:
 
-     1. [Demystefying Nextflow resume](https://www.nextflow.io/blog/2019/demystifying-nextflow-resume.html)
+     1. [Demystifying Nextflow resume](https://www.nextflow.io/blog/2019/demystifying-nextflow-resume.html)
      2. [Troubleshooting Nextflow resume](https://www.nextflow.io/blog/2019/troubleshooting-nextflow-resume.html)
      3. [Analyzing caching behavior of pipelines](https://nextflow.io/blog/2022/caching-behavior-analysis.html)
 

--- a/docs/basic_training/cache_and_resume.pt.md
+++ b/docs/basic_training/cache_and_resume.pt.md
@@ -200,7 +200,15 @@ Finalmente, a opção `-t` permite a criação de um relatório básico e custom
 
 ## Resolução de problemas de reentrância
 
-Se a execução do seu fluxo de trabalho não foi retomada como esperado com uma ou mais tarefas sendo inesperadamente re-executadas toda vez, essas são as causas mais prováveis:
+Ser capaz de retomar fluxos de trabalho é um recurso importante do Nextflow, mas nem sempre funciona como você espera. Nesta seção, analisamos alguns motivos comuns pelos quais o Nextflow pode estar ignorando seus resultados em cache.
+
+!!! tip
+
+    Para saber mais detalhes sobre o mecanismo de reentrância e como solucionar problemas, consulte as três postagens de blog a seguir:
+
+     1. [Demystifying Nextflow resume](https://www.nextflow.io/blog/2019/demystifying-nextflow-resume.html)
+     2. [Troubleshooting Nextflow resume](https://www.nextflow.io/blog/2019/troubleshooting-nextflow-resume.html)
+     3. [Analyzing caching behavior of pipelines](https://nextflow.io/blog/2022/caching-behavior-analysis.html)
 
 #### Arquivos de entrada mudados
 


### PR DESCRIPTION
Hi folks 👋 

I thought that [Resume troubleshooting](https://training.nextflow.io/basic_training/cache_and_resume/#resume-troubleshooting) might be a good place to mention the three cacheing related blogposts.

I was in doubt whether it should be at the end of the content as another point but then I thought, for the curious (or frustrated) folks putting it as a tip might be reasonable.

@mribeirodantas , desculpa que não adiocionei o português - nem tinha certeza que escolhi o lugar certo para adicionar o TIP em inglês. Mas posso fazer isso se vocês concordam mencionar os blogs como um TIP.
