### PR TITLE
A more consistent code style

### DIFF
--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -916,8 +916,8 @@ process FOO {
 
     script:
     """
-    < sample1.fq.gz zcat > sample1.fq
-    < sample2.fq.gz zcat > sample2.fq
+    zcat sample1.fq.gz > sample1.fq
+    zcat sample2.fq.gz > sample2.fq
 
     awk '{s++}END{print s/4}' sample1.fq > sample1_counts.txt
     awk '{s++}END{print s/4}' sample2.fq > sample2_counts.txt

--- a/docs/basic_training/processes.pt.md
+++ b/docs/basic_training/processes.pt.md
@@ -916,8 +916,8 @@ process FOO {
 
     script:
     """
-    < amostra1.fq.gz zcat > amostra1.fq
-    < amostra2.fq.gz zcat > amostra2.fq
+    zcat amostra1.fq.gz > amostra1.fq
+    zcat amostra2.fq.gz > amostra2.fq
 
     awk '{s++}END{print s/4}' amostra1.fq > amostra1_contagens.txt
     awk '{s++}END{print s/4}' amostra2.fq > amostra2_contagens.txt


### PR DESCRIPTION
Instead of **< sample1.fq.gz zcat > sample1.fq**, **using zcat sample1.fq.gz > sample1.fq** is a more common and intuitive method to decompress a gzip file. This approach is more standard and easier to understand.

Using < sample1.fq.gz zcat > sample1.fq is unnecessary and could lead to confusion. In fact, this usage might not work properly in certain cases, as not all versions of zcat support reading from standard input.