### PR TITLE
Fix mkdocs breaking version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,18 +124,25 @@ plugins:
               - hands_on/index.md
               - hands_on/solutions/*md
     - i18n:
-          default_language: en
+          docs_structure: suffix
+          fallback_to_default: true
           languages:
-              en:
-                  name: English
-                  build: true
-              pt:
-                  name: Português
-                  build: true
-              es:
-                  name: Español
-                  build: true
-              fr:
-                  name: Français
-                  build: true
+            - build: true
+              default: true
+              locale: en
+              name: English
+            - build: true
+              default: false
+              locale: pt
+              name: Português
+            - build: true
+              default: false
+              locale: es
+              name: Español
+            - build: true
+              default: false
+              locale: fr
+              name: Français
+          reconfigure_material: true
+          reconfigure_search: true
     - search

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs
-mkdocs-material
-mkdocs-static-i18n
+mkdocs==1.5.2
+mkdocs-material==9.2.5
+mkdocs-static-i18n==1.0.2
 pymdown-extensions
 pillow
 cairosvg


### PR DESCRIPTION
- Fix mkdocs.yml to the format of the new version of i18n plugin
- Pin versions of mkdoc related python packages
