### PR TITLE
Update Nextflow version to 23.04.1

### DIFF
--- a/docs/basic_training/channels.md
+++ b/docs/basic_training/channels.md
@@ -104,14 +104,17 @@ DataflowQueue(queue=[DataflowVariable(value=1), DataflowVariable(value=groovyx.g
 
 We have the value 1 as the single element of our queue channel and a poison pill, which will tell the process that there’s nothing left to be consumed. That’s why we only have one output for the example above, which is 2. Let’s inspect a value channel now.
 
-```groovy linenums="1"
+```groovy linenums="1" title="example3.nf"
 ch1 = Channel.value(1)
 println ch1
 ```
 
 ```console
-$ nextflow run example.nf -dsl1
-...
+$ NXF_VER=22.10.4 nextflow run example3.nf -dsl1
+```
+
+Output:
+```console
 DataflowVariable(value=1)
 ```
 

--- a/docs/basic_training/channels.md
+++ b/docs/basic_training/channels.md
@@ -85,17 +85,21 @@ When you run the script, it prints only 2, as you can see below:
 2
 ```
 
-To understand why, we can inspect the queue channel and running Nextflow with DSL1 gives us a more explicit comprehension of what is behind the curtains.
+To understand why, we can inspect the queue channel by running Nextflow with DSL1 which gives us a more explicit comprehension of what is behind the curtains.
+Save the script below as example2.nf.
 
-```groovy linenums="1"
+```groovy linenums="1" title="example2.nf"
 ch1 = Channel.of(1)
 println ch1
 ```
 
 ```console
-$ nextflow run example.nf -dsl1
-...
-DataflowQueue(queue=[DataflowVariable(value=1), DataflowVariable(value=groovyx.gpars.dataflow.operator.PoisonPill@34be065a)])
+$ NXF_VER=22.10.4 nextflow run example2.nf -dsl1
+```
+
+Output:
+```console
+DataflowQueue(queue=[DataflowVariable(value=1), DataflowVariable(value=groovyx.gpars.dataflow.operator.PoisonPill@ed2f2f6)])
 ```
 
 We have the value 1 as the single element of our queue channel and a poison pill, which will tell the process that there’s nothing left to be consumed. That’s why we only have one output for the example above, which is 2. Let’s inspect a value channel now.

--- a/docs/basic_training/channels.pt.md
+++ b/docs/basic_training/channels.pt.md
@@ -85,17 +85,20 @@ Ao rodar o script, ele imprime apenas 2, como você pode ver abaixo:
 2
 ```
 
-Para entender o motivo, podemos inspecionar o canal de fila executando o Nextflow com DSL1, o que nos dá uma compreensão mais explícita do que está por trás das cortinas.
+Para entender o motivo, podemos inspecionar o canal de fila executando o Nextflow com DSL1, o que nos dá uma compreensão mais explícita do que está por trás das cortinas. Salve o script abaixo como exemplo2.nf.
 
-```groovy linenums="1"
+```groovy linenums="1" title="exemplo2.nf"
 canal1 = Channel.of(1)
 println canal1
 ```
 
 ```console
-$ nextflow run exemplo.nf -dsl1
-...
-DataflowQueue(queue=[DataflowVariable(value=1), DataflowVariable(value=groovyx.gpars.dataflow.operator.PoisonPill@34be065a)])
+$ NXF_VER=22.10.4 nextflow run exemplo2.nf -dsl1
+```
+
+Output:
+```console
+DataflowQueue(queue=[DataflowVariable(value=1), DataflowVariable(value=groovyx.gpars.dataflow.operator.PoisonPill@ed2f2f6)])
 ```
 
 Temos o valor 1 como único elemento do nosso canal de fila e uma pílula de veneno, que vai dizer ao processo que não há mais nada para ser consumido. É por isso que temos apenas uma saída para o exemplo acima, que é 2. Vamos inspecionar um canal de valor agora.

--- a/docs/basic_training/channels.pt.md
+++ b/docs/basic_training/channels.pt.md
@@ -85,7 +85,7 @@ Ao rodar o script, ele imprime apenas 2, como você pode ver abaixo:
 2
 ```
 
-Para entender o motivo, podemos inspecionar o canal de fila executando o Nextflow com DSL1, o que nos dá uma compreensão mais explícita do que está por trás das cortinas. Salve o script abaixo como exemplo2.nf.
+Para entender o motivo, podemos inspecionar o canal de fila executando o Nextflow com DSL1, o que nos dá uma compreensão mais explícita do que está por trás das cortinas. Salve o script abaixo como `exemplo2.nf`.
 
 ```groovy linenums="1" title="exemplo2.nf"
 canal1 = Channel.of(1)
@@ -103,14 +103,17 @@ DataflowQueue(queue=[DataflowVariable(value=1), DataflowVariable(value=groovyx.g
 
 Temos o valor 1 como único elemento do nosso canal de fila e uma pílula de veneno, que vai dizer ao processo que não há mais nada para ser consumido. É por isso que temos apenas uma saída para o exemplo acima, que é 2. Vamos inspecionar um canal de valor agora.
 
-```groovy linenums="1"
+```groovy linenums="1" title="exemplo3.nf"
 canal1 = Channel.value(1)
 println canal1
 ```
 
 ```console
-$ nextflow run exemplo.nf -dsl1
-...
+$ NXF_VER=22.10.4 nextflow run exemplo3.nf -dsl1
+```
+
+Output:
+```console
 DataflowVariable(value=1)
 ```
 

--- a/docs/basic_training/setup.fr.md
+++ b/docs/basic_training/setup.fr.md
@@ -162,11 +162,11 @@ Les dernières versions peuvent être consultées sur GitHub [ici](https://githu
 Si vous souhaitez utiliser une version spécifique de Nextflow, vous pouvez définir la variable `NXF_VER` comme indiqué ci-dessous :
 
 ```bash
-export NXF_VER=22.04.5
+export NXF_VER=23.04.1
 ```
 
 !!! Remarque
 
-    Cet atelier tutoriel nécessite `NXF_VER=22.04.0`, ou une version plus récente. Cette version utilise DSL2 par défaut.
+    Cet atelier tutoriel nécessite `NXF_VER=23.04.1`, ou une version plus récente. Cette version utilise DSL2 par défaut.
 
 Exécutez `nextflow -version` à nouveau pour confirmer que le changement a pris effet.

--- a/docs/basic_training/setup.md
+++ b/docs/basic_training/setup.md
@@ -162,11 +162,11 @@ The latest releases can be viewed on GitHub [here](https://github.com/nextflow-i
 If you want to use a specific version of Nextflow, you can set the `NXF_VER` variable as shown below:
 
 ```bash
-export NXF_VER=22.04.5
+export NXF_VER=23.04.1
 ```
 
 !!! Note
 
-    This tutorial workshop requires `NXF_VER=22.04.0`, or later. This version will use DSL2 as default.
+    This tutorial workshop requires `NXF_VER=23.04.1`, or later. This version will use DSL2 as default.
 
 Run `nextflow -version` again to confirm that the change has taken effect.

--- a/docs/basic_training/setup.pt.md
+++ b/docs/basic_training/setup.pt.md
@@ -162,11 +162,11 @@ Os últimos lançamentos podem ser vistos no GitHub [aqui](https://github.com/ne
 Se você deseja usar uma versão específica do Nextflow, pode definir a variável `NXF_VER` conforme mostrado abaixo:
 
 ```bash
-export NXF_VER=22.04.5
+export NXF_VER=23.04.1
 ```
 
 !!! Note
 
-    Este treinamento requer `NXF_VER=22.04.0`, ou posterior. Esta versão usará a DSL2 como padrão.
+    Este treinamento requer `NXF_VER=23.04.1`, ou posterior. Esta versão usará a DSL2 como padrão.
 
 Execute `nextflow -version` novamente para confirmar que a alteração entrou em vigor.


### PR DESCRIPTION
- [X] Update recommended NXF version for training material
- [X] Fix exception when NXF_VER=22.10.4 must be used for -dsl1
- [X] Sync Portuguese translation of the channels section
- [ ] Update output for 23.04.1
