### PR TITLE
Improve syntax consistency of training material

### DIFF
--- a/docs/basic_training/cache_and_resume.md
+++ b/docs/basic_training/cache_and_resume.md
@@ -229,13 +229,13 @@ For example:
 
 ```groovy linenums="1"
 Channel
-    .of(1,2,3)
-    .map { it -> X=it; X+=2 }
+    .of(1, 2, 3)
+    .map { it -> X = it; X += 2 }
     .view { "ch1 = $it" }
 
 Channel
-    .of(1,2,3)
-    .map { it -> X=it; X*=2 }
+    .of(1, 2, 3)
+    .map { it -> X = it; X *= 2 }
     .view { "ch2 = $it" }
 ```
 
@@ -245,13 +245,13 @@ The correct implementation requires the use of the `def` keyword to declare the 
 
 ```groovy linenums="1"
 Channel
-    .of(1,2,3)
-    .map { it -> def X=it; X+=2 }
+    .of(1, 2, 3)
+    .map { it -> def X = it; X += 2 }
     .println { "ch1 = $it" }
 
 Channel
-    .of(1,2,3)
-    .map { it -> def X=it; X*=2 }
+    .of(1, 2, 3)
+    .map { it -> def X = it; X *= 2 }
     .println { "ch2 = $it" }
 ```
 
@@ -276,7 +276,7 @@ process FOO {
 }
 
 workflow {
-    channel.of('A','B','C','D') | FOO | view
+    channel.of('A', 'B', 'C', 'D') | FOO | view
 }
 ```
 

--- a/docs/basic_training/cache_and_resume.md
+++ b/docs/basic_training/cache_and_resume.md
@@ -300,18 +300,18 @@ A common solution for this is to use what is commonly referred to as a _meta map
 // These would normally be outputs from upstream processes.
 Channel
     .of(
-        [[id:'sample_1'], '/path/to/sample_1.bam'],
-        [[id:'sample_2'], '/path/to/sample_2.bam']
+        [[id: 'sample_1'], '/path/to/sample_1.bam'],
+        [[id: 'sample_2'], '/path/to/sample_2.bam']
     )
     .set { bam }
 
 // NB: sample_2 is now the first element, instead of sample_1
 Channel
     .of(
-        [[id:'sample_2'], '/path/to/sample_2.bai'],
-        [[id:'sample_1'], '/path/to/sample_1.bai']
+        [[id: 'sample_2'], '/path/to/sample_2.bai'],
+        [[id: 'sample_1'], '/path/to/sample_1.bai']
     )
-  .set { bai }
+    .set { bai }
 
 // Instead of feeding the downstream process with these two channels separately, we can
 // join them and provide a single channel where the sample meta map is implicitly matched:

--- a/docs/basic_training/cache_and_resume.pt.md
+++ b/docs/basic_training/cache_and_resume.pt.md
@@ -299,16 +299,16 @@ Uma solução comum para isso é usar o que é comumente chamado de _meta mapa_ 
 // Estes abaixo seriam normalmente as saídas de processos anteriores
 Channel
     .of(
-        [[id:'amostra_1'], '/caminho/para/amostra_1.bam'],
-        [[id:'amostra_2'], '/caminho/para/amostra_2.bam']
+        [[id: 'amostra_1'], '/caminho/para/amostra_1.bam'],
+        [[id: 'amostra_2'], '/caminho/para/amostra_2.bam']
     )
     .set { bam }
 
 // Nota: amostra_2 é agora o primeiro elemento, em vez de amostra_1
 Channel
     .of(
-        [[id:'amostra_2'], '/caminho/para/amostra_2.bai'],
-        [[id:'amostra_1'], '/caminho/para/amostra_1.bai']
+        [[id: 'amostra_2'], '/caminho/para/amostra_2.bai'],
+        [[id: 'amostra_1'], '/caminho/para/amostra_1.bai']
     )
     .set { bai }
 

--- a/docs/basic_training/cache_and_resume.pt.md
+++ b/docs/basic_training/cache_and_resume.pt.md
@@ -228,13 +228,13 @@ O Nextflow é desenvolvido para simplificar programação paralela, de modo que 
 
 ```groovy linenums="1"
 Channel
-    .of(1,2,3)
-    .map { it -> X=it; X+=2 }
+    .of(1, 2, 3)
+    .map { it -> X = it; X += 2 }
     .view { "canal1 = $it" }
 
 Channel
-    .of(1,2,3)
-    .map { it -> X=it; X*=2 }
+    .of(1, 2, 3)
+    .map { it -> X = it; X *= 2 }
     .view { "canal2 = $it" }
 ```
 
@@ -244,13 +244,13 @@ A implementação correta requer o uso da palavra chave `def` para declarar a va
 
 ```groovy linenums="1"
 Channel
-    .of(1,2,3)
-    .map { it -> def X=it; X+=2 }
+    .of(1, 2, 3)
+    .map { it -> def X = it; X += 2 }
     .println { "canal1 = $it" }
 
 Channel
-    .of(1,2,3)
-    .map { it -> def X=it; X*=2 }
+    .of(1, 2, 3)
+    .map { it -> def X = it; X *= 2 }
     .println { "canal2 = $it" }
 ```
 
@@ -275,7 +275,7 @@ process FOO {
 }
 
 workflow {
-    channel.of('A','B','C','D') | FOO | view
+    channel.of('A', 'B', 'C', 'D') | FOO | view
 }
 ```
 

--- a/docs/basic_training/channels.md
+++ b/docs/basic_training/channels.md
@@ -75,7 +75,7 @@ process SUM {
 }
 
 workflow {
-    SUM(ch1,ch2).view()
+    SUM(ch1, ch2).view()
 }
 ```
 
@@ -132,7 +132,7 @@ process SUM {
 }
 
 workflow {
-    SUM(ch1,ch2.first()).view()
+    SUM(ch1, ch2.first()).view()
 }
 ```
 

--- a/docs/basic_training/channels.md
+++ b/docs/basic_training/channels.md
@@ -33,7 +33,7 @@ Try the following snippets:
     Click the :material-plus-circle: icons in the code for explanations.
 
 ```groovy linenums="1"
-ch = Channel.of(1,2,3)
+ch = Channel.of(1, 2, 3)
 println(ch) // (1)!
 ch.view() // (2)!
 ```
@@ -46,7 +46,7 @@ ch.view() // (2)!
     Try to execute this snippet. You can do that by creating a new `.nf` file or by editing an already existing `.nf` file.
 
     ```groovy linenums="1"
-    ch = Channel.of(1,2,3)
+    ch = Channel.of(1, 2, 3)
     ch.view()
     ```
 
@@ -57,7 +57,7 @@ A **value** channel (a.k.a. singleton channel) by definition is bound to a singl
 To better understand the difference between value and queue channels, save the snippet below as `example.nf`.
 
 ```groovy linenums="1" title="example.nf" linenums="1"
-ch1 = Channel.of(1,2,3)
+ch1 = Channel.of(1, 2, 3)
 ch2 = Channel.of(1)
 
 process SUM {
@@ -114,7 +114,7 @@ DataflowVariable(value=1)
 There is no poison pill, and that’s why we get a different output with the code below, where `ch2` is turned into a value channel through the `first` operator.
 
 ```groovy linenums="1"
