### PR TITLE
Make terminology consistent in the basic training

### DIFF
--- a/docs/basic_training/cache_and_resume.md
+++ b/docs/basic_training/cache_and_resume.md
@@ -9,7 +9,7 @@ The Nextflow caching mechanism works by assigning a unique ID to each task which
 
 The task unique ID is generated as a 128-bit hash value composing the task input values, files and command string.
 
-The pipeline work directory is organized as shown below:
+The workflow work directory is organized as shown below:
 
 ```txt
 work/
@@ -54,13 +54,13 @@ work/
 
 ## How resume works
 
-The `-resume` command-line option allows the continuation of a pipeline execution from the last step that was completed successfully:
+The `-resume` command-line option allows the continuation of a workflow execution from the last step that was completed successfully:
 
 ```bash
 nextflow run <script> -resume
 ```
 
-In practical terms, the pipeline is executed from the beginning. However, before launching the execution of a process, Nextflow uses the task unique ID to check if the work directory already exists and that it contains a valid command exit state with the expected output files.
+In practical terms, the workflow is executed from the beginning. However, before launching the execution of a process, Nextflow uses the task unique ID to check if the work directory already exists and that it contains a valid command exit state with the expected output files.
 
 If this condition is satisfied the task execution is skipped and previously computed results are used as the process results.
 
@@ -86,7 +86,7 @@ nextflow run <script> -w /some/scratch/dir
 
 !!! warning
 
-    If you delete or move the pipeline work directory, it will prevent the use of the resume feature in subsequent runs.
+    If you delete or move the workflow work directory, it will prevent the use of the resume feature in subsequent runs.
 
 The hash code for input files is computed using:
 
@@ -102,7 +102,7 @@ It’s good practice to organize each **experiment** in its own folder. The main
 
 !!! note
 
-    In the same experiment, the same pipeline can be executed multiple times, however, launching two (or more) Nextflow instances in the same directory concurrently should be avoided.
+    In the same experiment, the same workflow can be executed multiple times, however, launching two (or more) Nextflow instances in the same directory concurrently should be avoided.
 
 The `nextflow log` command lists the executions run in the current folder:
 
@@ -124,7 +124,7 @@ nextflow run rnaseq-nf -resume mighty_boyd
 
 ## Execution provenance
 
-The `log` command, when provided with a **run name** or **session ID**, can return many useful bits of information about a pipeline execution that can be used to create a provenance report.
+The `log` command, when provided with a **run name** or **session ID**, can return many useful bits of information about a workflow execution that can be used to create a provenance report.
 
 By default, it will list the work directories used to compute each task. For example:
 
@@ -289,7 +289,7 @@ Just like we saw at the beginning of this tutorial with HELLO WORLD or WORLD HEL
 [1, A]
 ```
 
-..and that order will likely be different every time the pipeline is run.
+..and that order will likely be different every time the workflow is run.
 
 Imagine now that we have two processes like this, whose output channels are acting as input channels to a third process. Both channels will be independently random, so the third process must not expect them to retain a paired sequence. If it does assume that the first element in the first process output channel is related to the first element in the second process output channel, there will be a mismatch.
 

--- a/docs/basic_training/cache_and_resume.pt.md
+++ b/docs/basic_training/cache_and_resume.pt.md
@@ -9,7 +9,7 @@ O mecanismo de caching do Nextflow funciona atribuindo uma ID única para cada t
 
 A ID única de tarefa é gerada como uma hash de 128-bit compondo os valores de entrada da tarefa, arquivos e a string de comando.
 
-O diretório de trabalho do pipeline é organizado como mostrado abaixo:
+O diretório de trabalho do fluxo de trabalho é organizado como mostrado abaixo:
 
 ```txt
 work/
@@ -54,13 +54,13 @@ work/
 
 ## Como funciona a reentrância
 
-A opção de linha de comando `-resume` permite a continuação da execução do pipeline pelo último passo que foi completado com sucesso:
+A opção de linha de comando `-resume` permite a continuação da execução do fluxo de trabalho pelo último passo que foi completado com sucesso:
 
 ```bash
 nextflow run <script> -resume
 ```
 
-Em termos práticos, o pipeline é executado do início. Entretanto, antes do lançamento da execução de um processo, o Nextflow usa a ID única da tarefa para checar se o diretório de trabalho existe e se ele contém um estado de saída válido do comando com os esperados arquivos de saída.
+Em termos práticos, o fluxo de trabalho é executado do início. Entretanto, antes do lançamento da execução de um processo, o Nextflow usa a ID única da tarefa para checar se o diretório de trabalho existe e se ele contém um estado de saída válido do comando com os esperados arquivos de saída.
 
 Se esta condição for satisfeita a tarefa é ignorada e os resultados computados previamente são usados como resultados do processo.
 
@@ -68,7 +68,7 @@ A primeira tarefa que tem uma nova saída computada invalida todas execuções p
 
 ## Diretório de trabalho
 
-O diretório de trabalho das tarefas é criado por padrão na pasta `work` no mesmo diretório onde o pipeline foi executado. Essa localização é supostamente uma área de armazenamento **provisória** que pode ser limpada quando a execução do pipeline for finalizado.
+O diretório de trabalho das tarefas é criado por padrão na pasta `work` no mesmo diretório onde o fluxo de trabalho foi executado. Essa localização é supostamente uma área de armazenamento **provisória** que pode ser limpada quando a execução do fluxo de trabalho for finalizado.
 
 !!! note
 
@@ -86,7 +86,7 @@ nextflow run <script> -w /algum/diretorio/de/scratch
 
 !!! warning
 
-    Se você deletar ou mover o diretório de trabalho do pipeline, isso irá impedir que você use o recurso de reentrância nas execuções posteriores.
+    Se você deletar ou mover o diretório de trabalho do fluxo de trabalho, isso irá impedir que você use o recurso de reentrância nas execuções posteriores.
 
 O código hash para os arquivos de entrada são computados usando:
 
@@ -102,7 +102,7 @@ Portanto, o simples uso do **touch** em um arquivo irá invalidar a execução d
 
 !!! note
 
-    No mesmo experimento, o mesmo pipeline pode ser executado diversas vezes, entretanto, iniciar duas (ou mais) instâncias do Nextflow no mesmo diretório ao mesmo tempo deve ser evitado.
+    No mesmo experimento, o mesmo fluxo de trabalho pode ser executado diversas vezes, entretanto, iniciar duas (ou mais) instâncias do Nextflow no mesmo diretório ao mesmo tempo deve ser evitado.
 
 O comando `nextflow log` lista todas as execuções na pasta atual:
 
@@ -124,7 +124,7 @@ nextflow run rnaseq-nf -resume mighty_boyd
 
 ## Proveniência da execução
 
-O comando `log`, quando provido do **nome da execução** ou **ID da sessão**, pode retornar algumas informações importantes sobre um pipeline em execução que podem ser usadas para criar um relatório de proveniência.
+O comando `log`, quando provido do **nome da execução** ou **ID da sessão**, pode retornar algumas informações importantes sobre um fluxo de trabalho em execução que podem ser usadas para criar um relatório de proveniência.
 
 Por padrão, o comando irá listar todos diretórios de trabalho usados em cada tarefa. Por exemplo:
 
@@ -288,7 +288,7 @@ Assim como vimos no início deste tutorial com HELLO WORLD ou WORLD HELLO, a sa�
 [1, A]
 ```
 
-..e essa ordem provavelmente será diferente toda vez que o pipeline for executado.
+..e essa ordem provavelmente será diferente toda vez que o fluxo de trabalho for executado.
 
 Imagine agora que temos dois processos como este, cujos canais de saída estão atuando como canais de entrada para um terceiro processo. Ambos os canais serão aleatórios de forma independente, portanto, o terceiro processo não deve esperar que eles retenham uma sequência pareada. Se assumir que o primeiro elemento no primeiro canal de saída do processo está relacionado ao primeiro elemento no segundo canal de saída do processo, haverá uma incompatibilidade.
 

