### PR TITLE
Clarified Explanation in the "Warning" Section of the Process Page

### DIFF
--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -132,7 +132,7 @@ workflow {
 
 !!! warning
 
-    Since Nextflow uses the same Bash syntax for variable substitutions in strings, Bash environment variables need to be escaped using the `\` character. When you use a `\`, the current directory is a directory that Nextflow creates for that specific process (e.g. work/7f/f285b80022d9f61e82cd7f90436aa4/). 
+    Since Nextflow uses the same Bash syntax for variable substitutions in strings, Bash environment variables need to be escaped using the `\` character. When you use a `\`, the $PWD is a directory that Nextflow creates for that specific process (e.g. work/7f/f285b80022d9f61e82cd7f90436aa4/). 
 
 ```groovy linenums="1"
 process FOO {

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -132,7 +132,7 @@ workflow {
 
 !!! warning
 
-    Since Nextflow uses the same Bash syntax for variable substitutions in strings, Bash environment variables need to be escaped using the `\` character.
+    Since Nextflow uses the same Bash syntax for variable substitutions in strings, Bash environment variables need to be escaped using the `\` character. When you use a `\`, the working directory you see is the temporary directory that Nextflow creates for that specific process. However, when you don't use a `\`, the directory you see is the location from which the script was executed.
 
 ```groovy linenums="1"
 process FOO {

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -132,7 +132,7 @@ workflow {
 
 !!! warning
 
-    Since Nextflow uses the same Bash syntax for variable substitutions in strings, Bash environment variables need to be escaped using the `\` character. When you use a `\`, the working directory you see is the temporary directory that Nextflow creates for that specific process. However, when you don't use a `\`, the directory you see is the location from which the script was executed.
+    Since Nextflow uses the same Bash syntax for variable substitutions in strings, Bash environment variables need to be escaped using the `\` character. When you use a `\`, the current directory is a directory that Nextflow creates for that specific process (e.g. work/7f/f285b80022d9f61e82cd7f90436aa4/). 
 
 ```groovy linenums="1"
 process FOO {

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -132,7 +132,7 @@ workflow {
 
 !!! warning
 
-    Since Nextflow uses the same Bash syntax for variable substitutions in strings, Bash environment variables need to be escaped using the `\` character. When you use a `\`, the $PWD is a directory that Nextflow creates for that specific process (e.g. work/7f/f285b80022d9f61e82cd7f90436aa4/). 
+    Since Nextflow uses the same Bash syntax for variable substitutions in strings, Bash environment variables need to be escaped using the `\` character. The escaped version will be resolved later, returning the task directory (e.g. work/7f/f285b80022d9f61e82cd7f90436aa4/), while `$PWD` would show the directory where you're running Nextflow.
 
 ```groovy linenums="1"
 process FOO {

--- a/docs/basic_training/processes.pt.md
+++ b/docs/basic_training/processes.pt.md
@@ -132,7 +132,7 @@ workflow {
 
 !!! warning
 
-    Como o Nextflow usa a mesma sintaxe Bash para substituições de variáveis em strings, as variáveis de ambiente Bash precisam ser escapadas usando o caractere `\`.
+    Como o Nextflow usa a mesma sintaxe Bash para substituições de variáveis em strings, as variáveis de ambiente Bash precisam ser escapadas usando o caractere `\`. A versão escapada será resolvida posteriormente, retornando o diretório da tarefa (por exemplo, work/7f/f285b80022d9f61e82cd7f90436aa4/), enquanto `$PWD` mostraria o diretório onde você está executando o Nextflow.
 
 ```groovy linenums="1"
 process FOO {


### PR DESCRIPTION
In the first Warning section of the "process" page in the "basic train", I made changes to the statement: "**Since Nextflow uses the same Bash syntax for variable substitutions in strings, Bash environment variables need to be escaped using the \ character.**" 
I felt the explanation wasn't very clear, so I added the following content: "**When you use a \, the $PWD is a directory that Nextflow creates for that specific process (e.g. work/7f/f285b80022d9f61e82cd7f90436aa4/).**"