-ch1 = Channel.of(1,2,3)
+ch1 = Channel.of(1, 2, 3)
 ch2 = Channel.of(1)
 
 process SUM {
@@ -157,7 +157,7 @@ The `value` factory method is used to create a _value_ channel. An optional not 
 ```groovy linenums="1"
 ch1 = Channel.value() // (1)!
 ch2 = Channel.value('Hello there') // (2)!
-ch3 = Channel.value([1,2,3,4,5]) // (3)!
+ch3 = Channel.value([1, 2, 3, 4, 5]) // (3)!
 ```
 
 1. Creates an _empty_ value channel
@@ -186,8 +186,8 @@ The method `Channel.of` works in a similar manner to `Channel.from` (which is no
 
 ```groovy linenums="1"
 Channel
-  .of(1..23, 'X', 'Y')
-  .view()
+    .of(1..23, 'X', 'Y')
+    .view()
 ```
 
 ### `fromList()`
@@ -198,8 +198,8 @@ The method `Channel.fromList` creates a channel emitting the elements provided b
 list = ['hello', 'world']
 
 Channel
-  .fromList(list)
-  .view()
+    .fromList(list)
+    .view()
 ```
 
 ### `fromPath()`
@@ -236,7 +236,7 @@ Learn more about the glob patterns syntax at [this link](https://docs.oracle.com
 
         ```groovy linenums="1"
         Channel.fromPath('./data/ggal/**.fq', hidden: true)
-          .view()
+            .view()
         ```
 
 ### `fromFilePairs()`
@@ -245,8 +245,8 @@ The `fromFilePairs` method creates a channel emitting the file pairs matching a 
 
 ```groovy linenums="1"
 Channel
-  .fromFilePairs('./data/ggal/*_{1,2}.fq')
-  .view()
+    .fromFilePairs('./data/ggal/*_{1,2}.fq')
+    .view()
 ```
 
 It will produce an output similar to the following:
@@ -281,7 +281,7 @@ It will produce an output similar to the following:
 
         ```groovy linenums="1"
         Channel.fromFilePairs('./data/ggal/*_{1,2}.fq', flat: true)
-          .view()
+            .view()
         ```
 
         Then check the square brackets around the file names, to see the difference with `flat`.
@@ -312,8 +312,8 @@ For example, the following snippet will print the contents of an NCBI project ID
 params.ncbi_api_key = '<Your API key here>'
 
 Channel
-  .fromSRA(['SRP073307'], apiKey: params.ncbi_api_key)
-  .view()
+    .fromSRA(['SRP073307'], apiKey: params.ncbi_api_key)
+    .view()
 ```
 
 !!! info ""
@@ -335,8 +335,8 @@ Multiple accession IDs can be specified using a list object:
 ```groovy linenums="1"
 ids = ['ERR908507', 'ERR908506', 'ERR908505']
 Channel
-  .fromSRA(ids, apiKey: params.ncbi_api_key)
-  .view()
+    .fromSRA(ids, apiKey: params.ncbi_api_key)
+    .view()
 ```
 
 ```groovy
@@ -421,7 +421,7 @@ Channel
 You can also make counts for each line:
 
 ```groovy linenums="1"
-count=0
+count = 0
 
 Channel
     .fromPath('data/meta/random.txt')
@@ -434,7 +434,7 @@ Finally, you can also use the operator on plain files (outside of the channel co
 ```groovy linenums="1"
 def f = file('data/meta/random.txt')
 def lines = f.splitText()
-def count=0
+def count = 0
 for (String row : lines) {
     log.info "${count++} ${row.toUpperCase()}"
 }
@@ -525,7 +525,7 @@ for (List row : lines) {
         Channel
             .fromPath("fastq.csv")
             .splitCsv()
-            .view () { row -> "${row[0]},${row[1]},${row[2]}" }
+            .view { row -> "${row[0]},${row[1]},${row[2]}" }
             .set { read_pairs_ch }
         ```
 
@@ -593,13 +593,13 @@ for (List row : lines) {
 
 ### Tab separated values (.tsv)
 
-Parsing TSV files works in a similar way, simply add the `sep:'\t'` option in the `splitCsv` context:
+Parsing TSV files works in a similar way, simply add the `sep: '\t'` option in the `splitCsv` context:
 
 ```groovy linenums="1"
 Channel
     .fromPath("data/meta/regions.tsv", checkIfExists: true)
     // use `sep` option to parse TAB separated files
-    .splitCsv(sep:'\t')
+    .splitCsv(sep: '\t')
     .view()
 ```
 
@@ -614,7 +614,7 @@ Channel
         Channel
             .fromPath("data/meta/regions.tsv", checkIfExists: true)
             // use `sep` option to parse TAB separated files
-            .splitCsv(sep:'\t', header: true)
+            .splitCsv(sep: '\t', header: true)
             // row is a list object
             .view { row -> "${row.patient_id}" }
         ```

--- a/docs/basic_training/channels.md
+++ b/docs/basic_training/channels.md
@@ -673,6 +673,7 @@ process FOO {
     output:
     stdout
 
+    script:
     """
     echo $patient_id has $feature as feature
     """

--- a/docs/basic_training/channels.pt.md
+++ b/docs/basic_training/channels.pt.md
@@ -674,6 +674,7 @@ process FOO {
     output:
     stdout
 
+    script:
     """
     echo $patient_id has $feature as feature
     """

--- a/docs/basic_training/channels.pt.md
+++ b/docs/basic_training/channels.pt.md
@@ -75,7 +75,7 @@ process SUM {
 }
 
 workflow {
-    SUM(canal1,canal2).view()
+    SUM(canal1, canal2).view()
 }
 ```
 
@@ -132,7 +132,7 @@ process SUM {
 }
 
 workflow {
-    SUM(canal1,canal2.first()).view()
+    SUM(canal1, canal2.first()).view()
 }
 ```
 

--- a/docs/basic_training/channels.pt.md
+++ b/docs/basic_training/channels.pt.md
@@ -33,7 +33,7 @@ Tente os seguintes trechos de código:
     Clique no ícone :material-plus-circle: no código para ver explicações.
 
 ```groovy linenums="1"
-canal = Channel.of(1,2,3)
+canal = Channel.of(1, 2, 3)
 println(canal) // (1)!
 canal.view() // (2)!
 ```
@@ -46,7 +46,7 @@ canal.view() // (2)!
     Tente executar este trecho de código. Você pode fazer isso criando um novo arquivo `.nf` ou editando um arquivo `.nf` já existente.
 
     ```groovy linenums="1"
-    canal = Channel.of(1,2,3)
+    canal = Channel.of(1, 2, 3)
     canal.view()
     ```
 
@@ -57,7 +57,7 @@ Um canal de **valor** (também conhecido como canal singleton), por definição,
 Para entender melhor a diferença entre canais de valor e de fila, salve o trecho abaixo como `exemplo.nf`.
 
 ```groovy linenums="1" title="exemplo.nf" linenums="1"
-canal1 = Channel.of(1,2,3)
+canal1 = Channel.of(1, 2, 3)
 canal2 = Channel.of(1)
 
 process SUM {
@@ -114,7 +114,7 @@ DataflowVariable(value=1)
 Não há pílula de veneno, e é por isso que obtemos uma saída diferente com o código abaixo, onde `canal2` é transformado em um canal de valor por meio do operador `first`.
 
 ```groovy linenums="1"
-canal1 = Channel.of(1,2,3)
+canal1 = Channel.of(1, 2, 3)
 canal2 = Channel.of(1)
 
 process SUM {
@@ -157,7 +157,7 @@ A fábrica de canal `value` é utilizada para criar um canal de _valor_. Um argu
 ```groovy linenums="1"
 canal1 = Channel.value() // (1)!
 canal2 = Channel.value('Olá, você!') // (2)!
-canal3 = Channel.value([1,2,3,4,5]) // (3)!
+canal3 = Channel.value([1, 2, 3, 4, 5]) // (3)!
 ```
 
 1. Cria um canal de valor _vazio_
@@ -422,7 +422,7 @@ Channel
 Você também pode fazer contagens para cada linha:
 
 ```groovy linenums="1"
-contador=0
+contador = 0
 
 Channel
     .fromPath('data/meta/random.txt')
@@ -435,7 +435,7 @@ Por fim, você também pode usar o operador em arquivos simples (fora do context
 ```groovy linenums="1"
 def f = file('data/meta/random.txt')
 def linhas = f.splitText()
-def contador=0
+def contador = 0
 for (String linha : linhas) {
     log.info "${contador++} ${linha.toUpperCase()}"
 }
@@ -526,7 +526,7 @@ for (List linha : linhas) {
         Channel
             .fromPath("fastq.csv")
             .splitCsv()
-            .view () { linha -> "${linha[0]},${linha[1]},${linha[2]}" }
+            .view { linha -> "${linha[0]},${linha[1]},${linha[2]}" }
             .set { read_pairs_ch }
         ```
 
@@ -594,13 +594,13 @@ for (List linha : linhas) {
 
 ### Valores separados por tabulação (.tsv)
 
-A análise de arquivos TSV funciona de maneira semelhante, basta adicionar a opção `sep:'\t'` no contexto do `splitCsv`:
+A análise de arquivos TSV funciona de maneira semelhante, basta adicionar a opção `sep: '\t'` no contexto do `splitCsv`:
 
 ```groovy linenums="1"
 Channel
     .fromPath("data/meta/regions.tsv", checkIfExists: true)
     // Use a opção `sep` para analisar arquivos com tabulação como separador
-    .splitCsv(sep:'\t')
+    .splitCsv(sep: '\t')
     .view()
 ```
 
@@ -615,7 +615,7 @@ Channel
         Channel
             .fromPath("data/meta/regions.tsv", checkIfExists: true)
             // Use a opção `sep` para analisar arquivos com tabulação como separador
-            .splitCsv(sep:'\t', header: true)
+            .splitCsv(sep: '\t', header: true)
             // linha é um objeto de lista
             .view { linha -> "${linha.patient_id}" }
         ```

--- a/docs/basic_training/config.md
+++ b/docs/basic_training/config.md
@@ -132,6 +132,7 @@ Save the above snippet as a file named `my-env.config`. Then save the snippet be
 process FOO {
     debug true
 
+    script:
     '''
     env | egrep 'ALPHA|BETA'
     '''

--- a/docs/basic_training/config.md
+++ b/docs/basic_training/config.md
@@ -236,8 +236,8 @@ Finally, directives that are to be repeated in the process definition, in the co
 
 ```groovy linenums="1"
 process {
-    pod = [ [env: 'FOO', value: '123'],
-            [env: 'BAR', value: '456'] ]
+    pod = [[env: 'FOO', value: '123'],
+            [env: 'BAR', value: '456']]
 }
 ```
 

--- a/docs/basic_training/config.md
+++ b/docs/basic_training/config.md
@@ -238,7 +238,7 @@ Finally, directives that are to be repeated in the process definition, in the co
 ```groovy linenums="1"
 process {
     pod = [[env: 'FOO', value: '123'],
-            [env: 'BAR', value: '456']]
+           [env: 'BAR', value: '456']]
 }
 ```
 

--- a/docs/basic_training/config.pt.md
+++ b/docs/basic_training/config.pt.md
@@ -132,6 +132,7 @@ Salve o trecho acima como um arquivo chamado `meu-env.config`. Em seguida, salve
 process FOO {
     debug true
 
+    script:
     '''
     env | egrep 'ALFA|BETA'
     '''

--- a/docs/basic_training/config.pt.md
+++ b/docs/basic_training/config.pt.md
@@ -220,7 +220,7 @@ E o equivalente em um arquivo de configuração, se você preferir configurar is
 ```groovy linenums="1"
 process {
     withName: FOO {
-      memory = { 4.GB * task.cpus }
+        memory = { 4.GB * task.cpus }
     }
 }
 ```
@@ -238,7 +238,7 @@ Por fim, as diretivas que devem ser repetidas na definição do processo e nos a
 ```groovy linenums="1"
 process {
     pod = [[ambiente: 'FOO', valor: '123'],
-            [ambiente: 'BAR', valor: '456']]
+           [ambiente: 'BAR', valor: '456']]
 }
 ```
 

--- a/docs/basic_training/config.pt.md
+++ b/docs/basic_training/config.pt.md
@@ -236,8 +236,8 @@ Por fim, as diretivas que devem ser repetidas na definição do processo e nos a
 
 ```groovy linenums="1"
 process {
-    pod = [ [ambiente: 'FOO', valor: '123'],
-            [ambiente: 'BAR', valor: '456'] ]
+    pod = [[ambiente: 'FOO', valor: '123'],
+            [ambiente: 'BAR', valor: '456']]
 }
 ```
 

--- a/docs/basic_training/containers.md
+++ b/docs/basic_training/containers.md
@@ -546,7 +546,7 @@ Contrary to other registries that will pull the latest image when no tag (versio
         process QUANTIFICATION {
             tag "Salmon on $sample_id"
             container 'quay.io/biocontainers/salmon:1.7.0--h84f40af_0'
-            publishDir params.outdir, mode:'copy'
+            publishDir params.outdir, mode: 'copy'
         ...
         ```
 

--- a/docs/basic_training/containers.pt.md
+++ b/docs/basic_training/containers.pt.md
@@ -546,7 +546,7 @@ Contrariamente a outros registros que irão puxar a última imagem quando nenhum
         process QUANTIFICATION {
             tag "Salmon on $sample_id"
             container 'quay.io/biocontainers/salmon:1.7.0--h84f40af_0'
-            publishDir params.outdir, mode:'copy'
+            publishDir params.outdir, mode: 'copy'
         ...
         ```
 

--- a/docs/basic_training/executors.md
+++ b/docs/basic_training/executors.md
@@ -140,6 +140,7 @@ The workflow script:
 process TASK1 {
     label 'long'
 
+    script:
     """
     first_command --here
     """
@@ -148,6 +149,7 @@ process TASK1 {
 process TASK2 {
     label 'short'
 
+    script:
     """
     second_command --here
     """

--- a/docs/basic_training/executors.md
+++ b/docs/basic_training/executors.md
@@ -205,7 +205,6 @@ Configuration profiles are defined by using the special scope `profiles` which g
 
 ```groovy linenums="1"
 profiles {
-
     standard {
         params.genome = '/local/path/ref.fasta'
         process.executor = 'local'

--- a/docs/basic_training/executors.pt.md
+++ b/docs/basic_training/executors.pt.md
@@ -139,6 +139,7 @@ O script do fluxo de trabalho:
 process TAREFA1 {
     label 'longo'
 
+    script:
     """
     primeiro_comando --aqui
     """
@@ -147,6 +148,7 @@ process TAREFA1 {
 process TAREFA2 {
     label 'curto'
 
+    script:
     """
     segundo_comando --aqui
     """

--- a/docs/basic_training/executors.pt.md
+++ b/docs/basic_training/executors.pt.md
@@ -204,7 +204,6 @@ Os perfis de configuração são definidos usando o escopo especial `profiles` q
 
 ```groovy linenums="1"
 profiles {
-
     standard {
         params.genoma = '/local/caminho/ref.fasta'
         process.executor = 'local'

--- a/docs/basic_training/groovy.md
+++ b/docs/basic_training/groovy.md
@@ -137,7 +137,7 @@ assert [4, 2, 1, 3].findAll { it % 2 == 0 } == [4, 2]
 Maps are like lists that have an arbitrary key instead of an integer. Therefore, the syntax is very much aligned.
 
 ```groovy linenums="1"
-map = [a:0, b:1, c:2]
+map = [a: 0, b: 1, c: 2]
 ```
 
 Maps can be accessed in a conventional square-bracket syntax or as if the key was a property of the map.
@@ -162,7 +162,7 @@ To add data or to modify a map, the syntax is similar to adding values to a list
 map['a'] = 'x' // (1)!
 map.b = 'y' // (2)!
 map.put('c', 'z') // (3)!
-assert map == [a:'x', b:'y', c:'z']
+assert map == [a: 'x', b: 'y', c: 'z']
 ```
 
 1. Using square brackets.
@@ -306,7 +306,7 @@ if (x > 10)
 The classical `for` loop syntax is supported as shown here:
 
 ```groovy linenums="1"
-for (int i = 0; i <3; i++) {
+for (int i = 0; i < 3; i++) {
     println("Hello World $i")
 }
 ```
@@ -327,7 +327,7 @@ It is possible to define a custom function into a script, as shown here:
 
 ```groovy linenums="1"
 int fib(int n) {
-    return n < 2 ? 1 : fib(n-1) + fib(n-2)
+    return n < 2 ? 1 : fib(n - 1) + fib(n - 2)
 }
 
 assert fib(10)==89
@@ -337,7 +337,7 @@ A function can take multiple arguments separating them with a comma. The `return
 
 ```groovy linenums="1"
 def fact(n) {
-    n > 1 ? n * fact(n-1) : 1
+    n > 1 ? n * fact(n - 1) : 1
 }
 
 assert fact(5) == 120

--- a/docs/basic_training/groovy.md
+++ b/docs/basic_training/groovy.md
@@ -74,7 +74,7 @@ The `def` should be always used when defining variables local to a function or a
 A List object can be defined by placing the list items in square brackets:
 
 ```groovy linenums="1"
-list = [10,20,30,40]
+list = [10, 20, 30, 40]
 ```
 
 You can access a given item in the list with square-bracket notation (indexes start at `0`) or using the `get` method:
@@ -103,7 +103,7 @@ assert list[0] == 10
 Lists can also be indexed with negative indexes and reversed ranges.
 
 ```groovy linenums="1"
-list = [0,1,2]
+list = [0, 1, 2]
 assert list[-1] == 2
 assert list[-1..0] == list.reverse()
 ```
@@ -115,21 +115,21 @@ assert list[-1..0] == list.reverse()
 List objects implement all methods provided by the [java.util.List](https://docs.oracle.com/javase/8/docs/api/java/util/List.html) interface, plus the extension methods provided by [Groovy](http://docs.groovy-lang.org/latest/html/groovy-jdk/java/util/List.html).
 
 ```groovy linenums="1"
-assert [1,2,3] << 1 == [1,2,3,1]
-assert [1,2,3] + [1] == [1,2,3,1]
-assert [1,2,3,1] - [1] == [2,3]
-assert [1,2,3] * 2 == [1,2,3,1,2,3]
-assert [1,[2,3]].flatten() == [1,2,3]
-assert [1,2,3].reverse() == [3,2,1]
-assert [1,2,3].collect { it+3 } == [4,5,6]
-assert [1,2,3,1].unique().size() == 3
-assert [1,2,3,1].count(1) == 2
-assert [1,2,3,4].min() == 1
-assert [1,2,3,4].max() == 4
-assert [1,2,3,4].sum() == 10
-assert [4,2,1,3].sort() == [1,2,3,4]
-assert [4,2,1,3].find { it%2 == 0 } == 4
-assert [4,2,1,3].findAll { it%2 == 0 } == [4,2]
+assert [1, 2, 3] << 1 == [1, 2, 3, 1]
+assert [1, 2, 3] + [1] == [1, 2, 3, 1]
+assert [1, 2, 3, 1] - [1] == [2, 3]
+assert [1, 2, 3] * 2 == [1, 2, 3, 1, 2, 3]
+assert [1, [2, 3]].flatten() == [1, 2, 3]
+assert [1, 2, 3].reverse() == [3, 2, 1]
+assert [1, 2, 3].collect { it + 3 } == [4, 5, 6]
+assert [1, 2, 3, 1].unique().size() == 3
+assert [1, 2, 3, 1].count(1) == 2
+assert [1, 2, 3, 4].min() == 1
+assert [1, 2, 3, 4].max() == 4
+assert [1, 2, 3, 4].sum() == 10
+assert [4, 2, 1, 3].sort() == [1, 2, 3, 4]
+assert [4, 2, 1, 3].find { it % 2 == 0 } == 4
+assert [4, 2, 1, 3].findAll { it % 2 == 0 } == [4, 2]
 ```
 
 ## Maps
@@ -266,7 +266,7 @@ if (x > 10)
     Therefore a statement like:
 
     ```groovy linenums="1"
-    list = [1,2,3]
+    list = [1, 2, 3]
     if (list != null && list.size() > 0) {
         println list
     }
@@ -278,7 +278,7 @@ if (x > 10)
     Can be written as:
 
     ```groovy linenums="1"
-    list = [1,2,3]
+    list = [1, 2, 3]
     if (list)
         println list
     else
@@ -314,7 +314,7 @@ for (int i = 0; i <3; i++) {
 Iteration over list objects is also possible using the syntax below:
 
 ```groovy linenums="1"
-list = ['a','b','c']
+list = ['a', 'b', 'c']
 
 for (String elem : list) {
     println elem
@@ -365,12 +365,12 @@ assert square(9) == 81
 As is, this may not seem interesting, but we can now pass the `square` function as an argument to other functions or methods. Some built-in functions take a function like this as an argument. One example is the `collect` method on lists:
 
 ```groovy linenums="1"
-x = [ 1, 2, 3, 4 ].collect(square)
+x = [1, 2, 3, 4].collect(square)
 println x
 ```
 
 ```console title="Output"
-[ 1, 4, 9, 16 ]
+[1, 4, 9, 16]
 ```
 
 By default, closures take a single parameter called `it`. To give it a different name use the `->` syntax. For example:
@@ -385,7 +385,7 @@ For example, when the method `each()` is applied to a map it can take a closure 
 
 ```groovy linenums="1"
 printMap = { a, b -> println "$a with value $b" }
-values = [ "Yue" : "Wu", "Mark" : "Williams", "Sudha" : "Kumari" ]
+values = ["Yue": "Wu", "Mark": "Williams", "Sudha": "Kumari"]
 values.each(printMap)
 ```
 
@@ -405,7 +405,7 @@ As an example showing both these features, see the following code fragment:
 
 ```groovy linenums="1"
 result = 0 // (1)!
-values = ["China": 1, "India" : 2, "USA" : 3] // (2)!
+values = ["China": 1, "India": 2, "USA": 3] // (2)!
 values.keySet().each { result += values[it] } // (3)!
 println result
 ```

--- a/docs/basic_training/groovy.pt.md
+++ b/docs/basic_training/groovy.pt.md
@@ -137,7 +137,7 @@ assert [4, 2, 1, 3].findAll { it % 2 == 0 } == [4, 2]
 Os mapas são como listas que possuem uma chave arbitrária em vez de um número inteiro. Portanto, a sintaxe é bem parecida.
 
 ```groovy linenums="1"
-mapa = [a:0, b:1, c:2]
+mapa = [a: 0, b: 1, c: 2]
 ```
 
 Os mapas podem ser acessados em uma sintaxe convencional de colchetes ou como se a chave fosse uma propriedade do mapa.
@@ -162,7 +162,7 @@ Para adicionar dados ou modificar um mapa, a sintaxe é semelhante à adição d
 mapa['a'] = 'x' // (1)!
 mapa.b = 'y' // (2)!
 mapa.put('c', 'z') // (3)!
-assert mapa == [a:'x', b:'y', c:'z']
+assert mapa == [a: 'x', b: 'y', c: 'z']
 ```
 
 1. Usando colchetes.
@@ -306,7 +306,7 @@ if (x > 10)
 A sintaxe clássica do loop `for` é suportada como mostrado aqui:
 
 ```groovy linenums="1"
-for (int i = 0; i <3; i++) {
+for (int i = 0; i < 3; i++) {
     println("Olá mundo $i")
 }
 ```
@@ -327,7 +327,7 @@ for (String elem : lista) {
 
 ```groovy linenums="1"
 int fib(int n) {
-    return n < 2 ? 1 : fib(n-1) + fib(n-2)
+    return n < 2 ? 1 : fib(n - 1) + fib(n - 2)
 }
 
 assert fib(10)==89
@@ -337,7 +337,7 @@ Uma função pode receber vários argumentos, separando-os com uma vírgula. A p
 
 ```groovy linenums="1"
 def fact(n) {
-    n > 1 ? n * fact(n-1) : 1
+    n > 1 ? n * fact(n - 1) : 1
 }
 
 assert fact(5) == 120
@@ -405,7 +405,7 @@ Para um exemplo mostrando esses dois recursos, consulte o seguinte trecho de có
 
 ```groovy linenums="1"
 resultado = 0 // (1)!
-valores = ["China" : 1, "India" : 2, "USA" : 3] // (2)!
+valores = ["China": 1, "India": 2, "USA": 3] // (2)!
 valores.keySet().each { resultado += valores[it] } // (3)!
 println resultado
 ```

--- a/docs/basic_training/groovy.pt.md
+++ b/docs/basic_training/groovy.pt.md
@@ -385,7 +385,7 @@ Por exemplo, quando o método `each()` é aplicado a um mapa, ele pode receber u
 
 ```groovy linenums="1"
 imprimirMapa = { a, b -> println "$a com o valor $b" }
-valores = ["Yue" : "Wu", "Mark" : "Williams", "Sudha" : "Kumari"]
+valores = ["Yue": "Wu", "Mark": "Williams", "Sudha": "Kumari"]
 valores.each(imprimirMapa)
 ```
 

--- a/docs/basic_training/groovy.pt.md
+++ b/docs/basic_training/groovy.pt.md
@@ -74,7 +74,7 @@ O `def` deve ser sempre usado ao definir variáveis locais para uma função ou 
 Um objeto List pode ser definido colocando os itens da lista entre colchetes:
 
 ```groovy linenums="1"
-lista = [10,20,30,40]
+lista = [10, 20, 30, 40]
 ```
 
 Você pode acessar um determinado item na lista com a notação de colchetes (índices começam em `0`) ou usando o método `get`:
@@ -103,7 +103,7 @@ assert lista[0] == 10
 As listas também podem ser indexadas com índices negativos e intervalos invertidos.
 
 ```groovy linenums="1"
-lista = [0,1,2]
+lista = [0, 1, 2]
 assert lista[-1] == 2
 assert lista[-1..0] == lista.reverse()
 ```
@@ -115,21 +115,21 @@ assert lista[-1..0] == lista.reverse()
 Objetos List implementam todos os métodos fornecidos pela interface [java.util.List](https://docs.oracle.com/javase/8/docs/api/java/util/List.html), mais os métodos de extensão fornecidos pelo [Groovy](http://docs.groovy-lang.org/latest/html/groovy-jdk/java/util/List.html).
 
 ```groovy linenums="1"
-assert [1,2,3] << 1 == [1,2,3,1]
-assert [1,2,3] + [1] == [1,2,3,1]
-assert [1,2,3,1] - [1] == [2,3]
-assert [1,2,3] * 2 == [1,2,3,1,2,3]
-assert [1,[2,3]].flatten() == [1,2,3]
-assert [1,2,3].reverse() == [3,2,1]
-assert [1,2,3].collect { it+3 } == [4,5,6]
-assert [1,2,3,1].unique().size() == 3
-assert [1,2,3,1].count(1) == 2
-assert [1,2,3,4].min() == 1
-assert [1,2,3,4].max() == 4
-assert [1,2,3,4].sum() == 10
-assert [4,2,1,3].sort() == [1,2,3,4]
-assert [4,2,1,3].find { it%2 == 0 } == 4
-assert [4,2,1,3].findAll { it%2 == 0 } == [4,2]
+assert [1, 2, 3] << 1 == [1, 2, 3, 1]
+assert [1, 2, 3] + [1] == [1, 2, 3, 1]
+assert [1, 2, 3, 1] - [1] == [2, 3]
+assert [1, 2, 3] * 2 == [1, 2, 3, 1, 2, 3]
+assert [1, [2, 3]].flatten() == [1, 2, 3]
+assert [1, 2, 3].reverse() == [3, 2, 1]
+assert [1, 2, 3].collect { it + 3 } == [4, 5, 6]
+assert [1, 2, 3, 1].unique().size() == 3
+assert [1, 2, 3, 1].count(1) == 2
+assert [1, 2, 3, 4].min() == 1
+assert [1, 2, 3, 4].max() == 4
+assert [1, 2, 3, 4].sum() == 10
+assert [4, 2, 1, 3].sort() == [1, 2, 3, 4]
+assert [4, 2, 1, 3].find { it % 2 == 0 } == 4
+assert [4, 2, 1, 3].findAll { it % 2 == 0 } == [4, 2]
 ```
 
 ## Mapas
@@ -266,7 +266,7 @@ if (x > 10)
     Portanto, uma declaração como:
 
     ```groovy linenums="1"
-    lista = [1,2,3]
+    lista = [1, 2, 3]
     if (lista != null && lista.size() > 0) {
         println lista
     }
@@ -278,7 +278,7 @@ if (x > 10)
     Pode ser escrita como:
 
     ```groovy linenums="1"
-    lista = [1,2,3]
+    lista = [1, 2, 3]
     if (lista)
         println lista
     else
@@ -314,7 +314,7 @@ for (int i = 0; i <3; i++) {
 A iteração sobre objetos de lista também é possível usando a sintaxe abaixo:
 
 ```groovy linenums="1"
-list = ['a','b','c']
+list = ['a', 'b', 'c']
 
 for (String elem : lista) {
     println elem
@@ -365,12 +365,12 @@ assert quadrado(9) == 81
 Da forma como foi mostrado, isso pode não parecer interessante, mas agora podemos passar a função `quadrado` como um argumento para outras funções ou métodos. Algumas funções embutidas aceitam uma função como esta como um argumento. Um exemplo é o método `collect` em listas:
 
 ```groovy linenums="1"
-x = [ 1, 2, 3, 4 ].collect(quadrado)
+x = [1, 2, 3, 4].collect(quadrado)
 println x
 ```
 
 ```console title="Output"
-[ 1, 4, 9, 16 ]
+[1, 4, 9, 16]
 ```
 
 Por padrão, as clausuras recebem um único parâmetro chamado `it`. Para dar a ele um nome diferente, use a sintaxe `->`. Por exemplo:
@@ -385,7 +385,7 @@ Por exemplo, quando o método `each()` é aplicado a um mapa, ele pode receber u
 
 ```groovy linenums="1"
 imprimirMapa = { a, b -> println "$a com o valor $b" }
-valores = [ "Yue" : "Wu", "Mark" : "Williams", "Sudha" : "Kumari" ]
+valores = ["Yue" : "Wu", "Mark" : "Williams", "Sudha" : "Kumari"]
 valores.each(imprimirMapa)
 ```
 
@@ -405,7 +405,7 @@ Para um exemplo mostrando esses dois recursos, consulte o seguinte trecho de có
 
 ```groovy linenums="1"
 resultado = 0 // (1)!
-valores = ["China": 1, "India" : 2, "USA" : 3] // (2)!
+valores = ["China" : 1, "India" : 2, "USA" : 3] // (2)!
 valores.keySet().each { resultado += valores[it] } // (3)!
 println resultado
 ```

--- a/docs/basic_training/intro.md
+++ b/docs/basic_training/intro.md
@@ -79,8 +79,8 @@ TODO: Maybe either:
     Click the :material-plus-circle: icons in the code for explanations.
 
 ```groovy title="nf-training/hello.nf" linenums="1"
-#!/usr/bin/env nextflow // (1)!
-
+#!/usr/bin/env nextflow
+// (1)!
 params.greeting = 'Hello world!' // (2)!
 greeting_ch = Channel.of(params.greeting) // (3)!
 
@@ -90,8 +90,8 @@ process SPLITLETTERS { // (4)!
 
     output: // (7)!
     path 'chunk_*' // (8)!
-
-    """ // (9)!
+    // (9)!
+    """
     printf '$x' | split -b 6 - chunk_
     """
 } // (10)!
@@ -102,8 +102,8 @@ process CONVERTTOUPPER { // (11)!
 
     output: // (14)!
     stdout // (15)!
-
-    """ // (16)!
+    // (16)!
+    """
     cat $y | tr '[a-z]' '[A-Z]'
     """
 } // (17)!

--- a/docs/basic_training/intro.md
+++ b/docs/basic_training/intro.md
@@ -90,7 +90,8 @@ process SPLITLETTERS { // (4)!
 
     output: // (7)!
     path 'chunk_*' // (8)!
-    // (9)!
+
+    script: // (9)!
     """
     printf '$x' | split -b 6 - chunk_
     """
@@ -102,7 +103,8 @@ process CONVERTTOUPPER { // (11)!
 
     output: // (14)!
     stdout // (15)!
-    // (16)!
+
+    script: // (16)!
     """
     cat $y | tr '[a-z]' '[A-Z]'
     """
@@ -210,6 +212,7 @@ process CONVERTTOUPPER {
     output:
     stdout
 
+    script:
     """
     rev $y
     """

--- a/docs/basic_training/intro.md
+++ b/docs/basic_training/intro.md
@@ -79,8 +79,7 @@ TODO: Maybe either:
     Click the :material-plus-circle: icons in the code for explanations.
 
 ```groovy title="nf-training/hello.nf" linenums="1"
-#!/usr/bin/env nextflow
-// (1)!
+#!/usr/bin/env nextflow // (1)!
 
 params.greeting = 'Hello world!' // (2)!
 greeting_ch = Channel.of(params.greeting) // (3)!
@@ -92,8 +91,7 @@ process SPLITLETTERS { // (4)!
     output: // (7)!
     path 'chunk_*' // (8)!
 
-    // (9)!
-    """
+    """ // (9)!
     printf '$x' | split -b 6 - chunk_
     """
 } // (10)!
@@ -105,8 +103,7 @@ process CONVERTTOUPPER { // (11)!
     output: // (14)!
     stdout // (15)!
 
-    // (16)!
-    """
+    """ // (16)!
     cat $y | tr '[a-z]' '[A-Z]'
     """
 } // (17)!

--- a/docs/basic_training/intro.pt.md
+++ b/docs/basic_training/intro.pt.md
@@ -92,7 +92,7 @@ process SPLITLETTERS { // (4)!
     output: // (7)!
     path 'chunk_*' // (8)!
 
-    // (9)!
+    script: // (9)!
     """
     printf '$x' | split -b 6 - chunk_
     """
@@ -105,7 +105,7 @@ process CONVERTTOUPPER { // (11)!
     output: // (14)!
     stdout // (15)!
 
-    // (16)!
+    script: // (16)!
     """
     cat $y | tr '[a-z]' '[A-Z]'
     """
@@ -211,6 +211,7 @@ process CONVERTTOUPPER {
     output:
     stdout
 
+    script:
     """
     rev $y
     """

--- a/docs/basic_training/modules.md
+++ b/docs/basic_training/modules.md
@@ -66,6 +66,7 @@ include { CONVERTTOUPPER } from './modules.nf'
             output:
             path 'chunk_*'
 
+            script:
             """
             printf '$x' | split -b 6 - chunk_
             """
@@ -78,6 +79,7 @@ include { CONVERTTOUPPER } from './modules.nf'
             output:
             stdout
 
+            script:
             """
             cat $y | tr '[a-z]' '[A-Z]'
             """
@@ -201,6 +203,7 @@ process SPLITLETTERS {
     output:
     path 'chunk_*'
 
+    script:
     """
     printf '$x' | split -b 6 - chunk_
     """
@@ -213,6 +216,7 @@ process CONVERTTOUPPER {
     output:
     stdout emit: upper
 
+    script:
     """
     cat $y | tr '[a-z]' '[A-Z]'
     """
@@ -240,7 +244,7 @@ Another way to deal with outputs in the workflow scope is to use pipes `|`.
 
     ```groovy linenums="1"
     workflow {
-        Channel.of(params.greeting) | SPLITLETTERS | flatten() | CONVERTTOUPPER | view
+        Channel.of(params.greeting) | SPLITLETTERS | flatten | CONVERTTOUPPER | view
     }
     ```
 

--- a/docs/basic_training/modules.pt.md
+++ b/docs/basic_training/modules.pt.md
@@ -66,6 +66,7 @@ include { CONVERTTOUPPER } from './modules.nf'
             output:
             path 'chunk_*'
 
+            script:
             """
             printf '$x' | split -b 6 - chunk_
             """
@@ -78,6 +79,7 @@ include { CONVERTTOUPPER } from './modules.nf'
             output:
             stdout
 
+            script:
             """
             cat $y | tr '[a-z]' '[A-Z]'
             """
@@ -201,6 +203,7 @@ process SPLITLETTERS {
     output:
     path 'chunk_*'
 
+    script:
     """
     printf '$x' | split -b 6 - chunk_
     """
@@ -213,6 +216,7 @@ process CONVERTTOUPPER {
     output:
     stdout emit: upper
 
+    script:
     """
     cat $y | tr '[a-z]' '[A-Z]'
     """
@@ -240,7 +244,7 @@ Outra maneira de lidar com as saídas no escopo do workflow é usar pipes `|`.
 
     ```groovy linenums="1"
     workflow {
-        Channel.of(params.greeting) | SPLITLETTERS | flatten() | CONVERTTOUPPER | view
+        Channel.of(params.greeting) | SPLITLETTERS | flatten | CONVERTTOUPPER | view
     }
     ```
 

--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -23,7 +23,7 @@ There are seven main groups of operators are described in greater detail within 
     Click the :material-plus-circle: icons in the code for explanations.
 
 ```groovy linenums="1"
-nums = Channel.of(1,2,3,4) // (1)!
+nums = Channel.of(1, 2, 3, 4) // (1)!
 square = nums.map { it -> it * it } // (2)!
 square.view() // (3)!
 ```
@@ -40,7 +40,7 @@ Operators can also be chained to implement custom behaviors, so the previous sni
 
 ```groovy linenums="1"
 Channel
-    .of(1,2,3,4)
+    .of(1, 2, 3, 4)
     .map { it -> it * it }
     .view()
 ```
@@ -108,7 +108,7 @@ Channel
         ```groovy linenums="1"
         Channel
             .fromPath('data/ggal/*.fq')
-            .map { file -> [ file.name, file ] }
+            .map { file -> [file.name, file] }
             .view { name, file -> "> $name : $file" }
         ```
 
@@ -117,8 +117,8 @@ Channel
 The `mix` operator combines the items emitted by two (or more) channels into a single channel.
 
 ```groovy linenums="1"
-c1 = Channel.of(1,2,3)
-c2 = Channel.of('a','b')
+c1 = Channel.of(1, 2, 3)
+c2 = Channel.of('a', 'b')
 c3 = Channel.of('z')
 
 c1.mix(c2,c3).view()
@@ -142,8 +142,8 @@ z
 The `flatten` operator transforms a channel in such a way that every _tuple_ is flattened so that each entry is emitted as a sole element by the resulting channel.
 
 ```groovy linenums="1"
-foo = [1,2,3]
-bar = [4,5,6]
+foo = [1, 2, 3]
+bar = [4, 5, 6]
 
 Channel
     .of(foo, bar)
@@ -174,7 +174,7 @@ Channel
 It prints a single value:
 
 ```console title="Output"
-[1,2,3,4]
+[1, 2, 3, 4]
 ```
 
 !!! info
@@ -243,7 +243,7 @@ The selection criterion is defined by specifying a closure that provides one or 
 
 ```groovy linenums="1"
 Channel
-    .of(1,2,3,40,50)
+    .of(1, 2, 3, 40, 50)
     .branch {
         small: it < 10
         large: it > 10

--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -121,7 +121,7 @@ c1 = Channel.of(1, 2, 3)
 c2 = Channel.of('a', 'b')
 c3 = Channel.of('z')
 
-c1.mix(c2,c3).view()
+c1.mix(c2, c3).view()
 ```
 
 ```console title="Output"
@@ -189,7 +189,7 @@ Try the following example:
 
 ```groovy linenums="1"
 Channel
-    .of([1,'A'], [1,'B'], [2,'C'], [3, 'B'], [1,'C'], [2, 'A'], [3, 'D'])
+    .of([1, 'A'], [1, 'B'], [2, 'C'], [3, 'B'], [1, 'C'], [2, 'A'], [3, 'D'])
     .groupTuple()
     .view()
 ```

--- a/docs/basic_training/operators.pt.md
+++ b/docs/basic_training/operators.pt.md
@@ -124,7 +124,7 @@ c1 = Channel.of(1, 2, 3)
 c2 = Channel.of('a', 'b')
 c3 = Channel.of('z')
 
-c1.mix(c2,c3).view()
+c1.mix(c2, c3).view()
 ```
 
 ```console title="Output"
@@ -192,7 +192,7 @@ Por exemplo:
 
 ```groovy linenums="1"
 Channel
-    .of([1,'A'], [1,'B'], [2,'C'], [3, 'B'], [1,'C'], [2, 'A'], [3, 'D'])
+    .of([1, 'A'], [1, 'B'], [2, 'C'], [3, 'B'], [1, 'C'], [2, 'A'], [3, 'D'])
     .groupTuple()
     .view()
 ```

--- a/docs/basic_training/operators.pt.md
+++ b/docs/basic_training/operators.pt.md
@@ -23,7 +23,7 @@ Existem sete grupos de operadores descritos em detalhe na Documentação do Next
     Clique no ícone :material-plus-circle: para ver explicações do código.
 
 ```groovy linenums="1"
-nums = Channel.of(1,2,3,4) // (1)!
+nums = Channel.of(1, 2, 3, 4) // (1)!
 quadrados = nums.map { it -> it * it } // (2)!
 quadrados.view() // (3)!
 ```
@@ -40,7 +40,7 @@ Para implementar funcionalidades específicas operadores também podem ser encad
 
 ```groovy linenums="1"
 Channel
-    .of(1,2,3,4)
+    .of(1, 2, 3, 4)
     .map { it -> it * it }
     .view()
 ```
@@ -111,7 +111,7 @@ Channel
         ```groovy linenums="1"
         Channel
             .fromPath('data/ggal/*.fq')
-            .map { arquivo -> [ arquivo.name, arquivo ] }
+            .map { arquivo -> [arquivo.name, arquivo] }
             .view { nome, arquivo -> "> $nome : $arquivo" }
         ```
 
@@ -120,8 +120,8 @@ Channel
 O operador `mix` combina os itens emitidos por dois (ou mais) canais em um único canal.
 
 ```groovy linenums="1"
-c1 = Channel.of(1,2,3)
-c2 = Channel.of('a','b')
+c1 = Channel.of(1, 2, 3)
+c2 = Channel.of('a', 'b')
 c3 = Channel.of('z')
 
 c1.mix(c2,c3).view()
@@ -145,8 +145,8 @@ z
 O operador `flatten` transforma um canal de maneira que cada _tupla_ é achatada, isto é, cada entrada é emitida como um único elemento pelo canal resultante.
 
 ```groovy linenums="1"
-foo = [1,2,3]
-bar = [4,5,6]
+foo = [1, 2, 3]
+bar = [4, 5, 6]
 
 Channel
     .of(foo, bar)
@@ -177,7 +177,7 @@ Channel
 Isto imprime o valor:
 
 ```console title="Output"
-[1,2,3,4]
+[1, 2, 3, 4]
 ```
 
 !!! info
@@ -247,7 +247,7 @@ O critério de seleção de cada canal de saída é definido especificando uma c
 
 ```groovy linenums="1"
 Channel
-    .of(1,2,3,40,50)
+    .of(1, 2, 3, 40, 50)
     .branch {
         pequeno: it < 10
         grande: it > 10

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -632,7 +632,6 @@ process RANDOMNUM {
     """
 }
 
-
 workflow {
     receiver_ch = RANDOMNUM()
     receiver_ch.view { "Received: " + it.text }

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -652,6 +652,7 @@ process SPLITLETTERS {
     output:
     path 'chunk_*'
 
+    script:
     """
     printf 'Hola' | split -b 1 - chunk_
     """

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -94,7 +94,7 @@ process PYSTUFF {
 
     x = 'Hello'
     y = 'world!'
-    print ("%s - %s" % (x,y))
+    print ("%s - %s" % (x, y))
     """
 }
 
@@ -382,8 +382,8 @@ A key feature of processes is the ability to handle inputs from multiple channel
 Consider the following example:
 
 ```groovy linenums="1"
-ch1 = Channel.of(1,2,3)
-ch2 = Channel.of('a','b','c')
+ch1 = Channel.of(1, 2, 3)
+ch2 = Channel.of('a', 'b', 'c')
 
 process FOO {
     debug true
@@ -420,8 +420,8 @@ This means channel values are consumed serially one after another and the first 
 For example:
 
 ```groovy linenums="1"
-input1 = Channel.of(1,2)
-input2 = Channel.of('a','b','c','d')
+input1 = Channel.of(1, 2)
+input2 = Channel.of('a', 'b', 'c', 'd')
 
 process FOO {
     debug true
@@ -449,7 +449,7 @@ Compare the previous example with the following one:
 
 ```groovy linenums="1"
 input1 = Channel.value(1)
-input2 = Channel.of('a','b','c')
+input2 = Channel.of('a', 'b', 'c')
 
 process BAR {
     debug true
@@ -596,7 +596,7 @@ output:
 The `val` qualifier specifies a defined _value_ in the script context. Values are frequently defined in the _input_ and/or _output_ declaration blocks, as shown in the following example:
 
 ```groovy linenums="1"
-methods = ['prot','dna', 'rna']
+methods = ['prot', 'dna', 'rna']
 
 process FOO {
     input:

--- a/docs/basic_training/processes.pt.md
+++ b/docs/basic_training/processes.pt.md
@@ -94,7 +94,7 @@ process CODIGOPYTHON {
 
     x = 'Olá'
     y = 'mundo!'
-    print ("%s - %s" % (x,y))
+    print ("%s - %s" % (x, y))
     """
 }
 
@@ -382,8 +382,8 @@ Uma característica fundamental dos processos é a capacidade de lidar com entra
 Considere o seguinte exemplo:
 
 ```groovy linenums="1"
-canal1 = Channel.of(1,2,3)
-canal2 = Channel.of('a','b','c')
+canal1 = Channel.of(1, 2, 3)
+canal2 = Channel.of('a', 'b', 'c')
 
 process FOO {
     debug true
@@ -420,8 +420,8 @@ Isso significa que os valores do canal são consumidos serialmente um após o ou
 Por exemplo:
 
 ```groovy linenums="1"
-entrada1 = Channel.of(1,2)
-entrada2 = Channel.of('a','b','c','d')
+entrada1 = Channel.of(1, 2)
+entrada2 = Channel.of('a', 'b', 'c', 'd')
 
 process FOO {
     debug true
@@ -449,7 +449,7 @@ Compare o exemplo anterior com o seguinte:
 
 ```groovy linenums="1"
 entrada1 = Channel.value(1)
-entrada2 = Channel.of('a','b','c')
+entrada2 = Channel.of('a', 'b', 'c')
 
 process BAR {
     debug true
@@ -596,7 +596,7 @@ output:
 O qualificador `val` especifica um valor definido no contexto do script. Os valores são frequentemente definidos nos blocos de _input_ e/ou _output_, conforme mostrado no exemplo a seguir:
 
 ```groovy linenums="1"
-metodos = ['prot','dna', 'rna']
+metodos = ['prot', 'dna', 'rna']
 
 process FOO {
     input:

--- a/docs/basic_training/processes.pt.md
+++ b/docs/basic_training/processes.pt.md
@@ -652,6 +652,7 @@ process SEPARARLETRAS {
     output:
     path 'pedaco_*'
 
+    script:
     """
     printf 'Hola' | split -b 1 - pedaco_
     """

--- a/docs/basic_training/processes.pt.md
+++ b/docs/basic_training/processes.pt.md
@@ -632,7 +632,6 @@ process NUMALEATORIO {
     """
 }
 
-
 workflow {
     canal_de_recebimento = NUMALEATORIO()
     canal_de_recebimento.view { "Recebido: " + it.text }

--- a/docs/basic_training/rnaseq_pipeline.md
+++ b/docs/basic_training/rnaseq_pipeline.md
@@ -363,7 +363,7 @@ Nextflow parallelizes the execution of your pipeline simply by providing multipl
         Add the following before the `input` declaration in the `QUANTIFICATION` process:
 
         ```groovy
-        publishDir params.outdir, mode:'copy'
+        publishDir params.outdir, mode: 'copy'
         ```
 
 ### :material-check-all: Summary

--- a/docs/basic_training/rnaseq_pipeline.pt.md
+++ b/docs/basic_training/rnaseq_pipeline.pt.md
@@ -363,7 +363,7 @@ O Nextflow paraleliza a execução de seu pipeline simplesmente fornecendo vári
         Adicione o código a seguir antes da declaração de entrada no processo de `QUANTIFICATION`:
 
         ```groovy
-        publishDir params.outdir, mode:'copy'
+        publishDir params.outdir, mode: 'copy'
         ```
 
 ### :material-check-all: Resumo

--- a/docs/basic_training/rnaseq_pipeline.pt.md
+++ b/docs/basic_training/rnaseq_pipeline.pt.md
@@ -69,13 +69,13 @@ nextflow run script1.nf --reads '/workspace/gitpod/nf-training/data/ggal/lung_{1
 
         ```groovy
         log.info """\
-                    R N A S E Q - N F   P I P E L I N E
-                    ===================================
-                    transcriptoma               : ${params.transcriptome_file}
-                    arquivos de leituras        : ${params.reads}
-                    diretório de saíde          : ${params.outdir}
-                    """
-                    .stripIndent()
+            R N A S E Q - N F   P I P E L I N E
+            ===================================
+            transcriptoma               : ${params.transcriptome_file}
+            arquivos de leituras        : ${params.reads}
+            diretório de saíde          : ${params.outdir}
+            """
+            .stripIndent()
         ```
 
 ### :material-check-all: Resumo

--- a/nf-training/modules.hello.nf
+++ b/nf-training/modules.hello.nf
@@ -3,12 +3,12 @@
 params.greeting  = 'Hello world!'
 greeting_ch = Channel.of(params.greeting)
 
-include { splitLetters   } from './modules.nf'
-include { convertToUpper } from './modules.nf'
+include { SPLITLETTERS   } from './modules.nf'
+include { CONVERTTOUPPER } from './modules.nf'
 
 workflow{
-    letters_ch = splitLetters(greeting_ch)
-    results_ch = convertToUpper(letters_ch.flatten())
+    letters_ch = SPLITLETTERS(greeting_ch)
+    results_ch = CONVERTTOUPPER(letters_ch.flatten())
     results_ch.view{ it }
 }
 

--- a/nf-training/script3.nf
+++ b/nf-training/script3.nf
@@ -7,12 +7,12 @@ params.multiqc = "$projectDir/multiqc"
 params.outdir = "results"
 
 log.info """\
-        R N A S E Q - N F   P I P E L I N E
-        ===================================
-        transcriptome: ${params.transcriptome_file}
-        reads        : ${params.reads}
-        outdir       : ${params.outdir}
-        """
-        .stripIndent()
+    R N A S E Q - N F   P I P E L I N E
+    ===================================
+    transcriptome: ${params.transcriptome_file}
+    reads        : ${params.reads}
+    outdir       : ${params.outdir}
+    """
+    .stripIndent()
 
 read_pairs_ch = Channel.fromFilePairs(params.reads)


### PR DESCRIPTION
- Improve placement of + helpers in source code examples
- Add/remove spaces when required to make its usage consistent
- Sync Portuguese translations of the basic training material