--- a/docs/basic_training/channels.md
+++ b/docs/basic_training/channels.md
@@ -144,7 +144,7 @@ workflow {
 2
 ```
 
-Besides, in many situations, Nextflow will implicitly convert variables to value channels when they are used in a process invocation. For example, when you invoke a process with a pipeline parameter (`params.example`) which has a string value, it is automatically cast into a value channel.
+Besides, in many situations, Nextflow will implicitly convert variables to value channels when they are used in a process invocation. For example, when you invoke a process with a workflow parameter (`params.example`) which has a string value, it is automatically cast into a value channel.
 
 ## Channel factories
 
@@ -376,7 +376,7 @@ workflow {
 }
 ```
 
-If you want to run the pipeline above and do not have fastqc installed in your machine, don’t forget what you learned in the previous section. Run this pipeline with `-with-docker biocontainers/fastqc:v0.11.5`, for example.
+If you want to run the workflow above and do not have fastqc installed in your machine, don’t forget what you learned in the previous section. Run this workflow with `-with-docker biocontainers/fastqc:v0.11.5`, for example.
 
 ### Text files
 

--- a/docs/basic_training/channels.md
+++ b/docs/basic_training/channels.md
@@ -39,7 +39,7 @@ ch.view() // (2)!
 ```
 
 1. Use the built-in print line function `println` to print the `ch` channel
-2. Apply the `view` method to the `ch` channel prints each item emitted by the channels
+2. Apply the `view` channel operator to the `ch` channel prints each item emitted by the channels
 
 !!! exercise
 
@@ -52,7 +52,7 @@ ch.view() // (2)!
 
 ### Value channels
 
-A **value** channel (a.k.a. singleton channel) by definition is bound to a single value and it can be read unlimited times without consuming its contents. A `value` channel is created using the [value](https://www.nextflow.io/docs/latest/channel.html#value) factory method or by operators returning a single value, such as [first](https://www.nextflow.io/docs/latest/operator.html#first), [last](https://www.nextflow.io/docs/latest/operator.html#last), [collect](https://www.nextflow.io/docs/latest/operator.html#operator-collect), [count](https://www.nextflow.io/docs/latest/operator.html#operator-count), [min](https://www.nextflow.io/docs/latest/operator.html#operator-min), [max](https://www.nextflow.io/docs/latest/operator.html#operator-max), [reduce](https://www.nextflow.io/docs/latest/operator.html#operator-reduce), and [sum](https://www.nextflow.io/docs/latest/operator.html#operator-sum).
+A **value** channel (a.k.a. singleton channel) by definition is bound to a single value and it can be read unlimited times without consuming its contents. A `value` channel is created using the [value](https://www.nextflow.io/docs/latest/channel.html#value) channel factory or by operators returning a single value, such as [first](https://www.nextflow.io/docs/latest/operator.html#first), [last](https://www.nextflow.io/docs/latest/operator.html#last), [collect](https://www.nextflow.io/docs/latest/operator.html#operator-collect), [count](https://www.nextflow.io/docs/latest/operator.html#operator-count), [min](https://www.nextflow.io/docs/latest/operator.html#operator-min), [max](https://www.nextflow.io/docs/latest/operator.html#operator-max), [reduce](https://www.nextflow.io/docs/latest/operator.html#operator-reduce), and [sum](https://www.nextflow.io/docs/latest/operator.html#operator-sum).
 
 To better understand the difference between value and queue channels, save the snippet below as `example.nf`.
 
@@ -152,7 +152,7 @@ These are Nextflow commands for creating channels that have implicit expected in
 
 ### `value()`
 
-The `value` factory method is used to create a _value_ channel. An optional not `null` argument can be specified to bind the channel to a specific value. For example:
+The `value` channel factory is used to create a _value_ channel. An optional not `null` argument can be specified to bind the channel to a specific value. For example:
 
 ```groovy linenums="1"
 ch1 = Channel.value() // (1)!
@@ -173,7 +173,7 @@ ch = Channel.of(1, 3, 5, 7)
 ch.view { "value: $it" }
 ```
 
-The first line in this example creates a variable `ch` which holds a channel object. This channel emits the values specified as a parameter in the `of` method. Thus the second line will print the following:
+The first line in this example creates a variable `ch` which holds a channel object. This channel emits the values specified as a parameter in the `of` channel factory. Thus the second line will print the following:
 
 ```console
 value: 1
@@ -182,7 +182,7 @@ value: 5
 value: 7
 ```
 
-The method `Channel.of` works in a similar manner to `Channel.from` (which is now [deprecated](https://www.nextflow.io/docs/latest/channel.html#of)), fixing some inconsistent behaviors of the latter and providing better handling when specifying a range of values. For example, the following works with a range from 1 to 23:
+The `Channel.of` channel factory works in a similar manner to `Channel.from` (which is now [deprecated](https://www.nextflow.io/docs/latest/channel.html#of)), fixing some inconsistent behaviors of the latter and providing better handling when specifying a range of values. For example, the following works with a range from 1 to 23:
 
 ```groovy linenums="1"
 Channel
@@ -192,7 +192,7 @@ Channel
 
 ### `fromList()`
 
-The method `Channel.fromList` creates a channel emitting the elements provided by a list object specified as an argument:
+The `Channel.fromList` channel factory creates a channel emitting the elements provided by a list object specified as an argument:
 
 ```groovy linenums="1"
 list = ['hello', 'world']
@@ -204,7 +204,7 @@ Channel
 
 ### `fromPath()`
 
-The `fromPath` factory method creates a queue channel emitting one or more files matching the specified glob pattern.
+The `fromPath` channel factory creates a queue channel emitting one or more files matching the specified glob pattern.
 
 ```groovy linenums="1"
 Channel.fromPath('./data/meta/*.csv')
@@ -230,7 +230,7 @@ Learn more about the glob patterns syntax at [this link](https://docs.oracle.com
 
 !!! exercise
 
-    Use the `Channel.fromPath` method to create a channel emitting all files with the suffix `.fq` in the `data/ggal/` directory and any subdirectory, in addition to hidden files. Then print the file names.
+    Use the `Channel.fromPath` channel factory to create a channel emitting all files with the suffix `.fq` in the `data/ggal/` directory and any subdirectory, in addition to hidden files. Then print the file names.
 
     ??? solution
 
@@ -241,7 +241,7 @@ Learn more about the glob patterns syntax at [this link](https://docs.oracle.com
 
 ### `fromFilePairs()`
 
-The `fromFilePairs` method creates a channel emitting the file pairs matching a glob pattern provided by the user. The matching files are emitted as tuples, in which the first element is the grouping key of the matching pair and the second element is the list of files (sorted in lexicographical order).
+The `fromFilePairs` channel factory creates a channel emitting the file pairs matching a glob pattern provided by the user. The matching files are emitted as tuples, in which the first element is the grouping key of the matching pair and the second element is the list of files (sorted in lexicographical order).
 
 ```groovy linenums="1"
 Channel
@@ -273,7 +273,7 @@ It will produce an output similar to the following:
 
 !!! exercise
 
-    Use the `fromFilePairs` method to create a channel emitting all pairs of fastq read in the `data/ggal/` directory and print them. Then use the `flat: true` option and compare the output with the previous execution.
+    Use the `fromFilePairs` channel factory to create a channel emitting all pairs of fastq read in the `data/ggal/` directory and print them. Then use the `flat: true` option and compare the output with the previous execution.
 
     ??? solution
 
@@ -288,7 +288,7 @@ It will produce an output similar to the following:
 
 ### `fromSRA()`
 
-The `Channel.fromSRA` method makes it possible to query the [NCBI SRA](https://www.ncbi.nlm.nih.gov/sra) archive and returns a channel emitting the FASTQ files matching the specified selection criteria.
+The `Channel.fromSRA` channel factory makes it possible to query the [NCBI SRA](https://www.ncbi.nlm.nih.gov/sra) archive and returns a channel emitting the FASTQ files matching the specified selection criteria.
 
 The query can be project ID(s) or accession number(s) supported by the [NCBI ESearch API](https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch).
 

--- a/docs/basic_training/channels.pt.md
+++ b/docs/basic_training/channels.pt.md
@@ -144,7 +144,7 @@ workflow {
 2
 ```
 
-Além disso, em muitas situações, o Nextflow converterá implicitamente variáveis em canais de valor quando forem usadas em uma chamada de processo. Por exemplo, quando você chama um processo com um parâmetro de pipeline (`params.exemplo`) que possui um valor de string, ele é automaticamente convertido em um canal de valor.
+Além disso, em muitas situações, o Nextflow converterá implicitamente variáveis em canais de valor quando forem usadas em uma chamada de processo. Por exemplo, quando você chama um processo com um parâmetro de fluxo de trabalho (`params.exemplo`) que possui um valor de string, ele é automaticamente convertido em um canal de valor.
 
 ## Fábricas de canal
 
@@ -377,7 +377,7 @@ workflow {
 }
 ```
 
-Se você deseja executar o pipeline acima e não possui o fastqc instalado em sua máquina, não esqueça o que aprendeu na seção anterior. Execute este pipeline com `-with-docker biocontainers/fastqc:v0.11.5`, por exemplo.
+Se você deseja executar o fluxo de trabalho acima e não possui o fastqc instalado em sua máquina, não esqueça o que aprendeu na seção anterior. Execute este fluxo de trabalho com `-with-docker biocontainers/fastqc:v0.11.5`, por exemplo.
 
 ### Arquivos de texto
 

--- a/docs/basic_training/channels.pt.md
+++ b/docs/basic_training/channels.pt.md
@@ -704,7 +704,7 @@ def parseJsonFile(json_file) {
 }
 ```
 
-O Nextflow usará isso como uma função personalizada dentro do escopo do fluxo de trabalho.
+O Nextflow usará isso como uma função personalizada dentro do escopo `workflow`.
 
 !!! tip
 

--- a/docs/basic_training/channels.pt.md
+++ b/docs/basic_training/channels.pt.md
@@ -39,7 +39,7 @@ canal.view() // (2)!
 ```
 
 1. Use a função `println` embutida no Nextflow por padrão para imprimir o conteúdo do canal `canal`
-2. Aplique o método `view` no canal `canal` para imprimir cada item emitido por esse canal
+2. Aplique o operador `view` no canal `canal` para imprimir cada item emitido por esse canal
 
 !!! exercise
 
@@ -173,7 +173,7 @@ canal = Channel.of(1, 3, 5, 7)
 canal.view { "numero: $it" }
 ```
 
-A primeira linha neste exemplo cria uma variável `canal` que contém um objeto de canal. Este canal emite os valores especificados como parâmetro no método `of`. Assim, a segunda linha imprimirá o seguinte:
+A primeira linha neste exemplo cria uma variável `canal` que contém um objeto de canal. Este canal emite os valores especificados como parâmetro na fábrica de canal `of`. Assim, a segunda linha imprimirá o seguinte:
 
 ```console
 numero: 1
@@ -182,7 +182,7 @@ numero: 5
 numero: 7
 ```
 
-O método `Channel.of` funciona de maneira semelhante ao `Channel.from` (que foi [descontinuado](https://www.nextflow.io/docs/latest/channel.html#of)), corrigindo alguns comportamentos inconsistentes do último e fornecendo um melhor manuseio quando um intervalo de valores é especificado. Por exemplo, o seguinte funciona com um intervalo de 1 a 23:
+A fábrica de canal `Channel.of` funciona de maneira semelhante ao `Channel.from` (que foi [descontinuado](https://www.nextflow.io/docs/latest/channel.html#of)), corrigindo alguns comportamentos inconsistentes do último e fornecendo um melhor manuseio quando um intervalo de valores é especificado. Por exemplo, o seguinte funciona com um intervalo de 1 a 23:
 
 ```groovy linenums="1"
 Channel
@@ -192,7 +192,7 @@ Channel
 
 ### `fromList()`
 
-O método `Channel.fromList` cria um canal emitindo os elementos fornecidos por um objeto de lista especificado como um argumento:
+A fábrica de canal `Channel.fromList` cria um canal emitindo os elementos fornecidos por um objeto de lista especificado como um argumento:
 
 ```groovy linenums="1"
 list = ['olá', 'mundo']
@@ -204,7 +204,7 @@ Channel
 
 ### `fromPath()`
 
-A fábrica `fromPath` cria um canal de fila emitindo um ou mais arquivos correspondentes ao padrão glob especificado.
+A fábrica de canal `fromPath` cria um canal de fila emitindo um ou mais arquivos correspondentes ao padrão glob especificado.
 
 ```groovy linenums="1"
 Channel.fromPath('./data/meta/*.csv')
@@ -230,7 +230,7 @@ Saiba mais sobre a sintaxe dos padrões glob [neste link](https://docs.oracle.co
 
 !!! exercise
 
-    Use o método `Channel.fromPath` para criar um canal emitindo todos os arquivos com o sufixo `.fq` no diretório `data/ggal/` e qualquer subdiretório, além dos arquivos ocultos. Em seguida, imprima os nomes dos arquivos.
+    Use a fábrica de canal `Channel.fromPath` para criar um canal emitindo todos os arquivos com o sufixo `.fq` no diretório `data/ggal/` e qualquer subdiretório, além dos arquivos ocultos. Em seguida, imprima os nomes dos arquivos.
 
     ??? solution
 
@@ -241,7 +241,7 @@ Saiba mais sobre a sintaxe dos padrões glob [neste link](https://docs.oracle.co
 
 ### `fromFilePairs()`
 
-O método `fromFilePairs` cria um canal emitindo os pares de arquivos correspondentes a um padrão glob fornecido pelo usuário. Os arquivos correspondentes são emitidos como tuplas, nas quais o primeiro elemento é a chave de agrupamento do par correspondente e o segundo elemento é a lista de arquivos (classificados em ordem lexicográfica).
+A fábrica de canal `fromFilePairs` cria um canal emitindo os pares de arquivos correspondentes a um padrão glob fornecido pelo usuário. Os arquivos correspondentes são emitidos como tuplas, nas quais o primeiro elemento é a chave de agrupamento do par correspondente e o segundo elemento é a lista de arquivos (classificados em ordem lexicográfica).
 
 ```groovy linenums="1"
 Channel
@@ -273,7 +273,7 @@ Ele produzirá uma saída semelhante à seguinte:
 
 !!! exercise
 
-    Use o método `fromFilePairs` para criar um canal emitindo todos os pares de leituras em fastq no diretório `data/ggal/` e imprima-os. Em seguida, use a opção `flat: true` e compare a saída com a execução anterior.
+    Use a fábrica de canal `fromFilePairs` para criar um canal emitindo todos os pares de leituras em fastq no diretório `data/ggal/` e imprima-os. Em seguida, use a opção `flat: true` e compare a saída com a execução anterior.
 
     ??? solution
 
@@ -288,7 +288,7 @@ Ele produzirá uma saída semelhante à seguinte:
 
 ### `fromSRA()`
 
-O método `Channel.fromSRA` permite consultar o banco de dados [NCBI SRA](https://www.ncbi.nlm.nih.gov/sra) e retorna um canal que emite os arquivos FASTQ correspondentes aos critérios de seleção especificados.
+A fábrica de canal `Channel.fromSRA` permite consultar o banco de dados [NCBI SRA](https://www.ncbi.nlm.nih.gov/sra) e retorna um canal que emite os arquivos FASTQ correspondentes aos critérios de seleção especificados.
 
 A consulta pode ser ID(s) de projeto(s) ou número(s) de acesso suportado(s) pela API do [NCBI ESearch](https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch).
 

--- a/docs/basic_training/config.md
+++ b/docs/basic_training/config.md
@@ -11,7 +11,7 @@ This enables portable deployment without the need to modify the application code
 
 ## Configuration file
 
-When a pipeline script is launched, Nextflow looks for a file named `nextflow.config` in the current directory and in the script base directory (if it is not the same as the current directory). Finally, it checks for the file: `$HOME/.nextflow/config`.
+When a workflow script is launched, Nextflow looks for a file named `nextflow.config` in the current directory and in the script base directory (if it is not the same as the current directory). Finally, it checks for the file: `$HOME/.nextflow/config`.
 
 When more than one of the above files exists, they are merged, so that the settings in the first override the same settings that may appear in the second, and so on.
 
@@ -158,7 +158,7 @@ nextflow run foo.nf -c my-env.config
 
 ### Config process
 
-Process [directives](https://www.nextflow.io/docs/latest/process.html#directives) allow the specification of settings for the task execution such as `cpus`, `memory`, `container`, and other resources in the pipeline script.
+Process [directives](https://www.nextflow.io/docs/latest/process.html#directives) allow the specification of settings for the task execution such as `cpus`, `memory`, `container`, and other resources in the workflow script.
 
 This is useful when prototyping a small workflow script.
 

--- a/docs/basic_training/config.pt.md
+++ b/docs/basic_training/config.pt.md
@@ -11,7 +11,7 @@ Isso permite a portabilidade da aplicação sem a necessidade de modificar seu c
 
 ## Arquivo de configuração
 
-Quando um script de pipeline é executado, o Nextflow procura um arquivo chamado `nextflow.config` no diretório atual e no diretório base do script (se não for o mesmo que o diretório atual). Caso não encontre, o Nextflow verifica o arquivo: `$HOME/.nextflow/config`.
+Quando um script de fluxo de trabalho é executado, o Nextflow procura um arquivo chamado `nextflow.config` no diretório atual e no diretório base do script (se não for o mesmo que o diretório atual). Caso não encontre, o Nextflow verifica o arquivo: `$HOME/.nextflow/config`.
 
 Quando existir mais de um dos arquivos acima, eles serão mesclados, de modo que as configurações do primeiro substituam as mesmas configurações que podem aparecer no segundo e assim por diante.
 
@@ -72,7 +72,7 @@ beta {
 
 ### Configurar parâmetros
 
-O escopo `params` permite a definição de parâmetros que substituem os valores definidos no script principal do pipeline.
+O escopo `params` permite a definição de parâmetros que substituem os valores definidos no script principal do fluxo de trabalho.
 
 Isso é útil para reforçar o uso de um ou mais parâmetros de execução em um arquivo separado.
 
@@ -81,7 +81,7 @@ params.foo = 'Bonjour'
 params.bar = 'le monde!'
 ```
 
-```groovy linenums="1" title="Script do pipeline"
+```groovy linenums="1" title="Script do fluxo de trabalho"
 params.foo = 'Olá'
 params.bar = 'mundo!'
 
@@ -119,7 +119,7 @@ println "$params.foo $params.bar"
 
 ### Configurar ambiente
 
-O escopo `env` permite a definição de uma ou mais variáveis que serão exportadas para o ambiente onde serão executadas as tarefas do pipeline.
+O escopo `env` permite a definição de uma ou mais variáveis que serão exportadas para o ambiente onde serão executadas as tarefas do fluxo de trabalho.
 
 ```groovy linenums="1"
 env.ALFA = 'algum valor'
@@ -158,11 +158,11 @@ nextflow run foo.nf -c meu-env.config
 
 ### Configurar processos
 
-As [diretivas](https://www.nextflow.io/docs/latest/process.html#directives) de processos permite a especificação de configurações para a execução de uma tarefa, como `cpus`, `memory`, `container`, além de outros recursos, no script do pipeline.
+As [diretivas](https://www.nextflow.io/docs/latest/process.html#directives) de processos permite a especificação de configurações para a execução de uma tarefa, como `cpus`, `memory`, `container`, além de outros recursos, no script do fluxo de trabalho.
 
-Isso é útil ao criarmos um exemplo-teste ou um protótipo para o nosso pipeline.
+Isso é útil ao criarmos um exemplo-teste ou um protótipo para o nosso fluxo de trabalho.
 
-No entanto, é sempre uma boa prática desassociar a lógica de execução do pipeline das configurações que serão utilizadas por ele. Assim, é altamente recomendável definir as configurações do processo no arquivo de configuração do pipeline em vez de no script do pipeline.
+No entanto, é sempre uma boa prática desassociar a lógica de execução do fluxo de trabalho das configurações que serão utilizadas por ele. Assim, é altamente recomendável definir as configurações do processo no arquivo de configuração do fluxo de trabalho em vez de no script do fluxo de trabalho.
 
 Além disso, quaisquer [diretivas](https://www.nextflow.io/docs/latest/process.html#directives) do escopo dos processos (`process`) podem ser usadas no arquivo de configuração.
 
@@ -174,7 +174,7 @@ process {
 }
 ```
 
-O trecho de configuração acima define as diretivas `cpus`, `memory` e `container` para todos os processos em seu pipeline.
+O trecho de configuração acima define as diretivas `cpus`, `memory` e `container` para todos os processos em seu fluxo de trabalho.
 
 O [seletor de processo](https://www.nextflow.io/docs/latest/config.html#process-selectors) pode ser usado para aplicar a configuração a um processo específico ou grupo de processos (discutido posteriormente).
 
@@ -189,7 +189,7 @@ O [seletor de processo](https://www.nextflow.io/docs/latest/config.html#process-
 | `'1 min'`         | `1.min`          | 60 segundos          |
 | `'1 hour 25 sec'` | \-               | 1 hora e 25 segundos |
 
-A sintaxe para definir as diretivas de processo no arquivo de configuração requer `=` (ou seja, operador de atribuição). Esta notação não deve ser usada para definir as diretivas do processo no script do pipeline.
+A sintaxe para definir as diretivas de processo no arquivo de configuração requer `=` (ou seja, operador de atribuição). Esta notação não deve ser usada para definir as diretivas do processo no script do fluxo de trabalho.
 
 ??? example
 
@@ -260,7 +260,7 @@ docker.enabled = true
 
 ### Configurar execução do Singularity
 
-Para rodar um pipeline com Singularity, é necessário fornecer o caminho para o arquivo de imagem do contêiner usando a diretiva de contêiner (`container`):
+Para rodar um fluxo de trabalho com Singularity, é necessário fornecer o caminho para o arquivo de imagem do contêiner usando a diretiva de contêiner (`container`):
 
 ```groovy linenums="1"
 process.container = '/alguma/imagem/singularity/imagem.sif'

--- a/docs/basic_training/containers.md
+++ b/docs/basic_training/containers.md
@@ -344,7 +344,7 @@ In the same way that we can push Docker images to Docker Hub, we can upload Sing
 
 ## Conda/Bioconda packages
 
-Conda is a popular package and environment manager. The built-in support for Conda allows Nextflow pipelines to automatically create and activate the Conda environment(s), given the dependencies specified by each process.
+Conda is a popular package and environment manager. The built-in support for Conda allows Nextflow workflows to automatically create and activate the Conda environment(s), given the dependencies specified by each process.
 
 In this Gitpod environment, conda is already installed.
 
@@ -438,7 +438,7 @@ ENV PATH /opt/conda/envs/nf-tutorial/bin:$PATH
 
 The above `Dockerfile` takes the parent image _mambaorg/micromamba_, then installs a `conda` environment using `micromamba`, and installs `salmon`, `fastqc` and `multiqc`.
 
-Try executing the RNA-Seq pipeline from earlier (script7.nf). Start by building your own micromamba `Dockerfile` (from above), save it to your Docker hub repo, and direct Nextflow to run from this container (changing your `nextflow.config`).
+Try executing the RNA-Seq workflow from earlier (script7.nf). Start by building your own micromamba `Dockerfile` (from above), save it to your Docker hub repo, and direct Nextflow to run from this container (changing your `nextflow.config`).
 
 !!! warning
 
@@ -517,7 +517,7 @@ Contrary to other registries that will pull the latest image when no tag (versio
 
 !!! exercise "Bonus Exercise"
 
-    Change the process directives in `script5.nf` or the `nextflow.config` file to make the pipeline automatically use BioContainers when using salmon, or fastqc.
+    Change the process directives in `script5.nf` or the `nextflow.config` file to make the workflow automatically use BioContainers when using salmon, or fastqc.
 
     !!! tip "Hint"
 
@@ -525,7 +525,7 @@ Contrary to other registries that will pull the latest image when no tag (versio
 
     ??? result
 
-        With these changes, you should be able to run the pipeline with BioContainers by running the following in the command line:
+        With these changes, you should be able to run the workflow with BioContainers by running the following in the command line:
 
         ```bash
         nextflow run script5.nf

--- a/docs/basic_training/containers.md
+++ b/docs/basic_training/containers.md
@@ -87,13 +87,13 @@ ENV PATH=$PATH:/usr/games/
 
 ### Build the image
 
-Build the Dockerfile image by using the following command:
+Build the Docker image based on the Dockerfile by using the following command:
 
 ```bash
 docker build -t my-image .
 ```
 
-Where "my-image" is the user-specified name tag for the Dockerfile, present in the current directory.
+Where "my-image" is the user-specified name for the container image you plan to build .
 
 !!! tip
 
@@ -206,7 +206,7 @@ Create an account on the <https://hub.docker.com> website. Then from your shell 
 docker login
 ```
 
-Tag the image with your Docker user name account:
+Rename the image to include your Docker user name account:
 
 ```bash
 docker tag my-image <user-name>/my-image

--- a/docs/basic_training/containers.pt.md
+++ b/docs/basic_training/containers.pt.md
@@ -344,7 +344,7 @@ Da mesma forma que disponibilizamos as imagens Docker no Docker Hub, nós podemo
 
 ## Pacotes Conda/Bioconda
 
-O Conda é um popular gerenciador de pacotes e ambientes. O suporte a Conda permite que pipelines Nextflow automaticamente criem e ativem ambientes Conda, dadas as dependências especificadas de cada processo.
+O Conda é um popular gerenciador de pacotes e ambientes. O suporte a Conda permite que fluxos de trabalho Nextflow automaticamente criem e ativem ambientes Conda, dadas as dependências especificadas de cada processo.
 
 Neste ambiente Gitpod, o conda já está instalado.
 
@@ -438,7 +438,7 @@ ENV PATH /opt/conda/envs/nf-tutorial/bin:$PATH
 
 O `Dockerfile` acima pega a imagem pai _mambaorg/micromamba_, e instala um ambiente `conda` utilizando `micromamba`, e então instala o `salmon`, o `fastqc` e o `multiqc`.
 
-Tente executar o pipeline RNA-seq visto anteriormente (script7.nf). Comece montando seu próprio `Dockerfile` micromamba (como mostrado acima), salve no seu repositório no Docker Hub, e oriente o Nextflow a rodar por esse contêiner (mudando seu `nextflow.config`).
+Tente executar o fluxo de trabalho RNA-seq visto anteriormente (script7.nf). Comece montando seu próprio `Dockerfile` micromamba (como mostrado acima), salve no seu repositório no Docker Hub, e oriente o Nextflow a rodar por esse contêiner (mudando seu `nextflow.config`).
 
 !!! warning
 
@@ -506,7 +506,7 @@ Contrariamente a outros registros que irão puxar a última imagem quando nenhum
 
 !!! exercise
 
-    Durante a seção onde construímos o pipeline de RNA-Seq, nós criamos um índice (script2.nf). Dado que nós não temos Salmon instalado localmente na máquina provida pelo Gitpod, nós temos que ou executar com `-with-conda` ou `-with-docker`. Sua tarefa agora é executar novamente com `-with-docker`, mas sem ter que criar sua própria imagem de contêiner Docker. Invés disso, use a imagem do BioContainers para Salmon 1.7.0.
+    Durante a seção onde construímos o fluxo de trabalho de RNA-Seq, nós criamos um índice (script2.nf). Dado que nós não temos Salmon instalado localmente na máquina provida pelo Gitpod, nós temos que ou executar com `-with-conda` ou `-with-docker`. Sua tarefa agora é executar novamente com `-with-docker`, mas sem ter que criar sua própria imagem de contêiner Docker. Invés disso, use a imagem do BioContainers para Salmon 1.7.0.
 
 
     ??? result
@@ -517,7 +517,7 @@ Contrariamente a outros registros que irão puxar a última imagem quando nenhum
 
 !!! exercise "Bonus Exercise"
 
-    Mude as diretivas do processo no `script5.nf` ou no arquivo `nextflow.config` para fazer o pipeline utilizar automaticamente BioContainers quando usando salmon, ou fastqc.
+    Mude as diretivas do processo no `script5.nf` ou no arquivo `nextflow.config` para fazer o fluxo de trabalho utilizar automaticamente BioContainers quando usando salmon, ou fastqc.
 
     !!! tip "Dica"
 
@@ -525,7 +525,7 @@ Contrariamente a outros registros que irão puxar a última imagem quando nenhum
 
     ??? result
 
-        Com essas mudanças, você deve ser capaz de executar o pipeline com BioContainers executando a seguinte linha de comando:
+        Com essas mudanças, você deve ser capaz de executar o fluxo de trabalho com BioContainers executando a seguinte linha de comando:
 
         ```bash
         nextflow run script5.nf

--- a/docs/basic_training/containers.pt.md
+++ b/docs/basic_training/containers.pt.md
@@ -87,13 +87,13 @@ ENV PATH=$PATH:/usr/games/
 
 ### Monte a imagem
 
-Monte a imagem do Dockerfile utilizando o seguinte comando:
+Monte a imagem do Docker com base no Dockerfile utilizando o seguinte comando:
 
 ```bash
 docker build -t minha-imagem .
 ```
 
-Onde "minha-imagem" é o rótulo que o usuário especificou para o Dockerfile, presente no diretório atual.
+Onde "minha-imagem" é o nome que o usuário especificou para a imagem que será criada.
 
 !!! tip
 
@@ -206,7 +206,7 @@ Crie uma conta no site <https://hub.docker.com>. Então no seu terminal shell ex
 docker login
 ```
 
-Marque a imagem com seu nome de usuário Docker:
+Renomeie a imagem para incluir seu nome de usuário Docker:
 
 ```bash
 docker tag minha-imagem <nome-de-usuario>/minha-imagem

--- a/docs/basic_training/executors.md
+++ b/docs/basic_training/executors.md
@@ -4,7 +4,7 @@ description: Basic Nextflow Training Workshop
 
 # Deployment scenarios
 
-Real-world genomic applications can spawn the execution of thousands of jobs. In this scenario a batch scheduler is commonly used to deploy a pipeline in a computing cluster, allowing the execution of many jobs in parallel across many compute nodes.
+Real-world genomic applications can spawn the execution of thousands of jobs. In this scenario a batch scheduler is commonly used to deploy a workflow in a computing cluster, allowing the execution of many jobs in parallel across many compute nodes.
 
 Nextflow has built-in support for the most commonly used batch schedulers, such as Univa Grid Engine, [SLURM](https://slurm.schedmd.com/) and IBM LSF. Check the Nextflow documentation for the complete list of supported [execution platforms](https://www.nextflow.io/docs/latest/executor.html).
 
@@ -14,7 +14,7 @@ A key Nextflow feature is the ability to decouple the workflow implementation fr
 
 ![Nextflow executors](img/nf-executors.png)
 
-To run your pipeline with a batch scheduler, modify the `nextflow.config` file specifying the target executor and the required computing resources if needed. For example:
+To run your workflow with a batch scheduler, modify the `nextflow.config` file specifying the target executor and the required computing resources if needed. For example:
 
 ```groovy linenums="1"
 process.executor = 'slurm'
@@ -65,20 +65,20 @@ For example, if your cluster uses Slurm as a job scheduler, you could create a f
 #SBATCH -c 1
 #SBATCH -t 12:00:00
 
-PIPELINE=$1
+WORKFLOW=$1
 CONFIG=$2
 
 # Use a conda environment where you have installed Nextflow
 # (may not be needed if you have installed it in a different way)
 conda activate nextflow
 
-nextflow -C ${CONFIG} run ${PIPELINE}
+nextflow -C ${CONFIG} run ${WORKFLOW}
 ```
 
 And then submit it with:
 
 ```bash linenums="1"
-sbatch launch_nf.sh /home/my_user/path/mypipeline.nf /home/my_user/path/myconfig_file.conf
+sbatch launch_nf.sh /home/my_user/path/my_workflow.nf /home/my_user/path/my_config_file.conf
 ```
 
 You can find more details about the example above [here](https://lescailab.unipv.it/guides/eos_guide/use_nextflow.html#large-testing-or-production).
@@ -201,7 +201,7 @@ Read more about config process selectors at [this link](https://www.nextflow.io/
 
 ## Configuration profiles
 
-Configuration files can contain the definition of one or more _profiles_. A profile is a set of configuration attributes that can be activated/chosen when launching a pipeline execution by using the `-profile` command- line option.
+Configuration files can contain the definition of one or more _profiles_. A profile is a set of configuration attributes that can be activated/chosen when launching a workflow execution by using the `-profile` command- line option.
 
 Configuration profiles are defined by using the special scope `profiles` which group the attributes that belong to the same profile using a common prefix. For example:
 
@@ -250,7 +250,7 @@ nextflow run <your script> -profile cluster
 
 [AWS Batch](https://aws.amazon.com/batch/) is a managed computing service that allows the execution of containerized workloads in the Amazon cloud infrastructure.
 
-Nextflow provides built-in support for AWS Batch which allows the seamless deployment of a Nextflow pipeline in the cloud, offloading the process executions as Batch jobs.
+Nextflow provides built-in support for AWS Batch which allows the seamless deployment of a Nextflow workflow in the cloud, offloading the process executions as Batch jobs.
 
 Once the Batch environment is configured, specify the instance types to be used and the max number of CPUs to be allocated, you need to create a Nextflow configuration file like the one shown below:
 
@@ -317,7 +317,7 @@ aws {
 
 ## Custom job definition
 
-Nextflow automatically creates the Batch [Job definitions](https://docs.aws.amazon.com/batch/latest/userguide/job_definitions.html) needed to execute your pipeline processes. Therefore it’s not required to define them before you run your workflow.
+Nextflow automatically creates the Batch [Job definitions](https://docs.aws.amazon.com/batch/latest/userguide/job_definitions.html) needed to execute your workflow processes. Therefore it’s not required to define them before you run your workflow.
 
 However, you may still need to specify a custom Job Definition to provide fine-grained control of the configuration settings of a specific job (e.g. to define custom mount paths or other special settings of a Batch Job).
 

--- a/docs/basic_training/executors.pt.md
+++ b/docs/basic_training/executors.pt.md
@@ -4,7 +4,7 @@ description: Material de treinamento básico do Nextflow
 
 # Cenários de implantação
 
-Aplicações genômicas do mundo real podem gerar milhares de tarefas sendo executadas. Nesse cenário, um escalonador de lote (batch scheduler) é comumente usado para implantar um pipeline em um cluster de computação, permitindo a execução de muitos trabalhos em paralelo em muitos nós de computação.
+Aplicações genômicas do mundo real podem gerar milhares de tarefas sendo executadas. Nesse cenário, um escalonador de lote (batch scheduler) é comumente usado para implantar um fluxo de trabalho em um cluster de computação, permitindo a execução de muitos trabalhos em paralelo em muitos nós de computação.
 
 O Nextflow possui suporte embutido para os escalonadores de lote mais usados, como o Univa Grid Engine, o [SLURM](https://slurm.schedmd.com/) e o IBM LSF. Verifique a documentação do Nextflow para obter a lista completa dos [ambientes de computação](https://www.nextflow.io/docs/latest/executor.html).
 
@@ -14,7 +14,7 @@ Um recurso importante do Nextflow é a capacidade de desacoplar a implementaçã
 
 ![Executores no Nextflow](img/nf-executors.png)
 
-Para executar seu pipeline com um escalonador de lote, modifique o arquivo `nextflow.config` especificando o executor de destino e os recursos de computação necessários, se necessário. Por exemplo:
+Para executar seu fluxo de trabalho com um escalonador de lote, modifique o arquivo `nextflow.config` especificando o executor de destino e os recursos de computação necessários, se necessário. Por exemplo:
 
 ```groovy linenums="1"
 process.executor = 'slurm'
@@ -65,20 +65,20 @@ Por exemplo, se seu cluster usa Slurm como escalonador de tarefas, você pode cr
 #SBATCH -c 1
 #SBATCH -t 12:00:00
 
-PIPELINE=$1
+FLUXO_DE_TRABALHO=$1
 CONFIG=$2
 
 # Use um ambiente conda onde você instalou o Nextflow
 # (pode não ser necessário se você o tiver instalado de uma maneira diferente)
 conda activate nextflow
 
-nextflow -C ${CONFIG} run ${PIPELINE}
+nextflow -C ${CONFIG} run ${FLUXO_DE_TRABALHO}
 ```
 
 E, em seguida, submeta-o com:
 
 ```bash linenums="1"
-sbatch launch_nf.sh /home/meu_usuario/caminho/meupipeline.nf /home/meu_usuario/caminho/meu_arquivo_configuracao.conf
+sbatch launch_nf.sh /home/meu_usuario/caminho/meu_fluxo_de_trabalho.nf /home/meu_usuario/caminho/meu_arquivo_configuracao.conf
 ```
 
 Você pode encontrar mais detalhes sobre o exemplo acima [aqui](https://lescailab.unipv.it/guides/eos_guide/use_nextflow.html#large-testing-or-production). Você também poderá encontrar mais dicas de como executar o Nextflow em HPC nos seguintes posts de blog:
@@ -200,7 +200,7 @@ Leia mais sobre seletores de processo de configuração [neste link](https://www
 
 ## Perfis de configuração
 
-Os arquivos de configuração podem conter a definição de um ou mais _perfis_. Um perfil é um conjunto de atributos de configuração que podem ser ativados/escolhidos ao lançar a execução de um pipeline usando a opção de linha de comando `-profile`.
+Os arquivos de configuração podem conter a definição de um ou mais _perfis_. Um perfil é um conjunto de atributos de configuração que podem ser ativados/escolhidos ao lançar a execução de um fluxo de trabalho usando a opção de linha de comando `-profile`.
 
 Os perfis de configuração são definidos usando o escopo especial `profiles` que agrupa os atributos que pertencem ao mesmo perfil usando um prefixo comum. Por exemplo:
 
@@ -249,7 +249,7 @@ nextflow run <seu script> -profile cluster
 
 [AWS Batch](https://aws.amazon.com/batch/) é um serviço de computação gerenciada que permite a execução de cargas de trabalho em contêineres na infraestrutura de nuvem da Amazon.
 
-O Nextflow fornece suporte embutido para o AWS Batch, que permite uma implantação simples de um pipeline do Nextflow na nuvem, descarregando as execuções de processo como trabalhos em lote.
+O Nextflow fornece suporte embutido para o AWS Batch, que permite uma implantação simples de um fluxo de trabalho do Nextflow na nuvem, descarregando as execuções de processo como trabalhos em lote.
 
 Uma vez que o ambiente Batch esteja configurado, especifique os tipos de instância a serem usadas e o número máximo de CPUs a serem alocadas. Você precisa criar um arquivo de configuração do Nextflow como o mostrado abaixo:
 
@@ -316,7 +316,7 @@ aws {
 
 ## Definição de tarefa personalizada
 
-O Nextflow cria automaticamente as [definições de trabalho](https://docs.aws.amazon.com/batch/latest/userguide/job_definitions.html) do Batch necessárias para executar seus processos de pipeline. Portanto, não é necessário defini-las antes de executar seu fluxo de trabalho.
+O Nextflow cria automaticamente as [definições de trabalho](https://docs.aws.amazon.com/batch/latest/userguide/job_definitions.html) do Batch necessárias para executar seus processos de fluxo de trabalho. Portanto, não é necessário defini-las antes de executar seu fluxo de trabalho.
 
 No entanto, você ainda pode precisar especificar uma definição de tarefa personalizada para fornecer controle refinado das definições de configuração de uma tarefa específica (por exemplo, para definir caminhos de montagem personalizados ou outras configurações especiais de uma tarefa no Batch).
 

--- a/docs/basic_training/index.md
+++ b/docs/basic_training/index.md
@@ -12,7 +12,7 @@ We are excited to have you on the path to writing reproducible and scalable scie
 
 By the end of this course you should:
 
-1. Be proficient in writing Nextflow pipelines
+1. Be proficient in writing Nextflow workflows
 2. Know the basic Nextflow concepts of Channels, Processes and Operators
 3. Have an understanding of containerized workflows
 4. Understand the different execution platforms supported by Nextflow
@@ -28,4 +28,4 @@ To get you started with Nextflow as quickly as possible, we will walk through th
 4. Dive deeper into the core Nextflow syntax, including Channels, Processes, and Operators
 5. Cover cluster and cloud deployment scenarios and explore Nextflow Tower capabilities
 
-This will give you a broad understanding of Nextflow, to start writing your own pipelines. We hope you enjoy the course! This is an ever-evolving document - feedback is always welcome.
+This will give you a broad understanding of Nextflow, to start writing your own workflows. We hope you enjoy the course! This is an ever-evolving document - feedback is always welcome.

--- a/docs/basic_training/index.pt.md
+++ b/docs/basic_training/index.pt.md
@@ -12,7 +12,7 @@ Estamos entusiasmados em tê-lo no caminho para escrever fluxos de trabalho cien
 
 Ao final deste curso você deverá:
 
-1. Ser proficiente em escrever pipelines com o Nextflow
+1. Ser proficiente em escrever fluxos de trabalho com o Nextflow
 2. Conhecer os conceitos básicos de Canais, Processos e Operadores no Nextflow
 3. Ter uma compreensão dos fluxos de trabalho usando contêineres
 4. Entender as diferentes plataformas de execução suportadas pelo Nextflow
@@ -28,4 +28,4 @@ Para começar a usar o Nextflow o mais rápido possível, seguiremos as seguinte
 4. Mergulhar mais fundo na sintaxe principal do Nextflow, incluindo Canais, Processos e Operadores
 5. Cobrir cenários de implantação na nuvem e em clusters e explorar os recursos do Nextflow Tower
 
-Isso lhe dará uma ampla compreensão do Nextflow para começar a escrever seus próprios pipelines. Esperamos que goste do curso! Este é um documento em constante evolução - feedback é sempre bem-vindo.
+Isso lhe dará uma ampla compreensão do Nextflow para começar a escrever seus próprios fluxos de trabalho. Esperamos que goste do curso! Este é um documento em constante evolução - feedback é sempre bem-vindo.

--- a/docs/basic_training/intro.md
+++ b/docs/basic_training/intro.md
@@ -239,9 +239,9 @@ You will see that the execution of the process `SPLITLETTERS` is skipped (the pr
 
     The workflow results are cached by default in the directory `$PWD/work`. Depending on your script, this folder can take up a lot of disk space. If you are sure you won’t need to resume your workflow execution, clean this folder periodically.
 
-## Pipeline parameters
+## Workflow parameters
 
-Pipeline parameters are simply declared by prepending the prefix `params` to a variable name, separated by a dot character. Their value can be specified on the command line by prefixing the parameter name with a double dash character, i.e. `--paramName`.
+Workflow parameters are simply declared by prepending the prefix `params` to a variable name, separated by a dot character. Their value can be specified on the command line by prefixing the parameter name with a double dash character, i.e. `--paramName`.
 
 Now, let’s try to execute the previous example specifying a different input string parameter, as shown below:
 

--- a/docs/basic_training/intro.md
+++ b/docs/basic_training/intro.md
@@ -6,7 +6,7 @@ description: Getting started with Nextflow
 
 ## Basic concepts
 
-Nextflow is a workflow orchestration engine and domain-specific language (DSL) that makes it easy to write data-intensive computational pipelines.
+Nextflow is a workflow orchestration engine and domain-specific language (DSL) that makes it easy to write data-intensive computational workflows.
 
 It is designed around the idea that the Linux platform is the _lingua franca_ of data science. Linux provides many simple but powerful command-line and scripting tools that, when chained together, facilitate complex data manipulations.
 
@@ -18,11 +18,11 @@ Nextflow extends this approach, adding the ability to define complex program int
 
 ### Processes and Channels
 
-In practice, a Nextflow pipeline is made by joining together different processes. Each `process` can be written in any scripting language that can be executed by the Linux platform (Bash, Perl, Ruby, Python, etc.).
+In practice, a Nextflow workflow is made by joining together different processes. Each `process` can be written in any scripting language that can be executed by the Linux platform (Bash, Perl, Ruby, Python, etc.).
 
 Processes are executed independently and are isolated from each other, i.e., they do not share a common (writable) state. The only way they can communicate is via asynchronous first-in, first-out (FIFO) queues, called `channels`.
 
-Any `process` can define one or more `channels` as an `input` and `output`. The interaction between these processes, and ultimately the pipeline execution flow itself, is implicitly defined by these `input` and `output` declarations.
+Any `process` can define one or more `channels` as an `input` and `output`. The interaction between these processes, and ultimately the workflow execution flow itself, is implicitly defined by these `input` and `output` declarations.
 
 <figure class="excalidraw">
 --8<-- "docs/basic_training/img/channel-process.excalidraw.svg"
@@ -32,9 +32,9 @@ Any `process` can define one or more `channels` as an `input` and `output`. The 
 
 While a `process` defines _what_ command or `script` has to be executed, the executor determines _how_ that `script` is run in the target platform.
 
-If not otherwise specified, processes are executed on the local computer. The local executor is very useful for pipeline development and testing purposes, however, for real-world computational pipelines a high-performance computing (HPC) or cloud platform is often required.
+If not otherwise specified, processes are executed on the local computer. The local executor is very useful for workflow development and testing purposes, however, for real-world computational workflows a high-performance computing (HPC) or cloud platform is often required.
 
-In other words, Nextflow provides an abstraction between the pipeline’s functional logic and the underlying execution system (or runtime). Thus, it is possible to write a pipeline that runs seamlessly on your computer, a cluster, or the cloud, without being modified. You simply define the target execution platform in the configuration file.
+In other words, Nextflow provides an abstraction between the workflow’s functional logic and the underlying execution system (or runtime). Thus, it is possible to write a workflow that runs seamlessly on your computer, a cluster, or the cloud, without being modified. You simply define the target execution platform in the configuration file.
 
 <figure markdown>
 
@@ -185,7 +185,7 @@ The standard output shows (line by line):
 
 !!! tip
 
-    The second process runs twice, executing in two different work directories for each input file. The [ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code) log output from Nextflow dynamically refreshes as the pipeline runs; in the previous example the work directory `[1a/3c54ed]` is the second of the two directories that were processed (overwriting the log with the first). To print all the relevant paths to the screen, disable the ANSI log output usin the `-ansi-log` flag (e.g., `nextflow run hello.nf -ansi-log false`).
+    The second process runs twice, executing in two different work directories for each input file. The [ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code) log output from Nextflow dynamically refreshes as the workflow runs; in the previous example the work directory `[1a/3c54ed]` is the second of the two directories that were processed (overwriting the log with the first). To print all the relevant paths to the screen, disable the ANSI log output usin the `-ansi-log` flag (e.g., `nextflow run hello.nf -ansi-log false`).
 
 It’s worth noting that the process `CONVERTTOUPPER` is executed in parallel, so there’s no guarantee that the instance processing the first split (the chunk _Hello ') will be executed before the one processing the second split (the chunk 'world!_).
 
@@ -198,9 +198,9 @@ HELLO
 
 ## Modify and resume
 
-Nextflow keeps track of all the processes executed in your pipeline. If you modify some parts of your script, only the processes that are changed will be re-executed. The execution of the processes that are not changed will be skipped and the cached result will be used instead.
+Nextflow keeps track of all the processes executed in your workflow. If you modify some parts of your script, only the processes that are changed will be re-executed. The execution of the processes that are not changed will be skipped and the cached result will be used instead.
 
-This allows for testing or modifying part of your pipeline without having to re-execute it from scratch.
+This allows for testing or modifying part of your workflow without having to re-execute it from scratch.
 
 For the sake of this tutorial, modify the `CONVERTTOUPPER` process in the previous example, replacing the process script with the string `rev $y`, so that the process looks like this:
 
@@ -237,7 +237,7 @@ You will see that the execution of the process `SPLITLETTERS` is skipped (the pr
 
 !!! info
 
-    The pipeline results are cached by default in the directory `$PWD/work`. Depending on your script, this folder can take up a lot of disk space. If you are sure you won’t need to resume your pipeline execution, clean this folder periodically.
+    The workflow results are cached by default in the directory `$PWD/work`. Depending on your script, this folder can take up a lot of disk space. If you are sure you won’t need to resume your workflow execution, clean this folder periodically.
 
 ## Pipeline parameters
 
@@ -264,7 +264,7 @@ uojnoB
 
 ### In DAG-like format
 
-To better understand how Nextflow is dealing with the data in this pipeline, below is a DAG-like figure to visualize all the `inputs`, `outputs`, `channels` and `processes`:
+To better understand how Nextflow is dealing with the data in this workflow, below is a DAG-like figure to visualize all the `inputs`, `outputs`, `channels` and `processes`:
 
 <figure markdown>
 

--- a/docs/basic_training/intro.pt.md
+++ b/docs/basic_training/intro.pt.md
@@ -6,13 +6,13 @@ description: Introdução ao Nextflow
 
 ## Conceitos básicos
 
-O Nextflow é tanto um motor de orquestração de fluxo de trabalho quanto uma linguagem de domínio específico (Domain-Specific Language - DSL) que facilita a escrita de fluxos de trabalho computacionais com uso intensivo de dados.
+O Nextflow é tanto um motor de orquestração de fluxo de trabalho quanto uma linguagem de domínio específico (Domain-Specific Language - DSL) que facilita a escrita de fluxos de trabalho computacionais que fazem uso intensivo de dados.
 
 Ele foi projetado com base na ideia de que a plataforma Linux é a _língua franca_ da ciência de dados. O Linux fornece muitas ferramentas de linha de comando que, ainda que simples, são poderosas ferramentas de script que, quando encadeadas, facilitam manipulações complexas de dados.
 
 O Nextflow estende essa abordagem, adicionando a capacidade de definir interações complexas entre programas e um ambiente de computação paralela de alto nível, baseado no modelo de programação Dataflow. Os principais recursos do Nextflow são:
 
--   Portabilidade e reprodutibilidade do fluxo de trabalho
+-   Portabilidade e reprodutibilidade de fluxos de trabalho
 -   Escalabilidade na paralelização e na implantação
 -   Integração de ferramentas já existentes, sistemas e padrões da indústria
 
@@ -32,7 +32,7 @@ Qualquer processo pode definir um ou mais `canais` como uma `entrada` e `saída`
 
 Enquanto um processo define _qual_ comando ou `script` deve ser executado, o executor determina _como_ esse `script` é executado na plataforma alvo.
 
-Se não for especificado de outra forma, os processos são executados no computador local. O executor local é muito útil para fins de desenvolvimento e teste de fluxo de trabalho, no entanto, para fluxos de trabalho computacionais do mundo real, uma plataforma de computação de alto desempenho (High-Performance Computing - HPC) ou de computação em nuvem geralmente é necessária.
+Se não for especificado de outra forma, os processos são executados no computador local. O executor local é muito útil para fins de desenvolvimento e teste de fluxos de trabalho, no entanto, para fluxos de trabalho computacionais do mundo real, uma plataforma de computação de alto desempenho (High-Performance Computing - HPC) ou de computação em nuvem geralmente é necessária.
 
 Em outras palavras, o Nextflow fornece uma abstração entre a lógica funcional do fluxo de trabalho e o sistema de execução subjacente (ou sistema de tempo de execução). Assim, é possível escrever um fluxo de trabalho que seja executado perfeitamente em seu computador, em um cluster ou na nuvem, sem ser modificado. Você simplesmente define a plataforma de execução alvo no arquivo de configuração.
 

--- a/docs/basic_training/intro.pt.md
+++ b/docs/basic_training/intro.pt.md
@@ -6,7 +6,7 @@ description: Introdução ao Nextflow
 
 ## Conceitos básicos
 
-O Nextflow é tanto um motor de orquestração de fluxo de trabalho quanto uma linguagem de domínio específico (Domain-Specific Language - DSL) que facilita a escrita de pipelines computacionais com uso intensivo de dados.
+O Nextflow é tanto um motor de orquestração de fluxo de trabalho quanto uma linguagem de domínio específico (Domain-Specific Language - DSL) que facilita a escrita de fluxos de trabalho computacionais com uso intensivo de dados.
 
 Ele foi projetado com base na ideia de que a plataforma Linux é a _língua franca_ da ciência de dados. O Linux fornece muitas ferramentas de linha de comando que, ainda que simples, são poderosas ferramentas de script que, quando encadeadas, facilitam manipulações complexas de dados.
 
@@ -18,11 +18,11 @@ O Nextflow estende essa abordagem, adicionando a capacidade de definir interaç�
 
 ### Processos e Canais
 
-Na prática, um pipeline Nextflow é feito juntando diferentes processos. Cada processo pode ser escrito em qualquer linguagem de script que possa ser executada pela plataforma Linux (Bash, Perl, Ruby, Python, etc.).
+Na prática, um fluxo de trabalho Nextflow é feito juntando diferentes processos. Cada processo pode ser escrito em qualquer linguagem de script que possa ser executada pela plataforma Linux (Bash, Perl, Ruby, Python, etc.).
 
 Os processos são executados de forma independente e isolados uns dos outros, ou seja, não compartilham um estado (gravável) comum. A única maneira de eles se comunicarem é por meio de filas assíncronas, chamadas de `canais`, onde o primeiro elemento a entrar, é o primeiro a sair (FIFO - First-in-First-out).
 
-Qualquer processo pode definir um ou mais `canais` como uma `entrada` e `saída`. A interação entre esses processos e, em última análise, o próprio fluxo de execução do pipeline, é definido implicitamente por essas declarações de `entrada` e `saída`.
+Qualquer processo pode definir um ou mais `canais` como uma `entrada` e `saída`. A interação entre esses processos e, em última análise, o próprio fluxo de execução do fluxo de trabalho, é definido implicitamente por essas declarações de `entrada` e `saída`.
 
 <figure class="excalidraw">
 --8<-- "docs/basic_training/img/channel-process.excalidraw.pt.svg"
@@ -32,9 +32,9 @@ Qualquer processo pode definir um ou mais `canais` como uma `entrada` e `saída`
 
 Enquanto um processo define _qual_ comando ou `script` deve ser executado, o executor determina _como_ esse `script` é executado na plataforma alvo.
 
-Se não for especificado de outra forma, os processos são executados no computador local. O executor local é muito útil para fins de desenvolvimento e teste de pipeline, no entanto, para pipelines computacionais do mundo real, uma plataforma de computação de alto desempenho (High-Performance Computing - HPC) ou de computação em nuvem geralmente é necessária.
+Se não for especificado de outra forma, os processos são executados no computador local. O executor local é muito útil para fins de desenvolvimento e teste de fluxo de trabalho, no entanto, para fluxos de trabalho computacionais do mundo real, uma plataforma de computação de alto desempenho (High-Performance Computing - HPC) ou de computação em nuvem geralmente é necessária.
 
-Em outras palavras, o Nextflow fornece uma abstração entre a lógica funcional do pipeline e o sistema de execução subjacente (ou sistema de tempo de execução). Assim, é possível escrever um pipeline que seja executado perfeitamente em seu computador, em um cluster ou na nuvem, sem ser modificado. Você simplesmente define a plataforma de execução alvo no arquivo de configuração.
+Em outras palavras, o Nextflow fornece uma abstração entre a lógica funcional do fluxo de trabalho e o sistema de execução subjacente (ou sistema de tempo de execução). Assim, é possível escrever um fluxo de trabalho que seja executado perfeitamente em seu computador, em um cluster ou na nuvem, sem ser modificado. Você simplesmente define a plataforma de execução alvo no arquivo de configuração.
 
 <figure markdown>
 
@@ -184,7 +184,7 @@ A saída padrão mostra (linha por linha):
 
 !!! tip
 
-    O segundo processo é executado duas vezes, em dois diretórios de trabalho diferentes para cada arquivo de entrada. A saída de log [ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code) do Nextflow é atualizada dinamicamente conforme o pipeline é executado; no exemplo anterior, o diretório de trabalho `[1a/3c54ed]` é o segundo dos dois diretórios que foram processados (sobrescrevendo o log com o primeiro). Para imprimir para a tela todos os caminhos relevantes, desative a saída de log ANSI usando o sinalizador `-ansi-log` (por exemplo, `nextflow run hello.nf -ansi-log false`).
+    O segundo processo é executado duas vezes, em dois diretórios de trabalho diferentes para cada arquivo de entrada. A saída de log [ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code) do Nextflow é atualizada dinamicamente conforme o fluxo de trabalho é executado; no exemplo anterior, o diretório de trabalho `[1a/3c54ed]` é o segundo dos dois diretórios que foram processados (sobrescrevendo o log com o primeiro). Para imprimir para a tela todos os caminhos relevantes, desative a saída de log ANSI usando o sinalizador `-ansi-log` (por exemplo, `nextflow run hello.nf -ansi-log false`).
 
 Vale ressaltar que o processo `CONVERTTOUPPER` é executado em paralelo, portanto não há garantia de que a instância que processa a primeira divisão (o bloco _Hello_) será executada antes daquela que processa a segundo divisão (o bloco _world!_).
 
@@ -197,9 +197,9 @@ HELLO
 
 ## Modifique e retome
 
-O Nextflow acompanha todos os processos executados em seu pipeline. Se você modificar algumas partes do seu script, apenas os processos alterados serão executados novamente. A execução dos processos que não foram alterados será ignorada e o resultado armazenado em cache será usado em seu lugar.
+O Nextflow acompanha todos os processos executados em seu fluxo de trabalho. Se você modificar algumas partes do seu script, apenas os processos alterados serão executados novamente. A execução dos processos que não foram alterados será ignorada e o resultado armazenado em cache será usado em seu lugar.
 
-Isso permite testar ou modificar parte do pipeline sem precisar executá-lo novamente do zero.
+Isso permite testar ou modificar parte do fluxo de trabalho sem precisar executá-lo novamente do zero.
 
 Para este tutorial, modifique o processo `CONVERTTOUPPER` do exemplo anterior, substituindo o script do processo pela string `rev $y`, para que o processo fique assim:
 
@@ -236,11 +236,11 @@ Você verá que a execução do processo `SPLITLETTERS` é ignorada (o ID do pro
 
 !!! info
 
-    Os resultados do pipeline são armazenados em cache por padrão no diretório `$PWD/work`. Dependendo do seu script, esta pasta pode ocupar muito espaço em disco. Se tiver certeza de que não precisará retomar a execução do pipeline, limpe esta pasta periodicamente.
+    Os resultados do fluxo de trabalho são armazenados em cache por padrão no diretório `$PWD/work`. Dependendo do seu script, esta pasta pode ocupar muito espaço em disco. Se tiver certeza de que não precisará retomar a execução do fluxo de trabalho, limpe esta pasta periodicamente.
 
-## Parâmetros do pipeline
+## Parâmetros do fluxo de trabalho
 
-Os parâmetros de pipeline são declarados simplesmente adicionando o prefixo `params` a um nome de variável, separando-os por um caractere de ponto. Seu valor pode ser especificado na linha de comando prefixando o nome do parâmetro com um traço duplo, ou seja, `--nomeParametro`.
+Os parâmetros de fluxo de trabalho são declarados simplesmente adicionando o prefixo `params` a um nome de variável, separando-os por um caractere de ponto. Seu valor pode ser especificado na linha de comando prefixando o nome do parâmetro com um traço duplo, ou seja, `--nomeParametro`.
 
 Agora, vamos tentar executar o exemplo anterior especificando um parâmetro de string de entrada diferente, conforme mostrado abaixo:
 
@@ -263,7 +263,7 @@ uojnoB
 
 ### Em formato de DAG
 
-Para entender melhor como o Nextflow está lidando com os dados neste pipeline, abaixo está uma figura tipo DAG para visualizar todas as entradas (`input`), saídas (`output`), canais (`channel`) e processos (`process`):
+Para entender melhor como o Nextflow está lidando com os dados neste fluxo de trabalho, abaixo está uma figura tipo DAG para visualizar todas as entradas (`input`), saídas (`output`), canais (`channel`) e processos (`process`):
 
 <figure markdown>
 

--- a/docs/basic_training/modules.md
+++ b/docs/basic_training/modules.md
@@ -4,9 +4,9 @@ description: Basic Nextflow Training Workshop
 
 # Modularization
 
-The definition of module libraries simplifies the writing of complex data analysis pipelines and makes re-use of processes much easier.
+The definition of module libraries simplifies the writing of complex data analysis workflows and makes re-use of processes much easier.
 
-Using the `hello.nf` example from earlier, we will convert the pipeline’s processes into modules, then call them within the workflow scope in a variety of ways.
+Using the `hello.nf` example from earlier, we will convert the workflow’s processes into modules, then call them within the workflow scope in a variety of ways.
 
 ## Modules
 
@@ -148,7 +148,7 @@ workflow {
 !!! tip
 
     You can store each process in separate files within separate sub-folders or combined in one big file (both are valid).
-    You can find examples of this on public repos such as the [Seqera RNA-Seq tutorial](https://github.com/seqeralabs/rnaseq-nf/tree/master/modules) or within nf-core pipelines, such as [nf-core/rnaseq](https://github.com/nf-core/rnaseq/tree/master/modules/nf-core).
+    You can find examples of this on public repos such as the [Seqera RNA-Seq tutorial](https://github.com/seqeralabs/rnaseq-nf/tree/master/modules) or within nf-core workflows, such as [nf-core/rnaseq](https://github.com/nf-core/rnaseq/tree/master/modules/nf-core).
 
 ## Output definition
 
@@ -263,7 +263,7 @@ include { SPLITLETTERS } from './modules.nf'
 include { CONVERTTOUPPER } from './modules.nf'
 
 
-workflow my_pipeline {
+workflow my_workflow {
     greeting_ch = Channel.of(params.greeting)
     SPLITLETTERS(greeting_ch)
     CONVERTTOUPPER(SPLITLETTERS.out.flatten())
@@ -271,11 +271,11 @@ workflow my_pipeline {
 }
 
 workflow {
-    my_pipeline()
+    my_workflow()
 }
 ```
 
-For example, the snippet above defines a `workflow` named `my_pipeline`, that can be invoked via another `workflow` definition.
+For example, the snippet above defines a `workflow` named `my_workflow`, that can be invoked via another `workflow` definition.
 
 !!! note
 
@@ -297,7 +297,7 @@ params.greeting = 'Hello world!'
 include { SPLITLETTERS } from './modules.nf'
 include { CONVERTTOUPPER } from './modules.nf'
 
-workflow my_pipeline {
+workflow my_workflow {
     take:
     greeting
 
@@ -316,7 +316,7 @@ The input for the `workflow` can then be specified as an argument:
 
 ```groovy linenums="1"
 workflow {
-    my_pipeline(Channel.of(params.greeting))
+    my_workflow(Channel.of(params.greeting))
 }
 ```
 
@@ -325,7 +325,7 @@ workflow {
 A `workflow` can declare one or more output channels using the `emit` statement. For example:
 
 ```groovy linenums="1"
-workflow my_pipeline {
+workflow my_workflow {
     take:
     greeting
 
@@ -338,17 +338,17 @@ workflow my_pipeline {
 }
 
 workflow {
-    my_pipeline(Channel.of(params.greeting))
-    my_pipeline.out.view()
+    my_workflow(Channel.of(params.greeting))
+    my_workflow.out.view()
 }
 ```
 
-As a result, we can use the `my_pipeline.out` notation to access the outputs of `my_pipeline` in the invoking `workflow`.
+As a result, we can use the `my_workflow.out` notation to access the outputs of `my_workflow` in the invoking `workflow`.
 
 We can also declare named outputs within the `emit` block.
 
 ```groovy linenums="1" hl_lines="10 15"
-workflow my_pipeline {
+workflow my_workflow {
     take:
     greeting
 
@@ -361,18 +361,18 @@ workflow my_pipeline {
 }
 
 workflow {
-    my_pipeline(Channel.of(params.greeting))
-    my_pipeline.out.my_data.view()
+    my_workflow(Channel.of(params.greeting))
+    my_workflow.out.my_data.view()
 }
 ```
 
-The result of the above snippet can then be accessed using `my_pipeline.out.my_data`.
+The result of the above snippet can then be accessed using `my_workflow.out.my_data`.
 
 ### Calling named workflows
 
 Within a `main.nf` script (called `hello.nf` in our example) we also can have multiple workflows. In which case we may want to call a specific workflow when running the code. For this we use the entrypoint call `-entry <workflow_name>`.
 
-The following snippet has two named workflows (`my_pipeline_one` and `my_pipeline_two`):
+The following snippet has two named workflows (`my_workflow_one` and `my_workflow_two`):
 
 ```groovy linenums="1"
 #!/usr/bin/env nextflow
@@ -386,28 +386,28 @@ include { CONVERTTOUPPER as CONVERTTOUPPER_one } from './modules.nf'
 include { CONVERTTOUPPER as CONVERTTOUPPER_two } from './modules.nf'
 
 
-workflow my_pipeline_one {
+workflow my_workflow_one {
     letters_ch1 = SPLITLETTERS_one(params.greeting)
     results_ch1 = CONVERTTOUPPER_one(letters_ch1.flatten())
     results_ch1.view { it }
 }
 
-workflow my_pipeline_two {
+workflow my_workflow_two {
     letters_ch2 = SPLITLETTERS_two(params.greeting)
     results_ch2 = CONVERTTOUPPER_two(letters_ch2.flatten())
     results_ch2.view { it }
 }
 
 workflow {
-    my_pipeline_one(Channel.of(params.greeting))
-    my_pipeline_two(Channel.of(params.greeting))
+    my_workflow_one(Channel.of(params.greeting))
+    my_workflow_two(Channel.of(params.greeting))
 }
 ```
 
 You can choose which workflow to run by using the `entry` flag:
 
 ```bash
-nextflow run hello.2.nf -entry my_pipeline_one
+nextflow run hello.2.nf -entry my_workflow_one
 ```
 
 ### Parameter scopes
@@ -447,7 +447,7 @@ As highlighted above, the script will print `Hola mundo!` instead of `Hello worl
 
 !!! info
 
-    To avoid being ignored, pipeline parameters should be defined at the beginning of the script before any `include` declarations.
+    To avoid being ignored, workflow parameters should be defined at the beginning of the script before any `include` declarations.
 
 The `addParams` option can be used to extend the module parameters without affecting the external scope. For example:
 

--- a/docs/basic_training/modules.pt.md
+++ b/docs/basic_training/modules.pt.md
@@ -4,9 +4,9 @@ description: Material de treinamento básico do Nextflow
 
 # Modularização
 
-A definição de bibliotecas modulares simplifica a escrita de pipelines complexos de análise de dados, além tornar o reuso de processos mais fácil.
+A definição de bibliotecas modulares simplifica a escrita de fluxos de trabalho complexos de análise de dados, além tornar o reuso de processos mais fácil.
 
-Ao usar o exemplo `hello.nf` da seção de introdução, nós converteremos os processos do pipeline em módulos e, em seguida, executaremos estes processos dentro do escopo do workflow de diferentes formas.
+Ao usar o exemplo `hello.nf` da seção de introdução, nós converteremos os processos do fluxo de trabalho em módulos e, em seguida, executaremos estes processos dentro do escopo do fluxo de trabalho de diferentes formas.
 
 ## Módulos
 
@@ -49,7 +49,7 @@ include { CONVERTTOUPPER } from './modules.nf'
         include { SPLITLETTERS   } from './modules.nf'
         include { CONVERTTOUPPER } from './modules.nf'
 
-        workflow {
+        fluxo de trabalho {
             letters_ch = SPLITLETTERS(greeting_ch)
             results_ch = CONVERTTOUPPER(letters_ch.flatten())
             results_ch.view { it }
@@ -148,7 +148,7 @@ workflow {
 !!! tip
 
     Você pode armazenar cada processo em arquivos separados em subpastas separadas ou combinados em um arquivo grande (ambos são válidos).
-    Você pode encontrar exemplos disso em repositórios públicos, como no [tutorial de RNA-Seq da Seqera](https://github.com/seqeralabs/rnaseq-nf/tree/master/modules) ou em pipelines do nf-core, como o [nf-core/rnaseq](https://github.com/nf-core/rnaseq/tree/master/modules/nf-core).
+    Você pode encontrar exemplos disso em repositórios públicos, como no [tutorial de RNA-Seq da Seqera](https://github.com/seqeralabs/rnaseq-nf/tree/master/modules) ou em fluxos de trabalho do nf-core, como o [nf-core/rnaseq](https://github.com/nf-core/rnaseq/tree/master/modules/nf-core).
 
 ## Definição de saída
 
@@ -223,7 +223,7 @@ process CONVERTTOUPPER {
 }
 ```
 
-Em seguida, altere o escopo do workflow em `hello.nf` para chamar essa saída nomeada específica (observe o `.upper` adicionado):
+Em seguida, altere o escopo do fluxo de trabalho em `hello.nf` para chamar essa saída nomeada específica (observe o `.upper` adicionado):
 
 ```groovy linenums="1" title="hello.nf"
 workflow {
@@ -236,14 +236,14 @@ workflow {
 
 ### Usando saídas canalizadas
 
-Outra maneira de lidar com as saídas no escopo do workflow é usar pipes `|`.
+Outra maneira de lidar com as saídas no escopo do fluxo de trabalho é usar pipes `|`.
 
 !!! exercise
 
      Tente alterar o script do fluxo de trabalho para o trecho abaixo:
 
     ```groovy linenums="1"
-    workflow {
+    fluxo de trabalho {
         Channel.of(params.greeting) | SPLITLETTERS | flatten | CONVERTTOUPPER | view
     }
     ```
@@ -263,7 +263,7 @@ include { SPLITLETTERS } from './modules.nf'
 include { CONVERTTOUPPER } from './modules.nf'
 
 
-workflow meu_pipeline {
+workflow meu_fluxo_de_trabalho {
     greeting_ch = Channel.of(params.greeting)
     SPLITLETTERS(greeting_ch)
     CONVERTTOUPPER(SPLITLETTERS.out.flatten())
@@ -271,11 +271,11 @@ workflow meu_pipeline {
 }
 
 workflow {
-    meu_pipeline()
+    meu_fluxo_de_trabalho()
 }
 ```
 
-Por exemplo, o trecho acima define um `workflow` chamado `meu_pipeline`, que pode ser chamado por meio de outra definição de `workflow`.
+Por exemplo, o trecho acima define um `workflow` chamado `meu_fluxo_de_trabalho`, que pode ser chamado por meio de outra definição de `workflow`.
 
 !!! note
 
@@ -283,7 +283,7 @@ Por exemplo, o trecho acima define um `workflow` chamado `meu_pipeline`, que pod
 
 !!! warning
 
-    Um componente de um workflow pode acessar qualquer variável ou parâmetro definido no escopo externo. No exemplo em execução, também podemos acessar `params.greeting` diretamente na definição de `workflow`.
+    Um componente de um fluxo de trabalho pode acessar qualquer variável ou parâmetro definido no escopo externo. No exemplo em execução, também podemos acessar `params.greeting` diretamente na definição de `workflow`.
 
 ### Entradas de workflow
 
@@ -297,7 +297,7 @@ params.greeting = 'Hello world!'
 include { SPLITLETTERS } from './modules.nf'
 include { CONVERTTOUPPER } from './modules.nf'
 
-workflow meu_pipeline {
+workflow meu_fluxo_de_trabalho {
     take:
     greeting
 
@@ -316,16 +316,16 @@ A entrada para o `workflow` pode então ser especificada como um argumento:
 
 ```groovy linenums="1"
 workflow {
-    meu_pipeline(Channel.of(params.greeting))
+    meu_fluxo_de_trabalho(Channel.of(params.greeting))
 }
 ```
 
 ### Saídas do workflow
 
-Um `workflow` pode declarar um ou mais canais de saída usando a instrução `emit`. Por exemplo:
+Um bloco `workflow` pode declarar um ou mais canais de saída usando a instrução `emit`. Por exemplo:
 
 ```groovy linenums="1"
-workflow meu_pipeline {
+workflow meu_fluxo_de_trabalho {
     take:
     greeting
 
@@ -338,17 +338,17 @@ workflow meu_pipeline {
 }
 
 workflow {
-    meu_pipeline(Channel.of(params.greeting))
-    meu_pipeline.out.view()
+    meu_fluxo_de_trabalho(Channel.of(params.greeting))
+    meu_fluxo_de_trabalho.out.view()
 }
 ```
 
-Como resultado, podemos usar a notação `meu_pipeline.out` para acessar as saídas de `meu_pipeline` na chamada `workflow`.
+Como resultado, podemos usar a notação `meu_fluxo_de_trabalho.out` para acessar as saídas de `meu_fluxo_de_trabalho` na chamada `workflow`.
 
 Também podemos declarar saídas nomeadas dentro do bloco `emit`.
 
 ```groovy linenums="1" hl_lines="10 15"
-workflow meu_pipeline {
+workflow meu_fluxo_de_trabalho {
     take:
     greeting
 
@@ -361,18 +361,18 @@ workflow meu_pipeline {
 }
 
 workflow {
-    meu_pipeline(Channel.of(params.greeting))
-    meu_pipeline.out.meus_dados.view()
+    meu_fluxo_de_trabalho(Channel.of(params.greeting))
+    meu_fluxo_de_trabalho.out.meus_dados.view()
 }
 ```
 
-O resultado do trecho de código acima pode ser acessado usando `meu_pipeline.out.meus_dados`.
+O resultado do trecho de código acima pode ser acessado usando `meu_fluxo_de_trabalho.out.meus_dados`.
 
-### Chamando workflows nomeados
+### Chamando fluxos de trabalho nomeados
 
-Dentro de um script `main.nf` (chamado `hello.nf` em nosso exemplo), também podemos ter vários fluxos de trabalho. Nesse caso, podemos chamar um fluxo de trabalho específico ao executar o código. Para isso, usamos a chamada de ponto de entrada `-entry <nome_do_workflow>`.
+Dentro de um script `main.nf` (chamado `hello.nf` em nosso exemplo), também podemos ter vários fluxos de trabalho. Nesse caso, podemos chamar um fluxo de trabalho específico ao executar o código. Para isso, usamos a chamada de ponto de entrada `-entry <nome_do_flux_de_trabalho>`.
 
-O trecho a seguir tem dois fluxos de trabalho nomeados (`meu_pipeline_um` e `meu_pipeline_dois`):
+O trecho a seguir tem dois fluxos de trabalho nomeados (`meu_fluxo_de_trabalho_um` e `meu_fluxo_de_trabalho_dois`):
 
 ```groovy linenums="1"
 #!/usr/bin/env nextflow
@@ -386,28 +386,28 @@ include { CONVERTTOUPPER as CONVERTTOUPPER_one } from './modules.nf'
 include { CONVERTTOUPPER as CONVERTTOUPPER_two } from './modules.nf'
 
 
-workflow meu_pipeline_um {
+workflow meu_fluxo_de_trabalho_um {
     letras_canal1 = SPLITLETTERS_one(params.greeting)
     resultados_canal1 = CONVERTTOUPPER_one(letters_ch1.flatten())
     resultados_canal1.view { it }
 }
 
-workflow meu_pipeline_dois {
+workflow meu_fluxo_de_trabalho_dois {
     letras_canal2 = SPLITLETTERS_two(params.greeting)
     resultados_canal2 = CONVERTTOUPPER_two(letters_ch2.flatten())
     resultados_canal2.view { it }
 }
 
 workflow {
-    meu_pipeline_um(Channel.of(params.greeting))
-    meu_pipeline_dois(Channel.of(params.greeting))
+    meu_fluxo_de_trabalho_um(Channel.of(params.greeting))
+    meu_fluxo_de_trabalho_dois(Channel.of(params.greeting))
 }
 ```
 
-Você pode escolher qual workflow é executado usando o sinalizador `entry`:
+Você pode escolher qual fluxo de trabalho é executado usando o sinalizador `entry`:
 
 ```bash
-nextflow run hello.2.nf -entry meu_pipeline_um
+nextflow run hello.2.nf -entry meu_fluxo_de_trabalho_um
 ```
 
 ### Escopos de parâmetros
@@ -447,7 +447,7 @@ Como destacado acima, o script imprimirá `Hola mundo!` em vez de `Hello world!`
 
 !!! info
 
-    Para evitar que sejam ignorados, os parâmetros do pipeline devem ser definidos no início do script antes de qualquer declaração de inclusão.
+    Para evitar que sejam ignorados, os parâmetros do fluxo de trabalho devem ser definidos no início do script antes de qualquer declaração de inclusão.
 
 A opção `addParams` pode ser usada para estender os parâmetros do módulo sem afetar o escopo externo. Por exemplo:
 

--- a/docs/basic_training/modules.pt.md
+++ b/docs/basic_training/modules.pt.md
@@ -6,7 +6,7 @@ description: Material de treinamento básico do Nextflow
 
 A definição de bibliotecas modulares simplifica a escrita de fluxos de trabalho complexos de análise de dados, além tornar o reuso de processos mais fácil.
 
-Ao usar o exemplo `hello.nf` da seção de introdução, nós converteremos os processos do fluxo de trabalho em módulos e, em seguida, executaremos estes processos dentro do escopo do fluxo de trabalho de diferentes formas.
+Ao usar o exemplo `hello.nf` da seção de introdução, nós converteremos os processos do fluxo de trabalho em módulos e, em seguida, executaremos estes processos dentro do escopo `workflow` de diferentes formas.
 
 ## Módulos
 
@@ -167,7 +167,7 @@ workflow  {
 
 !!! note
 
-    Nós movemos o `greeting_ch` para o escopo do `workflow` para este exercício.
+    Nós movemos o `greeting_ch` para o escopo `workflow` para este exercício.
 
 Também podemos definir explicitamente a saída de um canal para outro usando o atributo `.out`, removendo completamente as definições de canal:
 
@@ -223,7 +223,7 @@ process CONVERTTOUPPER {
 }
 ```
 
-Em seguida, altere o escopo do fluxo de trabalho em `hello.nf` para chamar essa saída nomeada específica (observe o `.upper` adicionado):
+Em seguida, altere o escopo `workflow` em `hello.nf` para chamar essa saída nomeada específica (observe o `.upper` adicionado):
 
 ```groovy linenums="1" title="hello.nf"
 workflow {
@@ -236,7 +236,7 @@ workflow {
 
 ### Usando saídas canalizadas
 
-Outra maneira de lidar com as saídas no escopo do fluxo de trabalho é usar pipes `|`.
+Outra maneira de lidar com as saídas no escopo `workflow` é usar pipes `|`.
 
 !!! exercise
 
@@ -250,7 +250,7 @@ Outra maneira de lidar com as saídas no escopo do fluxo de trabalho é usar pip
 
      Aqui usamos um [pipe](https://www.nextflow.io/docs/latest/dsl2.html#pipes) que passa a saída de um processo como um canal para o próximo processo sem a necessidade de aplicar `.out` ao nome do processo.
 
-## Definição de workflow
+## Definição do escopo workflow
 
 O escopo `workflow` permite a definição de componentes que definem a invocação de um ou mais processos ou operadores:
 
@@ -285,7 +285,7 @@ Por exemplo, o trecho acima define um `workflow` chamado `meu_fluxo_de_trabalho`
 
     Um componente de um fluxo de trabalho pode acessar qualquer variável ou parâmetro definido no escopo externo. No exemplo em execução, também podemos acessar `params.greeting` diretamente na definição de `workflow`.
 
-### Entradas de workflow
+### Entradas no escopo workflow
 
 Um componente `workflow` pode declarar um ou mais canais de entrada usando a instrução `take`. Por exemplo:
 
@@ -320,7 +320,7 @@ workflow {
 }
 ```
 
-### Saídas do workflow
+### Saídas no escopo workflow
 
 Um bloco `workflow` pode declarar um ou mais canais de saída usando a instrução `emit`. Por exemplo:
 
@@ -368,7 +368,7 @@ workflow {
 
 O resultado do trecho de código acima pode ser acessado usando `meu_fluxo_de_trabalho.out.meus_dados`.
 
-### Chamando fluxos de trabalho nomeados
+### Chamando escopos workflows nomeados
 
 Dentro de um script `main.nf` (chamado `hello.nf` em nosso exemplo), também podemos ter vários fluxos de trabalho. Nesse caso, podemos chamar um fluxo de trabalho específico ao executar o código. Para isso, usamos a chamada de ponto de entrada `-entry <nome_do_flux_de_trabalho>`.
 

--- a/docs/basic_training/processes.pt.md
+++ b/docs/basic_training/processes.pt.md
@@ -369,7 +369,7 @@ workflow {
             """
         }
 
-        workflow {
+        fluxo de trabalho {
             canal_concatenado = CONCATENE(canal_leituras.collect())
             canal_concatenado.view()
         }
@@ -507,7 +507,7 @@ Isso ocorre porque os canais de valor podem ser consumidos várias vezes e não 
             """
         }
 
-        workflow {
+        fluxo de trabalho {
             canal_concatenado = COMANDO(canal_leituras, params.arquivo_transcriptoma)
             canal_concatenado.view()
         }
@@ -573,7 +573,7 @@ No exemplo acima, toda vez que um arquivo de sequências é recebido como entrad
             """
         }
 
-        workflow {
+        fluxo de trabalho {
             canal_concatenado = COMANDO(canal_leituras, params.arquivo_transcriptoma, metodos)
             canal_concatenado
                 .view { "Para executar : ${it.text}" }
@@ -777,7 +777,7 @@ workflow {
             """
         }
 
-        workflow {
+        fluxo de trabalho {
             canal_bam = FOO(canal_leituras)
             canal_bam.view()
         }

--- a/docs/basic_training/rnaseq_pipeline.md
+++ b/docs/basic_training/rnaseq_pipeline.md
@@ -284,7 +284,7 @@ nextflow run script3.nf --reads 'data/ggal/*_{1,2}.fq'
 
 !!! exercise
 
-    Use the `checkIfExists` option for the [fromFilePairs](https://www.nextflow.io/docs/latest/channel.html#fromfilepairs) method to check if the specified path contains file pairs.
+    Use the `checkIfExists` option for the [fromFilePairs](https://www.nextflow.io/docs/latest/channel.html#fromfilepairs) channel factory to check if the specified path contains file pairs.
 
     ??? result
 

--- a/docs/basic_training/rnaseq_pipeline.md
+++ b/docs/basic_training/rnaseq_pipeline.md
@@ -2,9 +2,9 @@
 description: Basic Nextflow Training Workshop
 ---
 
-# Simple RNA-Seq pipeline
+# Simple RNA-Seq workflow
 
-To demonstrate a real-world biomedical scenario, we will implement a proof of concept RNA-Seq pipeline which:
+To demonstrate a real-world biomedical scenario, we will implement a proof of concept RNA-Seq workflow which:
 
 1. Indexes a transcriptome file
 2. Performs quality controls
@@ -13,11 +13,11 @@ To demonstrate a real-world biomedical scenario, we will implement a proof of co
 
 This will be done using a series of seven scripts, each of which builds on the previous to create a complete workflow. You can find these in the tutorial folder (`script1.nf` - `script7.nf`).
 
-## Define the pipeline parameters
+## Define the workflow parameters
 
-Parameters are inputs and options that can be changed when the pipeline is run.
+Parameters are inputs and options that can be changed when the workflow is run.
 
-The script `script1.nf` defines the pipeline input parameters.
+The script `script1.nf` defines the workflow input parameters.
 
 ```groovy
 params.reads = "$projectDir/data/ggal/gut_{1,2}.fq"
@@ -43,7 +43,7 @@ nextflow run script1.nf --reads '/workspace/gitpod/nf-training/data/ggal/lung_{1
 
 !!! exercise
 
-    Modify the `script1.nf` by adding a fourth parameter named `outdir` and set it to a default path that will be used as the pipeline output directory.
+    Modify the `script1.nf` by adding a fourth parameter named `outdir` and set it to a default path that will be used as the workflow output directory.
 
     ??? result
 
@@ -56,7 +56,7 @@ nextflow run script1.nf --reads '/workspace/gitpod/nf-training/data/ggal/lung_{1
 
 !!! exercise
 
-    Modify `script1.nf` to print all of the pipeline parameters by using a single `log.info` command as a [multiline string](https://www.nextflow.io/docs/latest/script.html#multi-line-strings) statement.
+    Modify `script1.nf` to print all of the workflow parameters by using a single `log.info` command as a [multiline string](https://www.nextflow.io/docs/latest/script.html#multi-line-strings) statement.
 
     !!! tip ""
 
@@ -82,7 +82,7 @@ nextflow run script1.nf --reads '/workspace/gitpod/nf-training/data/ggal/lung_{1
 
 In this step you have learned:
 
-1. How to define parameters in your pipeline script
+1. How to define parameters in your workflow script
 2. How to pass parameters by using the command line
 3. The use of `$var` and `${var}` variable placeholders
 4. How to use multiline strings
@@ -334,7 +334,7 @@ nextflow run script4.nf -resume --reads 'data/ggal/*_{1,2}.fq'
 
 You will notice that the `QUANTIFICATION` process is executed multiple times.
 
-Nextflow parallelizes the execution of your pipeline simply by providing multiple sets of input data to your script.
+Nextflow parallelizes the execution of your workflow simply by providing multiple sets of input data to your script.
 
 !!! tip
 
@@ -417,9 +417,9 @@ In this step you have learned:
 
 ## Handle completion event
 
-This step shows how to execute an action when the pipeline completes the execution.
+This step shows how to execute an action when the workflow completes the execution.
 
-Note that Nextflow processes define the execution of **asynchronous** tasks i.e. they are not executed one after another as if they were written in the pipeline script in a common **imperative** programming language.
+Note that Nextflow processes define the execution of **asynchronous** tasks i.e. they are not executed one after another as if they were written in the workflow script in a common **imperative** programming language.
 
 The script uses the `workflow.onComplete` event handler to print a confirmation message when the script completes.
 
@@ -452,7 +452,7 @@ See [mail documentation](https://www.nextflow.io/docs/latest/mail.html#mail-conf
 
 ## Custom scripts
 
-Real-world pipelines use a lot of custom user scripts (BASH, R, Python, etc.). Nextflow allows you to consistently use and manage these scripts. Simply put them in a directory named `bin` in the pipeline project root. They will be automatically added to the pipeline execution `PATH`.
+Real-world workflows use a lot of custom user scripts (BASH, R, Python, etc.). Nextflow allows you to consistently use and manage these scripts. Simply put them in a directory named `bin` in the workflow project root. They will be automatically added to the workflow execution `PATH`.
 
 For example, create a file named `fastqc.sh` with the following content:
 
@@ -495,14 +495,14 @@ nextflow run script7.nf -resume --reads 'data/ggal/*_{1,2}.fq'
 
 In this step you have learned:
 
-1. How to write or use existing custom scripts in your Nextflow pipeline.
+1. How to write or use existing custom scripts in your Nextflow workflow.
 2. How to avoid the use of absolute paths by having your scripts in the `bin/` folder.
 
 ## Metrics and reports
 
 Nextflow can produce multiple reports and charts providing several runtime metrics and execution information.
 
-Run the [rnaseq-nf](https://github.com/nextflow-io/rnaseq-nf) pipeline previously introduced as shown below:
+Run the [rnaseq-nf](https://github.com/nextflow-io/rnaseq-nf) workflow previously introduced as shown below:
 
 ```bash
 nextflow run rnaseq-nf -with-docker -with-report -with-trace -with-timeline -with-dag dag.png
@@ -532,7 +532,7 @@ open dag.png
 
 ## Run a project from GitHub
 
-Nextflow allows the execution of a pipeline project directly from a GitHub repository (or similar services, e.g., BitBucket and GitLab).
+Nextflow allows the execution of a workflow project directly from a GitHub repository (or similar services, e.g., BitBucket and GitLab).
 
 This simplifies the sharing and deployment of complex projects and tracking changes in a consistent manner.
 
@@ -566,5 +566,5 @@ Tags enable precise control of the changes in your project files and dependencie
 
 -   [Nextflow documentation](http://docs.nextflow.io) - The Nextflow docs home.
 -   [Nextflow patterns](https://github.com/nextflow-io/patterns) - A collection of Nextflow implementation patterns.
--   [CalliNGS-NF](https://github.com/CRG-CNAG/CalliNGS-NF) - A Variant calling pipeline implementing GATK best practices.
--   [nf-core](http://nf-co.re/) - A community collection of production ready genomic pipelines.
+-   [CalliNGS-NF](https://github.com/CRG-CNAG/CalliNGS-NF) - A Variant calling workflow implementing GATK best practices.
+-   [nf-core](http://nf-co.re/) - A community collection of production ready genomic workflows.

--- a/docs/basic_training/rnaseq_pipeline.pt.md
+++ b/docs/basic_training/rnaseq_pipeline.pt.md
@@ -284,7 +284,7 @@ nextflow run script3.nf --reads 'data/ggal/*_{1,2}.fq'
 
 !!! exercise
 
-    Use a opção `checkIfExists` para o método [fromFilePairs](https://www.nextflow.io/docs/latest/channel.html#fromfilepairs) para checar se o caminho especificado contém os pares de arquivos.
+    Use a opção `checkIfExists` para a fábrica de canal [fromFilePairs](https://www.nextflow.io/docs/latest/channel.html#fromfilepairs) para checar se o caminho especificado contém os pares de arquivos.
 
     ??? result
 

--- a/docs/basic_training/rnaseq_pipeline.pt.md
+++ b/docs/basic_training/rnaseq_pipeline.pt.md
@@ -2,9 +2,9 @@
 description: Material de treinamento básico do Nextflow
 ---
 
-# Pipeline simples de RNA-Seq
+# Fluxo de trabalho simples de RNA-Seq
 
-Para demonstrar um cenário biomédico da vida real, nós iremos implementar uma prova de conceito de pipeline RNA-Seq que:
+Para demonstrar um cenário biomédico da vida real, nós iremos implementar uma prova de conceito de fluxo de trabalho RNA-Seq que:
 
 1. Cria arquivo de índice de transcriptoma
 2. Realiza controles de qualidade
@@ -13,11 +13,11 @@ Para demonstrar um cenário biomédico da vida real, nós iremos implementar uma
 
 Isso será feito usando uma série de sete scripts, cada um se baseando no script anterior, para criar um fluxo de trabalho completo. Você poderá encontrá-los no diretório do tutorial (`script1.nf` - `script7.nf`).
 
-## Defina os parâmetros do pipeline
+## Defina os parâmetros do fluxo de trabalho
 
-Parâmetros são entradas e opções que podem ser modificadas quando um pipeline é executado.
+Parâmetros são entradas e opções que podem ser modificadas quando um fluxo de trabalho é executado.
 
-O script `script1.nf` define os parâmetros de entrada do pipeline.
+O script `script1.nf` define os parâmetros de entrada do fluxo de trabalho.
 
 ```groovy
 params.reads = "$projectDir/data/ggal/gut_{1,2}.fq"
@@ -43,7 +43,7 @@ nextflow run script1.nf --reads '/workspace/gitpod/nf-training/data/ggal/lung_{1
 
 !!! exercise
 
-    Modifique o `script1.nf` ao adicionar um quarto parâmetro chamado `outdir` e defina-o como um caminho padrão que será usado como o diretório de saída do pipeline.
+    Modifique o `script1.nf` ao adicionar um quarto parâmetro chamado `outdir` e defina-o como um caminho padrão que será usado como o diretório de saída do fluxo de trabalho.
 
     ??? result
 
@@ -56,7 +56,7 @@ nextflow run script1.nf --reads '/workspace/gitpod/nf-training/data/ggal/lung_{1
 
 !!! exercise
 
-    Modifique o `script1.nf` para imprimir todos os parâmetros do pipeline usando um único comando`log.info` como uma declaração de [string multilinha](https://www.nextflow.io/docs/latest/script.html#multi-line-strings).
+    Modifique o `script1.nf` para imprimir todos os parâmetros do fluxo de trabalho usando um único comando`log.info` como uma declaração de [string multilinha](https://www.nextflow.io/docs/latest/script.html#multi-line-strings).
 
     !!! tip ""
 
@@ -82,7 +82,7 @@ nextflow run script1.nf --reads '/workspace/gitpod/nf-training/data/ggal/lung_{1
 
 Nesta etapa você aprendeu:
 
-1. Como definir parâmetros em seu script de pipeline
+1. Como definir parâmetros em seu script de fluxo de trabalho
 2. Como atribuir parâmetros usando a linha de comando
 3. O uso de `$var` e `${var}` como espaço reservado para variáveis
 4. Como usar strings multilinhas
@@ -308,7 +308,7 @@ Nessa etapa você aprendeu:
 
 ## Realize a quantificação da expressão
 
-O script `script4.nf` adiciona um processo de quantificação de expressão gênica (`QUANTIFICATION`) e uma chamada para esse processo dentro do escopo workflow. A quantificação requer o arquivo de índice de transcriptoma e os arquivos fastq do par de leitura de RNA-Seq.
+O script `script4.nf` adiciona um processo de quantificação de expressão gênica (`QUANTIFICATION`) e uma chamada para esse processo dentro do escopo fluxo de trabalho. A quantificação requer o arquivo de índice de transcriptoma e os arquivos fastq do par de leitura de RNA-Seq.
 
 No escopo do fluxo de trabalho, observe como o canal `index_ch` é designado como saída do processo `INDEX`.
 
@@ -334,7 +334,7 @@ nextflow run script4.nf -resume --reads 'data/ggal/*_{1,2}.fq'
 
 Você irá perceber que o processo `QUANTIFICATION` é executado múltiplas vezes.
 
-O Nextflow paraleliza a execução de seu pipeline simplesmente fornecendo vários conjuntos de dados de entrada para seu script.
+O Nextflow paraleliza a execução de seu fluxo de trabalho simplesmente fornecendo vários conjuntos de dados de entrada para seu script.
 
 !!! tip
 
@@ -417,9 +417,9 @@ Nessa etapa você aprendeu:
 
 ## Lide com evento de conclusão
 
-Essa etapa mostra como executar uma ação quando o pipeline completa a execução.
+Essa etapa mostra como executar uma ação quando o fluxo de trabalho completa a execução.
 
-Observe que processos do Nextflow definem a execução de tarefas assíncronas, ou seja, elas não são executadas uma após a outra como se elas fossem escritas no script do pipeline em uma linguagem de programação **imperativa** comum.
+Observe que processos do Nextflow definem a execução de tarefas assíncronas, ou seja, elas não são executadas uma após a outra como se elas fossem escritas no script do fluxo de trabalho em uma linguagem de programação **imperativa** comum.
 
 O script usa o manipulador de evento `workflow.onComplete` para imprimir uma mensagem de confirmação quando o script for concluído.
 
@@ -452,7 +452,7 @@ Veja a [documentação de email](https://www.nextflow.io/docs/latest/mail.html#m
 
 ## Scripts personalizados
 
-Os pipelines do mundo real usam muitos scripts de usuário personalizados (BASH, R, Python, etc.). O Nextflow permite que você use e gerencie consistentemente esses scripts. Simplesmente os coloque em um diretório chamado `bin` na raiz do projeto do pipeline. Eles serão automaticamente adicionados para o `PATH` da execução do pipeline.
+Os fluxos de trabalho do mundo real usam muitos scripts de usuário personalizados (BASH, R, Python, etc.). O Nextflow permite que você use e gerencie consistentemente esses scripts. Simplesmente os coloque em um diretório chamado `bin` na raiz do projeto do fluxo de trabalho. Eles serão automaticamente adicionados para o `PATH` da execução do fluxo de trabalho.
 
 Por exemplo, crie um arquivo chamado de `fastqc.sh` com o conteúdo a seguir:
 
@@ -495,14 +495,14 @@ nextflow run script7.nf -resume --reads 'data/ggal/*_{1,2}.fq'
 
 Nessa etapa você aprendeu:
 
-1. Como escrever ou usar scripts personalizados existentes em seu pipeline do Nextflow.
+1. Como escrever ou usar scripts personalizados existentes em seu fluxo de trabalho do Nextflow.
 2. Como evitar o uso de caminhos absolutos tendo seus scripts na pasta `bin/`.
 
 ## Métricas e relatórios
 
 O Nextflow pode produzir vários relatórios e gráficos fornecendo várias métricas de tempo de execução e informações de execução.
 
-Execute o pipeline [rnaseq-nf](https://github.com/nextflow-io/rnaseq-nf) introduzido anteriormente, conforme mostrado abaixo:
+Execute o fluxo de trabalho [rnaseq-nf](https://github.com/nextflow-io/rnaseq-nf) introduzido anteriormente, conforme mostrado abaixo:
 
 ```bash
 nextflow run rnaseq-nf -with-docker -with-report -with-trace -with-timeline -with-dag dag.png
@@ -532,7 +532,7 @@ open dag.png
 
 ## Execute um projeto do GitHub
 
-O Nextflow permite a execução de um projeto de pipeline diretamente de um repositório do GitHub (ou serviços semelhantes, por exemplo, BitBucket e GitLab).
+O Nextflow permite a execução de um projeto de fluxo de trabalho diretamente de um repositório do GitHub (ou serviços semelhantes, por exemplo, BitBucket e GitLab).
 
 Isso simplifica o compartilhamento e implantação de projetos complexos e o rastreamento de mudanças de uma maneira consistente.
 
@@ -566,5 +566,5 @@ As etiquetas permitem o controle preciso das alterações nos arquivos e depend�
 
 -   [Documentação do Nextflow](http://docs.nextflow.io) - A página inicial dos documentos do Nextflow.
 -   [Nextflow patterns](https://github.com/nextflow-io/patterns) - Uma coleção de padrões de implementação do Nextflow.
--   [CalliNGS-NF](https://github.com/CRG-CNAG/CalliNGS-NF) - Um pipeline de chamada de variante implementando as melhores práticas recomendadas do GATK.
--   [nf-core](http://nf-co.re/) - Uma coleção comunitária de pipelines genômicos prontos para produção.
+-   [CalliNGS-NF](https://github.com/CRG-CNAG/CalliNGS-NF) - Um fluxo de trabalho de chamada de variante implementando as melhores práticas recomendadas do GATK.
+-   [nf-core](http://nf-co.re/) - Uma coleção comunitária de fluxos de trabalho genômicos prontos para produção.

--- a/docs/basic_training/rnaseq_pipeline.pt.md
+++ b/docs/basic_training/rnaseq_pipeline.pt.md
@@ -115,7 +115,7 @@ process INDEX {
 }
 ```
 
-Além disso, adicione um escopo de fluxo de trabalho contendo uma definição de canal de entrada e o processo de índice:
+Além disso, adicione um escopo `workflow` contendo uma definição de canal de entrada e o processo de índice:
 
 ```groovy
 workflow {
@@ -167,7 +167,7 @@ docker.enabled = true
 
     ??? result
 
-        Adicione o código a seguir ao final do bloco de fluxo de trabalho em seu arquivo de script
+        Adicione o código a seguir ao final do bloco `workflow` em seu arquivo de script
 
         ```groovy
         index_ch.view()
@@ -304,13 +304,13 @@ Nessa etapa você aprendeu:
 
 !!! info
 
-    A declaração de um canal pode ser feita antes do escopo do fluxo de trabalho ou dentro dele. Desde que a declaração esteja acima do processo que requer o canal específico.
+    A declaração de um canal pode ser feita antes do escopo `workflow` ou dentro dele. Desde que a declaração esteja acima do processo que requer o canal específico.
 
 ## Realize a quantificação da expressão
 
-O script `script4.nf` adiciona um processo de quantificação de expressão gênica (`QUANTIFICATION`) e uma chamada para esse processo dentro do escopo fluxo de trabalho. A quantificação requer o arquivo de índice de transcriptoma e os arquivos fastq do par de leitura de RNA-Seq.
+O script `script4.nf` adiciona um processo de quantificação de expressão gênica (`QUANTIFICATION`) e uma chamada para esse processo dentro do escopo `workflow`. A quantificação requer o arquivo de índice de transcriptoma e os arquivos fastq do par de leitura de RNA-Seq.
 
-No escopo do fluxo de trabalho, observe como o canal `index_ch` é designado como saída do processo `INDEX`.
+No escopo `workflow`, observe como o canal `index_ch` é designado como saída do processo `INDEX`.
 
 A seguir, note que o primeiro canal de entrada para o processo de `QUANTIFICATION` é o `index_ch` declarado previamente, que contém o caminho para o arquivo `salmon_index`.
 

--- a/docs/basic_training/tower.md
+++ b/docs/basic_training/tower.md
@@ -157,7 +157,7 @@ In brief, these are the steps you need to follow to set up a pipeline.
 
 1. Select the Launchpad button in the navigation bar. This will open the **Launch Form**.
 2. Select a [compute environment](https://help.tower.nf/compute-envs/overview).
-3. Enter the repository of the pipeline you want to launch. e.g. <https://github.com/nf-core/rnaseq.git>
+3. Enter the repository of the workflow you want to launch. e.g. <https://github.com/nf-core/rnaseq.git>
 4. Select a workflow **Revision number**. The Git default branch (main/master) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
 5. Set the **Work directory** location of the Nextflow work directory. The location associated with the compute environment will be selected by default.
 6. Enter the name(s) of each of the Nextflow **Config profiles** followed by the `Enter` key. See the Nextflow [Config profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) documentation for more details.

--- a/docs/basic_training/tower.md
+++ b/docs/basic_training/tower.md
@@ -7,13 +7,13 @@ description: Get started with Nextflow Tower
 
 ## Basic concepts
 
-Nextflow Tower is the centralized command post for data management and pipelines. It brings monitoring, logging and observability to distributed workflows and simplifies the deployment of pipelines on any cloud, cluster or laptop.
+Nextflow Tower is the centralized command post for data management and workflows. It brings monitoring, logging and observability to distributed workflows and simplifies the deployment of workflows on any cloud, cluster or laptop.
 
 Nextflow tower core features include:
 
--   The launching of pre-configured pipelines with ease.
+-   The launching of pre-configured workflows with ease.
 -   Programmatic integration to meet the needs of an organization.
--   Publishing pipelines to shared workspaces.
+-   Publishing workflows to shared workspaces.
 -   Management of the infrastructure required to run data analysis at scale.
 
 !!! tip
@@ -58,7 +58,7 @@ Where `eyxxxxxxxxxxxxxxxQ1ZTE=` is the token you have just created.
 
     Check your `nextflow -version`. Bearer tokens require Nextflow version 20.10.0 or later and can be set with the second command shown above. You can change the version if necessary.
 
-To submit a pipeline to a [Workspace](https://help.tower.nf/getting-started/workspace/) using the Nextflow command-line tool, add the workspace ID to your environment. For example:
+To submit a workflow to a [Workspace](https://help.tower.nf/getting-started/workspace/) using the Nextflow command-line tool, add the workspace ID to your environment. For example:
 
 ```bash
 export TOWER_WORKSPACE_ID=000000000000000
@@ -92,13 +92,13 @@ To run using the GUI, there are three main steps:
 
 1. Create an account and login into Tower, available free of charge, at [tower.nf](https://tower.nf).
 2. Create and configure a new [compute environment](https://help.tower.nf/compute-envs/overview/).
-3. Start [launching pipelines](https://help.tower.nf/launch/launchpad/).
+3. Start [launching workflows](https://help.tower.nf/launch/launchpad/).
 
 #### Configuring your compute environment
 
-Tower uses the concept of **Compute Environments** to define the execution platform where a pipeline will run.
+Tower uses the concept of **Compute Environments** to define the execution platform where a workflow will run.
 
-It supports the launching of pipelines into a growing number of **cloud** and **on-premise** infrastructures.
+It supports the launching of workflows into a growing number of **cloud** and **on-premise** infrastructures.
 
 ![Compute environments](img/compute_env_platforms.png)
 
@@ -120,22 +120,22 @@ Each compute environment must be pre-configured to enable Tower to submit tasks.
 
 #### Selecting a default compute environment
 
-If you have more than one **Compute Environment**, you can select which one will be used by default when launching a pipeline.
+If you have more than one **Compute Environment**, you can select which one will be used by default when launching a workflow.
 
 1. Navigate to your [compute environments](https://help.tower.nf/compute-envs/overview/).
 2. Choose your default environment by selecting the **Make primary** button.
 
 **Congratulations!**
 
-You are now ready to launch pipelines with your primary compute environment.
+You are now ready to launch workflows with your primary compute environment.
 
 #### Launchpad
 
-Launchpad makes it easy for any workspace user to launch a pre-configured pipeline.
+Launchpad makes it easy for any workspace user to launch a pre-configured workflow.
 
 ![Launchpad](img/overview_launch.png)
 
-A pipeline is a repository containing a Nextflow workflow, a compute environment and pipeline parameters.
+A workflow is a repository containing a Nextflow workflow, a compute environment and workflow parameters.
 
 #### Pipeline Parameters Form
 
@@ -143,36 +143,36 @@ Launchpad automatically detects the presence of a `nextflow_schema.json` in the 
 
 !!! info
 
-    The parameter forms view will appear if the workflow has a Nextflow schema file for the parameters. Please refer to the [Nextflow Schema guide](https://help.tower.nf/pipeline-schema/overview) to learn more about the schema file use-cases and how to create them.
+    The parameter forms view will appear if the workflow has a Nextflow schema file for the parameters. Please refer to the [Nextflow Schema guide](https://help.tower.nf/workflow-schema/overview) to learn more about the schema file use-cases and how to create them.
 
-This makes it trivial for users without any expertise in Nextflow to enter their pipeline parameters and launch.
+This makes it trivial for users without any expertise in Nextflow to enter their workflow parameters and launch.
 
 ![Pipeline parameters](img/launch_rnaseq_nextflow_schema.png)
 
-#### Adding a new pipeline
+#### Adding a new workflow
 
-Adding a pipeline to the pre-saved workspace launchpad is detailed in full on the [tower webpage docs](https://help.tower.nf/launch/launch/).
+Adding a workflow to the pre-saved workspace launchpad is detailed in full on the [tower webpage docs](https://help.tower.nf/launch/launch/).
 
-In brief, these are the steps you need to follow to set up a pipeline.
+In brief, these are the steps you need to follow to set up a workflow.
 
 1. Select the Launchpad button in the navigation bar. This will open the **Launch Form**.
 2. Select a [compute environment](https://help.tower.nf/compute-envs/overview).
-3. Enter the repository of the pipeline you want to launch. e.g. <https://github.com/nf-core/rnaseq.git>
-4. Select a pipeline **Revision number**. The Git default branch (main/master) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
+3. Enter the repository of the workflow you want to launch. e.g. <https://github.com/nf-core/rnaseq.git>
+4. Select a workflow **Revision number**. The Git default branch (main/master) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
 5. Set the **Work directory** location of the Nextflow work directory. The location associated with the compute environment will be selected by default.
 6. Enter the name(s) of each of the Nextflow **Config profiles** followed by the `Enter` key. See the Nextflow [Config profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) documentation for more details.
-7. Enter any pipeline parameters in YAML or JSON format. YAML example:
+7. Enter any workflow parameters in YAML or JSON format. YAML example:
 
     ```yaml
     reads: "s3://nf-bucket/exome-data/ERR013140_{1,2}.fastq.bz2"
     paired_end: true
     ```
 
-8. Select Launch to begin the pipeline execution.
+8. Select Launch to begin the workflow execution.
 
 !!! info
 
-    Nextflow pipelines are simply Git repositories and can be changed to any public or private Git-hosting platform. See [Git Integration](https://help.tower.nf/git/overview/) in the Tower docs and [Pipeline Sharing](https://www.nextflow.io/docs/latest/sharing.html) in the Nextflow docs for more details.
+    Nextflow workflows are simply Git repositories and can be changed to any public or private Git-hosting platform. See [Git Integration](https://help.tower.nf/git/overview/) in the Tower docs and [Pipeline Sharing](https://www.nextflow.io/docs/latest/sharing.html) in the Nextflow docs for more details.
 
 !!! note
 
@@ -184,7 +184,7 @@ In brief, these are the steps you need to follow to set up a pipeline.
 
 !!! tip
 
-    To create your own customized Nextflow Schema for your pipeline, see the examples from the `nf-core` workflows that have adopted this approach. For example, [eager](https://github.com/nf-core/eager/blob/2.3.3/nextflow_schema.json) and [rnaseq](https://github.com/nf-core/rnaseq/blob/3.0/nextflow_schema.json).
+    To create your own customized Nextflow Schema for your workflow, see the examples from the `nf-core` workflows that have adopted this approach. For example, [eager](https://github.com/nf-core/eager/blob/2.3.3/nextflow_schema.json) and [rnaseq](https://github.com/nf-core/rnaseq/blob/3.0/nextflow_schema.json).
 
 For advanced settings options check out this [page](https://help.tower.nf/launch/advanced/).
 

--- a/docs/basic_training/tower.md
+++ b/docs/basic_training/tower.md
@@ -7,13 +7,13 @@ description: Get started with Nextflow Tower
 
 ## Basic concepts
 
-Nextflow Tower is the centralized command post for data management and workflows. It brings monitoring, logging and observability to distributed workflows and simplifies the deployment of workflows on any cloud, cluster or laptop.
+Nextflow Tower is the centralized command post for data management and workflows. It brings monitoring, logging and observability to distributed workflows and simplifies the deployment of workflows on any cloud, cluster or laptop. In Tower terminology, a workflow is what we've been working on so far, and pipelines are pre-configured workflows that can be used by all users in a workspace. It is composed of a workflow repository, launch parameters, and a compute environment. We'll stick to these definitions in this section.
 
 Nextflow tower core features include:
 
--   The launching of pre-configured workflows with ease.
+-   The launching of pre-configured pipelines with ease.
 -   Programmatic integration to meet the needs of an organization.
--   Publishing workflows to shared workspaces.
+-   Publishing pipelines to shared workspaces.
 -   Management of the infrastructure required to run data analysis at scale.
 
 !!! tip
@@ -58,7 +58,7 @@ Where `eyxxxxxxxxxxxxxxxQ1ZTE=` is the token you have just created.
 
     Check your `nextflow -version`. Bearer tokens require Nextflow version 20.10.0 or later and can be set with the second command shown above. You can change the version if necessary.
 
-To submit a workflow to a [Workspace](https://help.tower.nf/getting-started/workspace/) using the Nextflow command-line tool, add the workspace ID to your environment. For example:
+To submit a pipeline to a [Workspace](https://help.tower.nf/getting-started/workspace/) using the Nextflow command-line tool, add the workspace ID to your environment. For example:
 
 ```bash
 export TOWER_WORKSPACE_ID=000000000000000
@@ -92,7 +92,7 @@ To run using the GUI, there are three main steps:
 
 1. Create an account and login into Tower, available free of charge, at [tower.nf](https://tower.nf).
 2. Create and configure a new [compute environment](https://help.tower.nf/compute-envs/overview/).
-3. Start [launching workflows](https://help.tower.nf/launch/launchpad/).
+3. Start [launching pipelines](https://help.tower.nf/launch/launchpad/).
 
 #### Configuring your compute environment
 
@@ -120,7 +120,7 @@ Each compute environment must be pre-configured to enable Tower to submit tasks.
 
 #### Selecting a default compute environment
 
-If you have more than one **Compute Environment**, you can select which one will be used by default when launching a workflow.
+If you have more than one **Compute Environment**, you can select which one will be used by default when launching a pipeline.
 
 1. Navigate to your [compute environments](https://help.tower.nf/compute-envs/overview/).
 2. Choose your default environment by selecting the **Make primary** button.
@@ -131,11 +131,11 @@ You are now ready to launch workflows with your primary compute environment.
 
 #### Launchpad
 
-Launchpad makes it easy for any workspace user to launch a pre-configured workflow.
+Launchpad makes it easy for any workspace user to launch a pre-configured pipeline.
 
 ![Launchpad](img/overview_launch.png)
 
-A workflow is a repository containing a Nextflow workflow, a compute environment and workflow parameters.
+A pipeline is a repository containing a Nextflow workflow, a compute environment and workflow parameters.
 
 #### Pipeline Parameters Form
 
@@ -143,21 +143,21 @@ Launchpad automatically detects the presence of a `nextflow_schema.json` in the 
 
 !!! info
 
-    The parameter forms view will appear if the workflow has a Nextflow schema file for the parameters. Please refer to the [Nextflow Schema guide](https://help.tower.nf/workflow-schema/overview) to learn more about the schema file use-cases and how to create them.
+    The parameter forms view will appear if the pipeline has a Nextflow schema file for the parameters. Please refer to the [Nextflow Schema guide](https://help.tower.nf/workflow-schema/overview) to learn more about the schema file use-cases and how to create them.
 
 This makes it trivial for users without any expertise in Nextflow to enter their workflow parameters and launch.
 
 ![Pipeline parameters](img/launch_rnaseq_nextflow_schema.png)
 
-#### Adding a new workflow
+#### Adding a new pipeline
 
-Adding a workflow to the pre-saved workspace launchpad is detailed in full on the [tower webpage docs](https://help.tower.nf/launch/launch/).
+Adding a pipeline to the pre-saved workspace launchpad is detailed in full on the [tower webpage docs](https://help.tower.nf/launch/launch/).
 
-In brief, these are the steps you need to follow to set up a workflow.
+In brief, these are the steps you need to follow to set up a pipeline.
 
 1. Select the Launchpad button in the navigation bar. This will open the **Launch Form**.
 2. Select a [compute environment](https://help.tower.nf/compute-envs/overview).
-3. Enter the repository of the workflow you want to launch. e.g. <https://github.com/nf-core/rnaseq.git>
+3. Enter the repository of the pipeline you want to launch. e.g. <https://github.com/nf-core/rnaseq.git>
 4. Select a workflow **Revision number**. The Git default branch (main/master) or `manifest.defaultBranch` in the Nextflow configuration will be used by default.
 5. Set the **Work directory** location of the Nextflow work directory. The location associated with the compute environment will be selected by default.
 6. Enter the name(s) of each of the Nextflow **Config profiles** followed by the `Enter` key. See the Nextflow [Config profiles](https://www.nextflow.io/docs/latest/config.html#config-profiles) documentation for more details.
@@ -168,7 +168,7 @@ In brief, these are the steps you need to follow to set up a workflow.
     paired_end: true
     ```
 
-8. Select Launch to begin the workflow execution.
+8. Select Launch to begin the pipeline execution.
 
 !!! info
 
@@ -196,7 +196,7 @@ To learn more about using the Tower API, visit the [API section](https://help.to
 
 ## Workspaces and Organizations
 
-Nextflow Tower simplifies the development and execution of workflows by providing a centralized interface for users and organizations.
+Nextflow Tower simplifies the development and execution of pipeline by providing a centralized interface for users and organizations.
 
 Each user has a unique **workspace** where they can interact and manage all resources such as workflows, compute environments and credentials. Details of this can be found [here](https://help.tower.nf/getting-started/workspace/).
 

--- a/docs/basic_training/tower.pt.md
+++ b/docs/basic_training/tower.pt.md
@@ -7,13 +7,13 @@ description: Comece a usar o Nextflow Tower
 
 ## Conceitos Básicos
 
-O Nextflow Tower é o posto de comando centralizado para gerenciamento de dados e fluxos de trabalho. Ele traz monitoramento, gerenciamento de logs e observabilidade para fluxos de trabalho distribuídos e simplifica a implantação de fluxos de trabalho em qualquer nuvem, cluster ou laptop.
+O Nextflow Tower é o posto de comando centralizado para gerenciamento de dados e fluxos de trabalho. Ele traz monitoramento, gerenciamento de logs e observabilidade para fluxos de trabalho distribuídos e simplifica a implantação de fluxos de trabalho em qualquer nuvem, cluster ou laptop. Na terminologia do Tower, um fluxo de trabalho é o que temos trabalhado até agora, e os pipelines são fluxos de trabalho pré-configurados que podem ser usados por todos os usuários em um espaço de trabalho. Ele é composto por um repositório de fluxo de trabalho, parâmetros de inicialização e um ambiente de computação. Vamos nos ater a essas definições nesta seção.
 
 Os principais recursos do Nextflow Tower incluem:
 
--   O lançamento de fluxos de trabalho pré-configurados com facilidade.
+-   O lançamento de pipelines pré-configurados com facilidade.
 -   Integração programática para atender às necessidades de uma organização.
--   Disponibilização de fluxos de trabalho em áreas de trabalho compartilhadas.
+-   Disponibilização pipelines em áreas de trabalho compartilhadas.
 -   Gerenciamento da infraestrutura necessária para executar análise de dados em escala.
 
 !!! tip
@@ -58,7 +58,7 @@ Onde `eyxxxxxxxxxxxxxxxQ1ZTE=` é o token que você acabou de criar.
 
     Verifique seu `nextflow -version`. Os tokens de portador requerem ao menos a versão 20.10.0 do Nextflow ou versões posteriores e isso pode ser configurado com o segundo comando mostrado acima. Você pode alterar para uma outra versão, se necessário.
 
-Para enviar um fluxo de trabalho para uma [área de trabalho](https://help.tower.nf/getting-started/workspace/) (workspace) usando a ferramenta de linha de comando do Nextflow, adicione o ID da área de trabalho em seu ambiente. Por exemplo:
+Para enviar um pipeline para uma [área de trabalho](https://help.tower.nf/getting-started/workspace/) (workspace) usando a ferramenta de linha de comando do Nextflow, adicione o ID da área de trabalho em seu ambiente. Por exemplo:
 
 ```bash
 export TOWER_WORKSPACE_ID=000000000000000
@@ -92,7 +92,7 @@ Para executar usando a interface gráfica (GUI), existem três etapas principais
 
 1. Crie uma conta e faça login no Tower, disponível gratuitamente, em [tower.nf](https://tower.nf).
 2. Crie e configure um novo [ambiente de computação](https://help.tower.nf/compute-envs/overview/) (compute environment).
-3. Comece a [lançar fluxos de trabalho](https://help.tower.nf/launch/launchpad/).
+3. Comece a [lançar pipelines](https://help.tower.nf/launch/launchpad/).
 
 #### Configurando seu ambiente de computação
 
@@ -121,7 +121,7 @@ Cada ambiente de computação deve ser pré-configurado para permitir que o Towe
 
 #### Selecionando um ambiente de computação padrão
 
-Se você tiver mais de um **Ambiente de computação**, poderá selecionar qual deles será usado por padrão ao lançar um fluxo de trabalho.
+Se você tiver mais de um **Ambiente de computação**, poderá selecionar qual deles será usado por padrão ao lançar um pipeline.
 
 1. Navegue até os seus [ambientes de computação](https://help.tower.nf/compute-envs/overview/).
 2. Escolha seu ambiente padrão selecionando o botão **Make primary**.
@@ -132,11 +132,11 @@ Agora você está pronto para lançar fluxos de trabalho com seu ambiente de com
 
 #### Launchpad
 
-O Launchpad torna fácil para qualquer usuário da área de trabalho lançar um fluxo de trabalho pré-configurado.
+O Launchpad torna fácil para qualquer usuário da área de trabalho lançar um pipeline pré-configurado.
 
 ![Launchpad](img/overview_launch.png)
 
-Um fluxo de trabalho é um repositório que contém um fluxo de trabalho do Nextflow, um ambiente de computação e parâmetros de fluxo de trabalho.
+Um pipeline é um repositório que contém um fluxo de trabalho do Nextflow, um ambiente de computação e parâmetros de fluxo de trabalho.
 
 #### Formulário de Parâmetros de Pipeline
 
@@ -144,17 +144,17 @@ O Launchpad detecta automaticamente a presença de um `nextflow_schema.json` na 
 
 !!! info
 
-    A exibição de formulários de parâmetro aparecerá se o fluxo de trabalho tiver um arquivo de esquema do Nextflow para os parâmetros. Consulte o [Guia do esquema do Nextflow](https://help.tower.nf/workflow-schema/overview) para saber mais sobre os casos de uso do arquivo de esquema e como criá-los.
+    A exibição de formulários de parâmetro aparecerá se o pipeline tiver um arquivo de esquema do Nextflow para os parâmetros. Consulte o [Guia do esquema do Nextflow](https://help.tower.nf/workflow-schema/overview) para saber mais sobre os casos de uso do arquivo de esquema e como criá-los.
 
 Isso torna trivial para usuários sem experiência em Nextflow inserir seus parâmetros de fluxo de trabalho e lançá-lo.
 
 ![Pipeline parameters](img/launch_rnaseq_nextflow_schema.png)
 
-#### Adicionando um novo fluxo de trabalho
+#### Adicionando um novo pipeline
 
-A adição de um fluxo de trabalho pré-salvo ao launchpad da área de trabalho é detalhada na íntegra na [documentação do Tower](https://help.tower.nf/launch/launch/).
+A adição de um pipeline ao launchpad da área de trabalho é detalhada na íntegra na [documentação do Tower](https://help.tower.nf/launch/launch/).
 
-Em resumo, essas são as etapas que você precisa seguir para configurar um fluxo de trabalho.
+Em resumo, essas são as etapas que você precisa seguir para configurar um pipeline.
 
 1. Selecione o botão Launchpad na barra de navegação. Isso abrirá o **Formulário de inicialização**.
 2. Selecione um [ambiente de computação](https://help.tower.nf/compute-envs/overview).
@@ -169,7 +169,7 @@ Em resumo, essas são as etapas que você precisa seguir para configurar um flux
     pares_de_leituras: true
     ```
 
-8. Selecione Launch para iniciar a execução do fluxo de trabalho.
+8. Selecione Launch para iniciar a execução do pipeline.
 
 !!! info
 
@@ -197,7 +197,7 @@ Para saber mais sobre como usar a API do Tower, visite a [seção da API](https:
 
 ## Áreas de trabalho e Organizações
 
-O Nextflow Tower simplifica o desenvolvimento e a execução de fluxos de trabalho, fornecendo uma interface centralizada para usuários e organizações.
+O Nextflow Tower simplifica o desenvolvimento e a execução de pipelines, fornecendo uma interface centralizada para usuários e organizações.
 
 Cada usuário tem uma **área de trabalho** exclusiva onde pode interagir e gerenciar todos os recursos, como fluxos de trabalho, ambientes de computação e credenciais. Detalhes disso podem ser encontrados [aqui](https://help.tower.nf/getting-started/workspace/).
 

--- a/docs/basic_training/tower.pt.md
+++ b/docs/basic_training/tower.pt.md
@@ -7,13 +7,13 @@ description: Comece a usar o Nextflow Tower
 
 ## Conceitos Básicos
 
-O Nextflow Tower é o posto de comando centralizado para gerenciamento de dados e pipelines. Ele traz monitoramento, gerenciamento de logs e observabilidade para fluxos de trabalho distribuídos e simplifica a implantação de pipelines em qualquer nuvem, cluster ou laptop.
+O Nextflow Tower é o posto de comando centralizado para gerenciamento de dados e fluxos de trabalho. Ele traz monitoramento, gerenciamento de logs e observabilidade para fluxos de trabalho distribuídos e simplifica a implantação de fluxos de trabalho em qualquer nuvem, cluster ou laptop.
 
 Os principais recursos do Nextflow Tower incluem:
 
--   O lançamento de pipelines pré-configurados com facilidade.
+-   O lançamento de fluxos de trabalho pré-configurados com facilidade.
 -   Integração programática para atender às necessidades de uma organização.
--   Disponibilização de pipelines em áreas de trabalho compartilhadas.
+-   Disponibilização de fluxos de trabalho em áreas de trabalho compartilhadas.
 -   Gerenciamento da infraestrutura necessária para executar análise de dados em escala.
 
 !!! tip
@@ -58,7 +58,7 @@ Onde `eyxxxxxxxxxxxxxxxQ1ZTE=` é o token que você acabou de criar.
 
     Verifique seu `nextflow -version`. Os tokens de portador requerem ao menos a versão 20.10.0 do Nextflow ou versões posteriores e isso pode ser configurado com o segundo comando mostrado acima. Você pode alterar para uma outra versão, se necessário.
 
-Para enviar um pipeline para uma [área de trabalho](https://help.tower.nf/getting-started/workspace/) (workspace) usando a ferramenta de linha de comando do Nextflow, adicione o ID da área de trabalho em seu ambiente. Por exemplo:
+Para enviar um fluxo de trabalho para uma [área de trabalho](https://help.tower.nf/getting-started/workspace/) (workspace) usando a ferramenta de linha de comando do Nextflow, adicione o ID da área de trabalho em seu ambiente. Por exemplo:
 
 ```bash
 export TOWER_WORKSPACE_ID=000000000000000
@@ -92,13 +92,13 @@ Para executar usando a interface gráfica (GUI), existem três etapas principais
 
 1. Crie uma conta e faça login no Tower, disponível gratuitamente, em [tower.nf](https://tower.nf).
 2. Crie e configure um novo [ambiente de computação](https://help.tower.nf/compute-envs/overview/) (compute environment).
-3. Comece a [lançar pipelines](https://help.tower.nf/launch/launchpad/).
+3. Comece a [lançar fluxos de trabalho](https://help.tower.nf/launch/launchpad/).
 
 #### Configurando seu ambiente de computação
 
-O Tower usa o conceito de **Ambientes de Computação** (compute environments) para definir a plataforma de execução onde um pipeline será executado.
+O Tower usa o conceito de **Ambientes de Computação** (compute environments) para definir a plataforma de execução onde um fluxo de trabalho será executado.
 
-Ele suporta o lançamento de pipelines em um número crescente de infraestruturas de **nuvem** e **on-prem** (infraestrutura dedicada).
+Ele suporta o lançamento de fluxos de trabalho em um número crescente de infraestruturas de **nuvem** e **on-prem** (infraestrutura dedicada).
 
 ![Ambientes de computação](img/compute_env_platforms.png)
 
@@ -121,22 +121,22 @@ Cada ambiente de computação deve ser pré-configurado para permitir que o Towe
 
 #### Selecionando um ambiente de computação padrão
 
-Se você tiver mais de um **Ambiente de computação**, poderá selecionar qual deles será usado por padrão ao lançar um pipeline.
+Se você tiver mais de um **Ambiente de computação**, poderá selecionar qual deles será usado por padrão ao lançar um fluxo de trabalho.
 
 1. Navegue até os seus [ambientes de computação](https://help.tower.nf/compute-envs/overview/).
 2. Escolha seu ambiente padrão selecionando o botão **Make primary**.
 
 **Parabéns!**
 
-Agora você está pronto para lançar pipelines com seu ambiente de computação principal.
+Agora você está pronto para lançar fluxos de trabalho com seu ambiente de computação principal.
 
 #### Launchpad
 
-O Launchpad torna fácil para qualquer usuário da área de trabalho lançar um pipeline pré-configurado.
+O Launchpad torna fácil para qualquer usuário da área de trabalho lançar um fluxo de trabalho pré-configurado.
 
 ![Launchpad](img/overview_launch.png)
 
-Um pipeline é um repositório que contém um fluxo de trabalho do Nextflow, um ambiente de computação e parâmetros de pipeline.
+Um fluxo de trabalho é um repositório que contém um fluxo de trabalho do Nextflow, um ambiente de computação e parâmetros de fluxo de trabalho.
 
 #### Formulário de Parâmetros de Pipeline
 
@@ -144,36 +144,36 @@ O Launchpad detecta automaticamente a presença de um `nextflow_schema.json` na 
 
 !!! info
 
-    A exibição de formulários de parâmetro aparecerá se o fluxo de trabalho tiver um arquivo de esquema do Nextflow para os parâmetros. Consulte o [Guia do esquema do Nextflow](https://help.tower.nf/pipeline-schema/overview) para saber mais sobre os casos de uso do arquivo de esquema e como criá-los.
+    A exibição de formulários de parâmetro aparecerá se o fluxo de trabalho tiver um arquivo de esquema do Nextflow para os parâmetros. Consulte o [Guia do esquema do Nextflow](https://help.tower.nf/workflow-schema/overview) para saber mais sobre os casos de uso do arquivo de esquema e como criá-los.
 
-Isso torna trivial para usuários sem experiência em Nextflow inserir seus parâmetros de pipeline e lançá-lo.
+Isso torna trivial para usuários sem experiência em Nextflow inserir seus parâmetros de fluxo de trabalho e lançá-lo.
 
 ![Pipeline parameters](img/launch_rnaseq_nextflow_schema.png)
 
-#### Adicionando um novo pipeline
+#### Adicionando um novo fluxo de trabalho
 
-A adição de um pipeline pré-salvo ao launchpad da área de trabalho é detalhada na íntegra na [documentação do Tower](https://help.tower.nf/launch/launch/).
+A adição de um fluxo de trabalho pré-salvo ao launchpad da área de trabalho é detalhada na íntegra na [documentação do Tower](https://help.tower.nf/launch/launch/).
 
-Em resumo, essas são as etapas que você precisa seguir para configurar um pipeline.
+Em resumo, essas são as etapas que você precisa seguir para configurar um fluxo de trabalho.
 
 1. Selecione o botão Launchpad na barra de navegação. Isso abrirá o **Formulário de inicialização**.
 2. Selecione um [ambiente de computação](https://help.tower.nf/compute-envs/overview).
-3. Insira o repositório do pipeline que você deseja iniciar. e.g. <https://github.com/nf-core/rnaseq.git>
-4. Selecione um **número de revisão** para o pipeline. O branching padrão do Git (main/master) ou `manifest.defaultBranch` na configuração do Nextflow será usada por padrão.
+3. Insira o repositório do fluxo de trabalho que você deseja iniciar. e.g. <https://github.com/nf-core/rnaseq.git>
+4. Selecione um **número de revisão** para o fluxo de trabalho. O branching padrão do Git (main/master) ou `manifest.defaultBranch` na configuração do Nextflow será usada por padrão.
 5. Defina o local do **diretório de trabalho** (`workDir`) do Nextflow. O local associado ao ambiente de computação será selecionado por padrão.
 6. Digite o(s) nome(s) de cada um dos **perfis de configuração** do Nextflow seguido da tecla `enter`. Veja mais [na documentação oficial](https://www.nextflow.io/docs/latest/config.html#config-profiles) sobre a configuração de perfis.
-7. Insira quaisquer parâmetros do pipeline no formato YAML ou JSON. Exemplo com YAML:
+7. Insira quaisquer parâmetros do fluxo de trabalho no formato YAML ou JSON. Exemplo com YAML:
 
     ```yaml
     leituras: "s3://nf-bucket/exome-data/ERR013140_{1,2}.fastq.bz2"
     pares_de_leituras: true
     ```
 
-8. Selecione Launch para iniciar a execução do pipeline.
+8. Selecione Launch para iniciar a execução do fluxo de trabalho.
 
 !!! info
 
-    Os pipelines do Nextflow são simplesmente repositórios Git e podem ser alterados para qualquer plataforma de hospedagem Git pública ou privada. Consulte [Integração com o Git](https://help.tower.nf/git/overview/) nos documentos do Tower e [Compartilhamento de Pipelines](https://www.nextflow.io/docs/latest/sharing.html) na documentação do Nextflow para obter mais detalhes.
+    Os fluxos de trabalho do Nextflow são simplesmente repositórios Git e podem ser alterados para qualquer plataforma de hospedagem Git pública ou privada. Consulte [Integração com o Git](https://help.tower.nf/git/overview/) nos documentos do Tower e [Compartilhamento de Pipelines](https://www.nextflow.io/docs/latest/sharing.html) na documentação do Nextflow para obter mais detalhes.
 
 !!! note
 
@@ -185,7 +185,7 @@ Em resumo, essas são as etapas que você precisa seguir para configurar um pipe
 
 !!! tip
 
-    Para criar seu próprio esquema de Nextflow personalizado para seu pipeline, veja os exemplos dos fluxos de trabalho do `nf-core` que adotaram essa abordagem. Por exemplo, o [eager](https://github.com/nf-core/eager/blob/2.3.3/nextflow_schema.json) e o [rnaseq](https://github.com/nf-core/rnaseq/blob/3.0/nextflow_schema.json).
+    Para criar seu próprio esquema de Nextflow personalizado para seu fluxo de trabalho, veja os exemplos dos fluxos de trabalho do `nf-core` que adotaram essa abordagem. Por exemplo, o [eager](https://github.com/nf-core/eager/blob/2.3.3/nextflow_schema.json) e o [rnaseq](https://github.com/nf-core/rnaseq/blob/3.0/nextflow_schema.json).
 
 Para opções de configurações avançadas, confira essa [página](https://help.tower.nf/launch/advanced/).
 
@@ -199,7 +199,7 @@ Para saber mais sobre como usar a API do Tower, visite a [seção da API](https:
 
 O Nextflow Tower simplifica o desenvolvimento e a execução de fluxos de trabalho, fornecendo uma interface centralizada para usuários e organizações.
 
-Cada usuário tem uma **área de trabalho** exclusiva onde pode interagir e gerenciar todos os recursos, como pipelines, ambientes de computação e credenciais. Detalhes disso podem ser encontrados [aqui](https://help.tower.nf/getting-started/workspace/).
+Cada usuário tem uma **área de trabalho** exclusiva onde pode interagir e gerenciar todos os recursos, como fluxos de trabalho, ambientes de computação e credenciais. Detalhes disso podem ser encontrados [aqui](https://help.tower.nf/getting-started/workspace/).
 
 As organizações podem ter vários espaços de trabalho com acesso personalizado para **membros** e **colaboradores** específicos da organização.
 
@@ -213,7 +213,7 @@ O Tower permite a criação de várias organizações, cada uma das quais pode c
 
 Qualquer usuário pode ser adicionado ou removido de uma determinada organização ou área de trabalho e pode receber um papel de acesso específico dentro dessa área de trabalho.
 
-O recurso Equipes fornece uma maneira para as organizações agruparem vários usuários e participantes em equipes. Por exemplo, `desenvolvedores-pipelines` ou `analistas`, e aplicar controle de acesso a todos os usuários dentro desta equipe coletivamente.
+O recurso Equipes fornece uma maneira para as organizações agruparem vários usuários e participantes em equipes. Por exemplo, `desenvolvedores-fluxos de trabalho` ou `analistas`, e aplicar controle de acesso a todos os usuários dentro desta equipe coletivamente.
 
 Para mais informações, consulte a seção de [Gerenciamento de Usuário](https://help.tower.nf/orgs-and-teams/organizations/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Find the one that's right for you:
 
         :material-lightbulb: This is the primary Nextflow training material used in most Nextflow and nf-core training events.
 
-    Basic training for all things Nextflow. Perfect for anyone looking to get to grips with using Nextflow to run analyses and build pipelines.
+    Basic training for all things Nextflow. Perfect for anyone looking to get to grips with using Nextflow to run analyses and build workflows.
 
     [Start the Nextflow Training Workshop :material-arrow-right:](basic_training/index.md){ .md-button .md-button--primary }
 

--- a/docs/index.pt.md
+++ b/docs/index.pt.md
@@ -30,7 +30,7 @@ Encontre o que se adequa mais ao que você está procurando:
 
         :material-lightbulb: Esse é o material de treinamento primário do Nextflow utilizado na maior parte dos eventos de treinamento do Nextflow e do nf-core.
 
-    Treinamento básico cobrindo um pouquinho de tudo do Nextflow. Perfeito para quem quer se familiarizar com o uso do Nextflow para executar análises e construir pipelines.
+    Treinamento básico cobrindo um pouquinho de tudo do Nextflow. Perfeito para quem quer se familiarizar com o uso do Nextflow para executar análises e construir fluxos de trabalho.
 
     [Comece já o treinamento do Nextflow :material-arrow-right:](basic_training/index.md){ .md-button .md-button--primary }
 


### PR DESCRIPTION
- Fix usage of image name and image tag
- Name them channel operator/factory instead of "method"
- Sync Portuguese translation
