### PR TITLE
Add -p to mkdir in script blocks

### DIFF
--- a/docs/hands_on/04_implementation.md
+++ b/docs/hands_on/04_implementation.md
@@ -325,7 +325,7 @@ The next process has the following structure:
 
         script:
         """
-        mkdir genome_dir
+        mkdir -p genome_dir
 
         STAR --runMode genomeGenerate \
              --genomeDir genome_dir \
@@ -365,7 +365,7 @@ The next process has the following structure:
 
             script: // (3)!
             """
-            mkdir genome_dir
+            mkdir -p genome_dir
 
             STAR --runMode genomeGenerate \
                  --genomeDir genome_dir \
@@ -570,7 +570,7 @@ The process has the following structure:
              --outFilterMismatchNmax 999
 
         # 2nd pass (improve alignments using table of splice junctions and create a new index)
-        mkdir genomeDir
+        mkdir -p genomeDir
         STAR --runMode genomeGenerate \
              --genomeDir genomeDir \
              --genomeFastaFiles $genome \
@@ -642,7 +642,7 @@ The process has the following structure:
                  --outFilterMismatchNmax 999
 
             # 2nd pass (improve alignments using table of splice junctions and create a new index)
-            mkdir genomeDir
+            mkdir -p genomeDir
             STAR --runMode genomeGenerate \
                  --genomeDir genomeDir \
                  --genomeFastaFiles $genome \

--- a/hands-on/final_main.nf
+++ b/hands-on/final_main.nf
@@ -61,7 +61,7 @@ process prepare_star_genome_index {
 
     script:
     """
-    mkdir genome_dir
+    mkdir -p genome_dir
 
     STAR --runMode genomeGenerate \
          --genomeDir genome_dir \
@@ -124,7 +124,7 @@ process rnaseq_mapping_star {
          --outFilterMismatchNmax 999
 
     # 2nd pass (improve alignments using table of splice junctions and create a new index)
-    mkdir genomeDir
+    mkdir -p genomeDir
     STAR --runMode genomeGenerate \
          --genomeDir genomeDir \
          --genomeFastaFiles $genome \


### PR DESCRIPTION
Depending on how a pipeline is stopped (e.g. CTRL-C), Nextflow
may not have the opportunity to finish things properly, which
will make it attempt to run the task again but on the same path.
If you're trying to use `mkdir` and the folder is already there,
there will be an error and the task will fail. The `-p` will make
mkdir not complain if the folder is already there.
