### PR TITLE
more clear explanation

### DIFF
--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -220,7 +220,7 @@ This operator is useful to process a group together with all the elements that s
 
 ### `join()`
 
-The `join` operator creates a channel that joins together the items emitted by two channels with a matching key. The key is defined, by default, as the first element in each item emitted.
+The `join` operator creates a channel that joins together the items emitted by two channels with a matching key. The key is defined, by default, as the first element in each item emitted. In the output, items from the 'left' channel always precede the corresponding items from the 'right' channel.
 
 ```groovy linenums="1"
 left = Channel.of(['X', 1], ['Y', 2], ['Z', 3], ['P', 7])


### PR DESCRIPTION
I propose adding a line to clarify this as follows:

In the output, items from the 'left' channel always precede the corresponding items from the 'right' channel."

This would make it clearer for new users and provide a more complete understanding of the function's behavior. Please let me know if this change would be acceptable.