### PR TITLE
Fix issue on process rnaseq_call_variants not executed at sample level in hands-on training materials

### DIFF
--- a/docs/hands_on/04_implementation.md
+++ b/docs/hands_on/04_implementation.md
@@ -1106,7 +1106,7 @@ The next process has the following structure:
 
     ??? solution
 
-        ```groovy linenums="1" hl_lines="61-70"
+        ```groovy linenums="1" hl_lines="62-71"
         /*
          * Process 5: GATK Variant Calling
          */
@@ -1218,7 +1218,7 @@ You should implement two processes having the following structure:
 
     You must have the output of process 6A become the input of process 6B.
 
-    ```groovy linenums="1" hl_lines="80"
+    ```groovy linenums="1" hl_lines="87"
     /*
      * Processes 6: ASE & RNA Editing
      */
@@ -1314,7 +1314,7 @@ You should implement two processes having the following structure:
     ??? solution
 
 
-        ```groovy linenums="1" hl_lines="81-83"
+        ```groovy linenums="1" hl_lines="87-89"
         /*
          * Processes 6: ASE & RNA Editing
          */
@@ -1439,13 +1439,11 @@ The final step is the GATK ASEReadCounter.
 
     Your aim is to fill in the `BLANKS` below.
 
-    ```groovy linenums="1" hl_lines="3-6"
-    rnaseq_gatk_recalibrate
-        .out
+    ```groovy linenums="1" hl_lines="2-4"
+    recalibrated_samples
         .BLANK // (1)!
-        .BLANK // (2)!
-        .map { BLANK } // (3)!
-        .set { BLANK } // (4)!
+        .map { BLANK } // (2)!
+        .set { BLANK } // (3)!
     ```
 
     1.   an operator that joins two channels taking a key into consideration. See [here](https://www.nextflow.io/docs/latest/operator.html?join#join) for more details
@@ -1454,7 +1452,7 @@ The final step is the GATK ASEReadCounter.
 
     ??? solution
 
-        ```groovy linenums="1" hl_lines="35-38"
+        ```groovy linenums="1" hl_lines="34-36"
         workflow {
             reads_ch = Channel.fromFilePairs(params.reads)
 
@@ -1525,7 +1523,7 @@ The next process has the following structure:
 
     ??? solution
 
-        ```groovy linenums="1" hl_lines="5-29 70-73"
+        ```groovy linenums="1" hl_lines="5-29 74-77"
         /*
          * Processes 7: Allele-Specific Expression analysis with GATK ASEReadCounter
          */

--- a/hands-on/final_main.nf
+++ b/hands-on/final_main.nf
@@ -372,17 +372,22 @@ workflow {
                            rnaseq_gatk_splitNcigar.out,
                            prepare_vcf_file.out)
 
+    // New channel to aggregate bam from different replicates into sample level.
+    rnaseq_gatk_recalibrate.out 
+        | groupTuple
+        | set {sample_bam_ch}
+
     rnaseq_call_variants(params.genome,
                          prepare_genome_samtools.out,
                          prepare_genome_picard.out,
-                         rnaseq_gatk_recalibrate.out)
+                         sample_bam_ch)
 
     post_process_vcf(rnaseq_call_variants.out,
                         prepare_vcf_file.out)
+
     prepare_vcf_for_ase(post_process_vcf.out)
-    rnaseq_gatk_recalibrate
-        .out
-        .groupTuple()
+
+    sample_bam_ch 
         .join(prepare_vcf_for_ase.out.vcf_for_ASE)
         .map { meta, bams, bais, vcf -> [meta, vcf, bams, bais] }
         .set { grouped_vcf_bam_bai_ch }

--- a/hands-on/final_main.nf
+++ b/hands-on/final_main.nf
@@ -373,21 +373,21 @@ workflow {
                            prepare_vcf_file.out)
 
     // New channel to aggregate bam from different replicates into sample level.
-    rnaseq_gatk_recalibrate.out 
+    rnaseq_gatk_recalibrate.out
         | groupTuple
-        | set {sample_bam_ch}
+        | set { relicabrated_samples }
 
     rnaseq_call_variants(params.genome,
                          prepare_genome_samtools.out,
                          prepare_genome_picard.out,
-                         sample_bam_ch)
+                         recalibrated_samples)
 
     post_process_vcf(rnaseq_call_variants.out,
                         prepare_vcf_file.out)
 
     prepare_vcf_for_ase(post_process_vcf.out)
 
-    sample_bam_ch 
+    recalibrated_samples
         .join(prepare_vcf_for_ase.out.vcf_for_ASE)
         .map { meta, bams, bais, vcf -> [meta, vcf, bams, bais] }
         .set { grouped_vcf_bam_bai_ch }

--- a/hands-on/final_main.nf
+++ b/hands-on/final_main.nf
@@ -375,7 +375,7 @@ workflow {
     // New channel to aggregate bam from different replicates into sample level.
     rnaseq_gatk_recalibrate.out
         | groupTuple
-        | set { relicabrated_samples }
+        | set { recalibrated_samples }
 
     rnaseq_call_variants(params.genome,
                          prepare_genome_samtools.out,


### PR DESCRIPTION
Hi,

In the hands-on training, the process `rnaseq_call_variants` is meant to be executed at the sample level (as documented in problem 9 https://training.nextflow.io/hands_on/04_implementation/#process-5-gatk-variant-calling), but instead executed at the replicate level. 

This results in 2 `final.vcf` files produced in 1 sample, and 1 of vcf would be selected and used in the final step (ASE_knownSNPs process).

This error can be spotted in the expected output section (https://training.nextflow.io/hands_on/04_implementation/#bonus-step), where `rnaseq_call_variants ` is executed 6 times but not 3 times.

A fix for this is to do a `groupTuble` on the `rnaseq_gatk_recalibrate.out` channel and before feeding it to `rnaseq_call_variants`
