### PR TITLE
Revert Portuguese translation in RNAseq section of the basic training

### DIFF
--- a/docs/basic_training/rnaseq_pipeline.pt.md
+++ b/docs/basic_training/rnaseq_pipeline.pt.md
@@ -77,9 +77,9 @@ nextflow run script1.nf --reads '/workspace/gitpod/nf-training/data/ggal/lung_{1
         log.info """\
             R N A S E Q - N F   P I P E L I N E
             ===================================
-            transcriptoma               : ${params.transcriptome_file}
-            arquivos de leituras        : ${params.reads}
-            diretório de saíde          : ${params.outdir}
+            transcriptome: ${params.transcriptome_file}
+            reads        : ${params.reads}
+            outdir       : ${params.outdir}
             """
             .stripIndent(true)
         ```


### PR DESCRIPTION
Source code in script file was translated, but this is specifically
the exception when we shouldn't translate, that is, when there is a
script file with the source code (so that we don't have multiple
source code files, one for each language).
