### PR TITLE
Make usage of task/job/process consistent

### DIFF
--- a/docs/basic_training/channels.md
+++ b/docs/basic_training/channels.md
@@ -235,7 +235,8 @@ Learn more about the glob patterns syntax at [this link](https://docs.oracle.com
     ??? solution
 
         ```groovy linenums="1"
-        Channel.fromPath('./data/ggal/**.fq', hidden: true)
+        Channel
+            .fromPath('./data/ggal/**.fq', hidden: true)
             .view()
         ```
 
@@ -280,7 +281,8 @@ It will produce an output similar to the following:
         Use the following, with or without `flat: true`:
 
         ```groovy linenums="1"
-        Channel.fromFilePairs('./data/ggal/*_{1,2}.fq', flat: true)
+        Channel
+            .fromFilePairs('./data/ggal/*_{1,2}.fq', flat: true)
             .view()
         ```
 
@@ -680,7 +682,8 @@ process FOO {
 }
 
 workflow {
-    Channel.fromPath('data/meta/regions*.json')
+    Channel
+        .fromPath('data/meta/regions*.json')
         | flatMap { parseJsonFile(it) }
         | map { record -> [record.patient_id, record.feature] }
         | unique

--- a/docs/basic_training/channels.pt.md
+++ b/docs/basic_training/channels.pt.md
@@ -235,7 +235,8 @@ Saiba mais sobre a sintaxe dos padrões glob [neste link](https://docs.oracle.co
     ??? solution
 
         ```groovy linenums="1"
-        Channel.fromPath('./data/ggal/**.fq', hidden: true)
+        Channel
+            .fromPath('./data/ggal/**.fq', hidden: true)
             .view()
         ```
 
@@ -280,7 +281,8 @@ Ele produzirá uma saída semelhante à seguinte:
         Use o seguinte, com ou sem `flat: true`:
 
         ```groovy linenums="1"
-        Channel.fromFilePairs('./data/ggal/*_{1,2}.fq', flat: true)
+        Channel
+            .fromFilePairs('./data/ggal/*_{1,2}.fq', flat: true)
             .view()
         ```
 
@@ -681,7 +683,8 @@ process FOO {
 }
 
 workflow {
-    Channel.fromPath('data/meta/regions*.json')
+    Channel
+        .fromPath('data/meta/regions*.json')
         | flatMap { parseJsonFile(it) }
         | map { record -> [record.patient_id, record.feature] }
         | unique

--- a/docs/basic_training/debugging.md
+++ b/docs/basic_training/debugging.md
@@ -50,18 +50,18 @@ If this is not enough, `cd` into the task work directory. It contains all the fi
 The task execution directory contains these files:
 
 -   `.command.sh`: The command script.
--   `.command.run`: The command wrapped used to run the job.
--   `.command.out`: The complete job standard output.
--   `.command.err`: The complete job standard error.
+-   `.command.run`: The command wrapped used to run the task.
+-   `.command.out`: The complete task standard output.
+-   `.command.err`: The complete task standard error.
 -   `.command.log`: The wrapper execution output.
--   `.command.begin`: Sentinel file created as soon as the job is launched.
+-   `.command.begin`: Sentinel file created as soon as the task is launched.
 -   `.exitcode`: A file containing the task exit code.
 -   Task input files (symlinks)
 -   Task output files
 
 Verify that the `.command.sh` file contains the expected command and all variables are correctly resolved.
 
-Also verify the existence of the `.exitcode` and `.command.begin` files, which if absent, suggest the task was never executed by the subsystem (e.g. the batch scheduler). If the `.command.begin` file exists, the job was launched but was likely killed abruptly.
+Also verify the existence of the `.exitcode` and `.command.begin` files, which if absent, suggest the task was never executed by the subsystem (e.g. the batch scheduler). If the `.command.begin` file exists, the task was launched but was likely killed abruptly.
 
 You can replicate the failing execution using the command `bash .command.run` to verify the cause of the error.
 
@@ -125,9 +125,9 @@ process FOO {
 
 ## Dynamic resources allocation
 
-It’s a very common scenario that different instances of the same process may have very different needs in terms of computing resources. In such situations requesting, for example, an amount of memory too low will cause some tasks to fail. Instead, using a higher limit that fits all the tasks in your execution could significantly decrease the execution priority of your jobs.
+It’s a very common scenario that different instances of the same process may have very different needs in terms of computing resources. In such situations requesting, for example, an amount of memory too low will cause some tasks to fail. Instead, using a higher limit that fits all the tasks in your execution could significantly decrease the execution priority of your job in a scheduling system.
 
-To handle this use case, you can use a `retry` error strategy and increase the computing resources allocated by the job at each successive _attempt_.
+To handle this use case, you can use a `retry` error strategy and increase the computing resources allocated by the task at each successive _attempt_.
 
 ```groovy linenums="1"
 process FOO {

--- a/docs/basic_training/debugging.pt.md
+++ b/docs/basic_training/debugging.pt.md
@@ -127,7 +127,7 @@ process FOO {
 
 ## Alocação dinâmica de recursos
 
-Uma situação bastante comum é que diferentes instâncias de um mesmo processo podem ter necessidades diferentes de recursos computacionais. Nessas situações, solicitar uma quantidade de memória muito baixa, por exemplo, irá levar algumas tarefas a falharem. Por outro lado, usar um limite mais elevado que abrange todas as suas tarefas pode reduzir significativamente a prioridade de execução delas.
+Uma situação bastante comum é que diferentes instâncias de um mesmo processo podem ter necessidades diferentes de recursos computacionais. Nessas situações, solicitar uma quantidade de memória muito baixa, por exemplo, irá levar algumas tarefas a falharem. Por outro lado, usar um limite mais elevado que abrange todas as suas tarefas pode reduzir significativamente a prioridade de execução delas em um sistema de escalonamento de tarefas.
 
 Para lidar com isso, você pode utilizar uma estratégia de erro `retry` e aumentar os recursos computacionais alocados pela tarefa em cada _tentativa_ consecutiva.
 

--- a/docs/basic_training/executors.md
+++ b/docs/basic_training/executors.md
@@ -4,7 +4,7 @@ description: Basic Nextflow Training Workshop
 
 # Deployment scenarios
 
-Real-world genomic applications can spawn the execution of thousands of jobs. In this scenario a batch scheduler is commonly used to deploy a workflow in a computing cluster, allowing the execution of many jobs in parallel across many compute nodes.
+Real-world genomic applications can spawn the execution of thousands of tasks. In this scenario a batch scheduler is commonly used to deploy a workflow in a computing cluster, allowing the execution of many jobs in parallel across many compute nodes.
 
 Nextflow has built-in support for the most commonly used batch schedulers, such as Univa Grid Engine, [SLURM](https://slurm.schedmd.com/) and IBM LSF. Check the Nextflow documentation for the complete list of supported [execution platforms](https://www.nextflow.io/docs/latest/executor.html).
 
@@ -29,7 +29,7 @@ This can be done using the following process directives:
 |                                                                   |                                                               |
 | ----------------------------------------------------------------- | ------------------------------------------------------------- |
 | [queue](https://www.nextflow.io/docs/latest/process.html#queue)   | the cluster _queue_ to be used for the computation            |
-| [cpus](https://www.nextflow.io/docs/latest/process.html#cpus)     | the number of _cpus_ to be allocated a task execution         |
+| [cpus](https://www.nextflow.io/docs/latest/process.html#cpus)     | the number of _cpus_ to be allocated for a task execution     |
 | [memory](https://www.nextflow.io/docs/latest/process.html#memory) | the amount of _memory_ to be allocated for a task execution   |
 | [time](https://www.nextflow.io/docs/latest/process.html#time)     | the max amount of _time_ to be allocated for a task execution |
 | [disk](https://www.nextflow.io/docs/latest/process.html#disk)     | the amount of _disk_ storage required for a task execution    |

--- a/docs/basic_training/intro.md
+++ b/docs/basic_training/intro.md
@@ -175,13 +175,13 @@ The standard output shows (line by line):
 1. The version of Nextflow that was executed.
 2. The script and version names.
 3. The executor used (in the above case: local).
-4. The first `process` is executed once. The line starts with a unique hexadecimal value (see TIP below), and ends with the percentage and job completion information.
-5. The second process is executed twice (once for chunk_aa and once for chunk_ab).
+4. The first `process` is executed once, which means there is one task. The line starts with a unique hexadecimal value (see TIP below), and ends with the percentage and other task completion information.
+5. The second process is executed twice (once for chunk_aa and once for chunk_ab), which means two tasks.
 6. The result string from stdout is printed.
 
 !!! info
 
-    The hexadecimal numbers, like `c8/c36893`, identify the unique process execution. These numbers are also the prefix of the directories where each process is executed. You can inspect the files produced by changing to the directory `$PWD/work` and using these numbers to find the process-specific execution path.
+    The hexadecimal numbers, like `c8/c36893`, identify the unique process execution, that we call a task. These numbers are also the prefix of the directories where each task is executed. You can inspect the files produced by changing to the directory `$PWD/work` and using these numbers to find the task-specific execution path.
 
 !!! tip
 
@@ -233,7 +233,7 @@ executor >  local (2)
  olleH
 ```
 
-You will see that the execution of the process `SPLITLETTERS` is skipped (the process ID is the same as in the first output) — its results are retrieved from the cache. The second process is executed as expected, printing the reversed strings.
+You will see that the execution of the process `SPLITLETTERS` is skipped (the task ID is the same as in the first output) — its results are retrieved from the cache. The second process is executed as expected, printing the reversed strings.
 
 !!! info
 

--- a/docs/basic_training/intro.pt.md
+++ b/docs/basic_training/intro.pt.md
@@ -174,13 +174,13 @@ A saída padrão mostra (linha por linha):
 1. A versão do Nextflow que foi executada.
 2. Os nomes do script e da versão.
 3. O executor usado (no caso acima: local).
-4. O primeiro processo é executado uma vez. A linha começa com um valor hexadecimal exclusivo (consulte a dica abaixo) e termina com as informações de porcentagem e conclusão do trabalho.
-5. O segundo processo é executado duas vezes (uma vez para chunk_aa e outra para chunk_ab).
+4. O primeiro processo é executado uma vez, o que significa que houve 1 tarefa. A linha começa com um valor hexadecimal exclusivo (consulte a dica abaixo) e termina com a porcentagem e outras informações de conclusão da tarefa.
+5. O segundo processo é executado duas vezes (uma vez para chunk_aa e outra para chunk_ab), o que significa duas tarefas.
 6. A string de resultado de stdout é impressa na tela.
 
 !!! info
 
-    Os números hexadecimais, como `c8/c36893`, identificam de forma única a execução do processo. Esses números também são o prefixo dos diretórios onde cada processo é executado. Você pode inspecionar os arquivos produzidos mudando para o diretório `$PWD/work` e usando esses números para encontrar o caminho de execução específico do processo.
+    Os números hexadecimais, como `c8/c36893`, identificam de forma única a execução do processo. Esses números também são o prefixo dos diretórios onde cada tarefa é executado. Você pode inspecionar os arquivos produzidos mudando para o diretório `$PWD/work` e usando esses números para encontrar o caminho de execução específico da tarefa.
 
 !!! tip
 
@@ -232,7 +232,7 @@ executor >  local (2)
  olleH
 ```
 
-Você verá que a execução do processo `SPLITLETTERS` é ignorada (o ID do processo é o mesmo da primeira saída) — seus resultados são recuperados do cache. O segundo processo é executado conforme o esperado, imprimindo as strings invertidas.
+Você verá que a execução do processo `SPLITLETTERS` é ignorada (o ID da tarefa é o mesmo da primeira saída) — seus resultados são recuperados do cache. O segundo processo é executado conforme o esperado, imprimindo as strings invertidas.
 
 !!! info
 

--- a/docs/basic_training/modules.pt.md
+++ b/docs/basic_training/modules.pt.md
@@ -49,7 +49,7 @@ include { CONVERTTOUPPER } from './modules.nf'
         include { SPLITLETTERS   } from './modules.nf'
         include { CONVERTTOUPPER } from './modules.nf'
 
-        fluxo de trabalho {
+        workflow {
             letters_ch = SPLITLETTERS(greeting_ch)
             results_ch = CONVERTTOUPPER(letters_ch.flatten())
             results_ch.view { it }
@@ -243,7 +243,7 @@ Outra maneira de lidar com as saídas no escopo `workflow` é usar pipes `|`.
      Tente alterar o script do fluxo de trabalho para o trecho abaixo:
 
     ```groovy linenums="1"
-    fluxo de trabalho {
+    workflow {
         Channel.of(params.greeting) | SPLITLETTERS | flatten | CONVERTTOUPPER | view
     }
     ```

--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -121,7 +121,9 @@ c1 = Channel.of(1, 2, 3)
 c2 = Channel.of('a', 'b')
 c3 = Channel.of('z')
 
-c1.mix(c2, c3).view()
+c1
+    .mix(c2, c3)
+    .view()
 ```
 
 ```console title="Output"
@@ -209,7 +211,8 @@ This operator is useful to process a group together with all the elements that s
     ??? solution
 
         ```groovy linenums="1"
-        Channel.fromPath('data/meta/*')
+        Channel
+            .fromPath('data/meta/*')
             .map { file -> tuple(file.baseName, file) }
             .groupTuple()
             .view { baseName, file -> "> $baseName : $file" }

--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -117,12 +117,12 @@ Channel
 The `mix` operator combines the items emitted by two (or more) channels into a single channel.
 
 ```groovy linenums="1"
-c1 = Channel.of(1, 2, 3)
-c2 = Channel.of('a', 'b')
-c3 = Channel.of('z')
+my_channel_1 = Channel.of(1, 2, 3)
+my_channel_2 = Channel.of('a', 'b')
+my_channel_3 = Channel.of('z')
 
-c1
-    .mix(c2, c3)
+my_channel_1
+    .mix(my_channel_2, my_channel_3)
     .view()
 ```
 

--- a/docs/basic_training/operators.pt.md
+++ b/docs/basic_training/operators.pt.md
@@ -120,12 +120,12 @@ Channel
 O operador `mix` combina os itens emitidos por dois (ou mais) canais em um único canal.
 
 ```groovy linenums="1"
-c1 = Channel.of(1, 2, 3)
-c2 = Channel.of('a', 'b')
-c3 = Channel.of('z')
+meu_canal_1 = Channel.of(1, 2, 3)
+meu_canal_2 = Channel.of('a', 'b')
+meu_canal_3 = Channel.of('z')
 
-c1
-    .mix(c2, c3)
+meu_canal_1
+    .mix(meu_canal_2, meu_canal_3)
     .view()
 ```
 

--- a/docs/basic_training/operators.pt.md
+++ b/docs/basic_training/operators.pt.md
@@ -124,7 +124,9 @@ c1 = Channel.of(1, 2, 3)
 c2 = Channel.of('a', 'b')
 c3 = Channel.of('z')
 
-c1.mix(c2, c3).view()
+c1
+    .mix(c2, c3)
+    .view()
 ```
 
 ```console title="Output"
@@ -212,7 +214,8 @@ Esse operador é útil para processar um grupo, juntando elementos que possuem u
     ??? solution
 
         ```groovy linenums="1"
-        Channel.fromPath('data/meta/*')
+        Channel
+            .fromPath('data/meta/*')
             .map { arquivo -> tuple(arquivo.baseName, arquivo) }
             .groupTuple()
             .view { baseName, arquivo -> "> $baseName : $arquivo" }

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -214,7 +214,7 @@ workflow {
 
 ## Inputs
 
-Nextflow processes instances (tasks) are isolated from each other but can communicate between themselves by sending values through channels.
+Nextflow process instances (tasks) are isolated from each other but can communicate between themselves by sending values through channels.
 
 Inputs implicitly determine the dependencies and the parallel execution of the process. The process execution is fired each time _new_ data is ready to be consumed from the input channel:
 

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -27,7 +27,7 @@ In more complex examples, the process body can contain up to **five** definition
 2. **Input** defines the expected input channel(s)
 3. **Output** defines the expected output channel(s)
 4. **When** is an optional clause statement to allow conditional processes
-5. **Script** is a string statement that defines the command to be executed by the process
+5. **Script** is a string statement that defines the command to be executed by the process' task
 
 The full process syntax is defined as follows:
 
@@ -214,7 +214,7 @@ workflow {
 
 ## Inputs
 
-Nextflow processes are isolated from each other but can communicate between themselves by sending values through channels.
+Nextflow processes instances (tasks) are isolated from each other but can communicate between themselves by sending values through channels.
 
 Inputs implicitly determine the dependencies and the parallel execution of the process. The process execution is fired each time _new_ data is ready to be consumed from the input channel:
 
@@ -844,16 +844,16 @@ process FOO {
 | Name                                                                | Description                                                                                                                                          |
 | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`cpus`](https://www.nextflow.io/docs/latest/process.html#cpus)     | Allows you to define the number of (logical) CPUs required by the process’ task.                                                                     |
-| [`time`](https://www.nextflow.io/docs/latest/process.html#time)     | Allows you to define how long a process is allowed to run (e.g., time _1h_: 1 hour, _1s_ 1 second, _1m_ 1 minute, _1d_ 1 day).                       |
-| [`memory`](https://www.nextflow.io/docs/latest/process.html#memory) | Allows you to define how much memory the process is allowed to use (e.g., _2 GB_ is 2 GB). Can also use B, KB,MB,GB and TB.                          |
-| [`disk`](https://www.nextflow.io/docs/latest/process.html#disk)     | Allows you to define how much local disk storage the process is allowed to use.                                                                      |
+| [`time`](https://www.nextflow.io/docs/latest/process.html#time)     | Allows you to define how long the task is allowed to run (e.g., time _1h_: 1 hour, _1s_ 1 second, _1m_ 1 minute, _1d_ 1 day).                       |
+| [`memory`](https://www.nextflow.io/docs/latest/process.html#memory) | Allows you to define how much memory the task is allowed to use (e.g., _2 GB_ is 2 GB). Can also use B, KB,MB,GB and TB.                          |
+| [`disk`](https://www.nextflow.io/docs/latest/process.html#disk)     | Allows you to define how much local disk storage the task is allowed to use.                                                                      |
 | [`tag`](https://www.nextflow.io/docs/latest/process.html#tag)       | Allows you to associate each process execution with a custom label to make it easier to identify them in the log file or the trace execution report. |
 
 ## Organize outputs
 
 ### PublishDir directive
 
-Given each process is being executed in separate temporary `work/` folder (e.g., `work/f1/850698…`; `work/g3/239712…`; etc.), we may want to save important, non-intermediary, and/or final files in a results folder.
+Given each task is being executed in separate temporary `work/` folder (e.g., `work/f1/850698…`; `work/g3/239712…`; etc.), we may want to save important, non-intermediary, and/or final files in a results folder.
 
 !!! tip
 
@@ -888,7 +888,7 @@ workflow {
 }
 ```
 
-The above example will copy all blast script files created by the `BLASTSEQ` task into the directory path `my-results`.
+The above example will copy all blast script files created by the `BLASTSEQ` process into the directory path `my-results`.
 
 !!! tip
 

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -844,9 +844,9 @@ process FOO {
 | Name                                                                | Description                                                                                                                                          |
 | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`cpus`](https://www.nextflow.io/docs/latest/process.html#cpus)     | Allows you to define the number of (logical) CPUs required by the process’ task.                                                                     |
-| [`time`](https://www.nextflow.io/docs/latest/process.html#time)     | Allows you to define how long the task is allowed to run (e.g., time _1h_: 1 hour, _1s_ 1 second, _1m_ 1 minute, _1d_ 1 day).                       |
-| [`memory`](https://www.nextflow.io/docs/latest/process.html#memory) | Allows you to define how much memory the task is allowed to use (e.g., _2 GB_ is 2 GB). Can also use B, KB,MB,GB and TB.                          |
-| [`disk`](https://www.nextflow.io/docs/latest/process.html#disk)     | Allows you to define how much local disk storage the task is allowed to use.                                                                      |
+| [`time`](https://www.nextflow.io/docs/latest/process.html#time)     | Allows you to define how long the task is allowed to run (e.g., time _1h_: 1 hour, _1s_ 1 second, _1m_ 1 minute, _1d_ 1 day).                        |
+| [`memory`](https://www.nextflow.io/docs/latest/process.html#memory) | Allows you to define how much memory the task is allowed to use (e.g., _2 GB_ is 2 GB). Can also use B, KB,MB,GB and TB.                             |
+| [`disk`](https://www.nextflow.io/docs/latest/process.html#disk)     | Allows you to define how much local disk storage the task is allowed to use.                                                                         |
 | [`tag`](https://www.nextflow.io/docs/latest/process.html#tag)       | Allows you to associate each process execution with a custom label to make it easier to identify them in the log file or the trace execution report. |
 
 ## Organize outputs

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -575,8 +575,7 @@ In the above example, every time a file of sequences is received as an input by 
 
         workflow {
             concat_ch = COMMAND(read_ch, params.transcriptome_file, methods)
-            concat_ch
-                .view { "To run : ${it.text}" }
+            concat_ch.view { "To run : ${it.text}" }
         }
         ```
 

--- a/docs/basic_training/processes.pt.md
+++ b/docs/basic_training/processes.pt.md
@@ -843,9 +843,9 @@ process FOO {
 | Nome                                                                | Descrição                                                                                                                                                            |
 | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`cpus`](https://www.nextflow.io/docs/latest/process.html#cpus)     | Permite definir o número de CPUs (lógicas) necessárias para a tarefa do processo.                                                                                    |
-| [`time`](https://www.nextflow.io/docs/latest/process.html#time)     | Permite definir por quanto tempo a tarefa pode ser executado (por exemplo, tempo _1h_: 1 hora, _1s_ 1 segundo, _1m_ 1 minuto, _1d_ 1 dia).                        |
-| [`memory`](https://www.nextflow.io/docs/latest/process.html#memory) | Permite definir quanta memória a tarefa pode usar (por exemplo, _2 GB_ é 2 GB). Também pode usar B, KB, MB, GB e TB.                                               |
-| [`disk`](https://www.nextflow.io/docs/latest/process.html#disk)     | Permite definir a quantidade de armazenamento em disco local que a tarefa pode usar.                                                                               |
+| [`time`](https://www.nextflow.io/docs/latest/process.html#time)     | Permite definir por quanto tempo a tarefa pode ser executado (por exemplo, tempo _1h_: 1 hora, _1s_ 1 segundo, _1m_ 1 minuto, _1d_ 1 dia).                           |
+| [`memory`](https://www.nextflow.io/docs/latest/process.html#memory) | Permite definir quanta memória a tarefa pode usar (por exemplo, _2 GB_ é 2 GB). Também pode usar B, KB, MB, GB e TB.                                                 |
+| [`disk`](https://www.nextflow.io/docs/latest/process.html#disk)     | Permite definir a quantidade de armazenamento em disco local que a tarefa pode usar.                                                                                 |
 | [`tag`](https://www.nextflow.io/docs/latest/process.html#tag)       | Permite associar cada execução de processo a um rótulo personalizado para facilitar sua identificação no arquivo de log ou no relatório de execução do rastreamento. |
 
 ## Organizando as saídas

--- a/docs/basic_training/processes.pt.md
+++ b/docs/basic_training/processes.pt.md
@@ -369,7 +369,7 @@ workflow {
             """
         }
 
-        fluxo de trabalho {
+        workflow {
             canal_concatenado = CONCATENE(canal_leituras.collect())
             canal_concatenado.view()
         }
@@ -507,7 +507,7 @@ Isso ocorre porque os canais de valor podem ser consumidos várias vezes e não 
             """
         }
 
-        fluxo de trabalho {
+        workflow {
             canal_concatenado = COMANDO(canal_leituras, params.arquivo_transcriptoma)
             canal_concatenado.view()
         }
@@ -573,10 +573,9 @@ No exemplo acima, toda vez que um arquivo de sequências é recebido como entrad
             """
         }
 
-        fluxo de trabalho {
+        workflow {
             canal_concatenado = COMANDO(canal_leituras, params.arquivo_transcriptoma, metodos)
-            canal_concatenado
-                .view { "Para executar : ${it.text}" }
+            canal_concatenado.view { "Para executar : ${it.text}" }
         }
         ```
 
@@ -778,7 +777,7 @@ workflow {
             """
         }
 
-        fluxo de trabalho {
+        workflow {
             canal_bam = FOO(canal_leituras)
             canal_bam.view()
         }

--- a/docs/basic_training/processes.pt.md
+++ b/docs/basic_training/processes.pt.md
@@ -698,7 +698,8 @@ Quando um nome de arquivo de saída precisa ser expresso dinamicamente, é poss�
 especies = ['gato', 'cachorro', 'preguiça']
 sequencias = ['AGATAG', 'ATGCTCT', 'ATCCCAA']
 
-Channel.fromList(especies)
+Channel
+    .fromList(especies)
     .set { canal_especies }
 
 process ALINHAR {

--- a/docs/basic_training/processes.pt.md
+++ b/docs/basic_training/processes.pt.md
@@ -27,7 +27,7 @@ Em exemplos mais complexos, o corpo do processo pode conter até **cinco** bloco
 2. **Input** (Bloco de entrada) define o(s) canal(is) de entrada esperado(s)
 3. **Output** (Bloco de saída) define o(s) canal(is) de saída esperado(s)
 4. **When** é uma declaração de cláusula opcional para permitir processos condicionais
-5. **Script** é uma string que define o comando a ser executado pelo processo
+5. **Script** é uma string que define o comando a ser executado pela tarefa do processo
 
 A sintaxe completa do processo é definida da seguinte forma:
 
@@ -214,7 +214,7 @@ workflow {
 
 ## Canais de entradas
 
-Os processos Nextflow são isolados uns dos outros, mas podem se comunicar entre si enviando valores por meio de canais.
+As instâncias dos processos (tarefas) Nextflow são isoladas umas das outras, mas podem se comunicar entre si enviando valores por meio de canais.
 
 As entradas determinam implicitamente as dependências e a execução paralela do processo. A execução do processo é disparada cada vez que dados _novos_ estão prontos para serem consumidos do canal de entrada:
 
@@ -843,16 +843,16 @@ process FOO {
 | Nome                                                                | Descrição                                                                                                                                                            |
 | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`cpus`](https://www.nextflow.io/docs/latest/process.html#cpus)     | Permite definir o número de CPUs (lógicas) necessárias para a tarefa do processo.                                                                                    |
-| [`time`](https://www.nextflow.io/docs/latest/process.html#time)     | Permite definir por quanto tempo um processo pode ser executado (por exemplo, tempo _1h_: 1 hora, _1s_ 1 segundo, _1m_ 1 minuto, _1d_ 1 dia).                        |
-| [`memory`](https://www.nextflow.io/docs/latest/process.html#memory) | Permite definir quanta memória o processo pode usar (por exemplo, _2 GB_ é 2 GB). Também pode usar B, KB, MB, GB e TB.                                               |
-| [`disk`](https://www.nextflow.io/docs/latest/process.html#disk)     | Permite definir a quantidade de armazenamento em disco local que o processo pode usar.                                                                               |
+| [`time`](https://www.nextflow.io/docs/latest/process.html#time)     | Permite definir por quanto tempo a tarefa pode ser executado (por exemplo, tempo _1h_: 1 hora, _1s_ 1 segundo, _1m_ 1 minuto, _1d_ 1 dia).                        |
+| [`memory`](https://www.nextflow.io/docs/latest/process.html#memory) | Permite definir quanta memória a tarefa pode usar (por exemplo, _2 GB_ é 2 GB). Também pode usar B, KB, MB, GB e TB.                                               |
+| [`disk`](https://www.nextflow.io/docs/latest/process.html#disk)     | Permite definir a quantidade de armazenamento em disco local que a tarefa pode usar.                                                                               |
 | [`tag`](https://www.nextflow.io/docs/latest/process.html#tag)       | Permite associar cada execução de processo a um rótulo personalizado para facilitar sua identificação no arquivo de log ou no relatório de execução do rastreamento. |
 
 ## Organizando as saídas
 
 ### A diretiva PublishDir
 
-Dado que cada processo está sendo executado em uma pasta `work/` temporária separada (por exemplo, `work/f1/850698…`; `work/g3/239712…`; etc.), podemos salvar informações importantes, não intermediárias, e/ou arquivos finais em uma pasta de resultados.
+Dado que cada tarefa está sendo executada em uma pasta `work/` temporária separada (por exemplo, `work/f1/850698…`; `work/g3/239712…`; etc.), podemos salvar informações importantes, não intermediárias, e/ou arquivos finais em uma pasta de resultados.
 
 !!! tip
 
@@ -887,7 +887,7 @@ workflow {
 }
 ```
 
-O exemplo acima copiará todos os arquivos de script blast criados pela tarefa `BLASTSEQ` no caminho do diretório `meus-resultados`.
+O exemplo acima copiará todos os arquivos de script blast criados pelo processo `BLASTSEQ` no caminho do diretório `meus-resultados`.
 
 !!! tip
 

--- a/docs/basic_training/rnaseq_pipeline.md
+++ b/docs/basic_training/rnaseq_pipeline.md
@@ -175,7 +175,7 @@ docker.enabled = true
 
 !!! exercise
 
-    If you have more CPUs available, try changing your script to request more resources for this process. For example, see the [directive docs](https://www.nextflow.io/docs/latest/process.html#cpus). `$task.cpus` is already specified in this script, so setting the number of CPUs as a directive will tell Nextflow how to run this job, in terms of number of CPUs.
+    If you have more CPUs available, try changing your script to request more resources for this process. For example, see the [directive docs](https://www.nextflow.io/docs/latest/process.html#cpus). `$task.cpus` is already specified in this script, so setting the number of CPUs as a directive will tell Nextflow how to execute this process, in terms of number of CPUs.
 
     ??? result
 

--- a/docs/basic_training/rnaseq_pipeline.md
+++ b/docs/basic_training/rnaseq_pipeline.md
@@ -69,13 +69,13 @@ nextflow run script1.nf --reads '/workspace/gitpod/nf-training/data/ggal/lung_{1
 
         ```groovy
         log.info """\
-                    R N A S E Q - N F   P I P E L I N E
-                    ===================================
-                    transcriptome: ${params.transcriptome_file}
-                    reads        : ${params.reads}
-                    outdir       : ${params.outdir}
-                    """
-                    .stripIndent(true)
+            R N A S E Q - N F   P I P E L I N E
+            ===================================
+            transcriptome: ${params.transcriptome_file}
+            reads        : ${params.reads}
+            outdir       : ${params.outdir}
+            """
+            .stripIndent(true)
         ```
 
 ### :material-check-all: Summary

--- a/docs/basic_training/rnaseq_pipeline.pt.md
+++ b/docs/basic_training/rnaseq_pipeline.pt.md
@@ -175,7 +175,7 @@ docker.enabled = true
 
 !!! exercise
 
-    Se você tiver mais CPUs disponíveis, tente alterar seu script para solicitar mais recursos para este processo. Por exemplo, consulte os [documentos de diretivas](https://www.nextflow.io/docs/latest/process.html#cpus). `$task.cpus` já está especificado no script, portanto definir o número de CPUs como uma diretiva informará ao Nextflow para executar este trabalho levando isso em consideração.
+    Se você tiver mais CPUs disponíveis, tente alterar seu script para solicitar mais recursos para este processo. Por exemplo, consulte os [documentos de diretivas](https://www.nextflow.io/docs/latest/process.html#cpus). `$task.cpus` já está especificado no script, portanto definir o número de CPUs como uma diretiva informará ao Nextflow para executar este processo levando isso em consideração.
 
     ??? result
 


### PR DESCRIPTION
- Make usage of process/task/job consistent
- Make line splitting consistent for chained operators
- Sync Portuguese translation
