### PR TITLE
Improve hands-on training

### DIFF
--- a/docs/hands_on/03_setup.md
+++ b/docs/hands_on/03_setup.md
@@ -2,7 +2,7 @@
 
 ## Gitpod
 
-This material intends to be a quick hands-on tutorial on Nextflow, so we prepared a Gitpod environment with everything you need to follow it. Gitpod offers a virtual machine with everything already set up for you, accessible from your web browser or built into your code editor (eg. VSCode). To start, click on the button bellow.
+This material intends to be a quick hands-on tutorial on Nextflow, so we prepared a Gitpod environment with everything you need to follow it. Gitpod offers a virtual machine with everything already set up for you, accessible from your web browser or built into your code editor (eg. VSCode). To start, click on the button below.
 
 [![Open in GitPod](https://img.shields.io/badge/Gitpod-%20Open%20in%20Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/nextflow-io/training)
 

--- a/docs/hands_on/04_implementation.md
+++ b/docs/hands_on/04_implementation.md
@@ -760,7 +760,7 @@ The next process has the following structure:
 
         The GATK command above automatically creates a bam index (`.bai`) of the `split.bam` output file
 
-    !!! example
+    !!! tip
 
         A `tag` line would also be useful in [Process 2](#process-2-star-mapping)
 
@@ -1106,7 +1106,7 @@ The next process has the following structure:
 
     ??? solution
 
-        ```groovy linenums="1" hl_lines="62-71"
+        ```groovy linenums="1" hl_lines="62-72"
         /*
          * Process 5: GATK Variant Calling
          */
@@ -1170,7 +1170,8 @@ The next process has the following structure:
 
             // New channel to aggregate bam from different replicates
             // into sample level.
-            rnaseq_gatk_recalibrate.out
+            rnaseq_gatk_recalibrate
+                .out
                 | groupTuple
                 | set { recalibrated_samples }
 
@@ -1218,7 +1219,7 @@ You should implement two processes having the following structure:
 
     You must have the output of process 6A become the input of process 6B.
 
-    ```groovy linenums="1" hl_lines="87"
+    ```groovy linenums="1" hl_lines="88"
     /*
      * Processes 6: ASE & RNA Editing
      */
@@ -1296,7 +1297,8 @@ You should implement two processes having the following structure:
 
         // New channel to aggregate bam from different replicates
         // into sample level.
-        rnaseq_gatk_recalibrate.out
+        rnaseq_gatk_recalibrate
+            .out
             | groupTuple
             | set { recalibrated_samples }
 
@@ -1314,7 +1316,7 @@ You should implement two processes having the following structure:
     ??? solution
 
 
-        ```groovy linenums="1" hl_lines="87-89"
+        ```groovy linenums="1" hl_lines="88-90"
         /*
          * Processes 6: ASE & RNA Editing
          */
@@ -1392,7 +1394,8 @@ You should implement two processes having the following structure:
 
             // New channel to aggregate bam from different replicates
             // into sample level.
-            rnaseq_gatk_recalibrate.out
+            rnaseq_gatk_recalibrate
+                .out
                 | groupTuple
                 | set { recalibrated_samples }
 
@@ -1452,7 +1455,7 @@ The final step is the GATK ASEReadCounter.
 
     ??? solution
 
-        ```groovy linenums="1" hl_lines="34-36"
+        ```groovy linenums="1" hl_lines="40-42"
         workflow {
             reads_ch = Channel.fromFilePairs(params.reads)
 
@@ -1475,6 +1478,13 @@ The final step is the GATK ASEReadCounter.
                                     prepare_genome_picard.out,
                                     rnaseq_gatk_splitNcigar.out,
                                     prepare_vcf_file.out)
+
+            // New channel to aggregate bam from different replicates
+            // into sample level.
+            rnaseq_gatk_recalibrate
+                .out
+                | groupTuple
+                | set { recalibrated_samples }
 
             rnaseq_call_variants(params.genome,
                                  prepare_genome_samtools.out,
@@ -1523,7 +1533,7 @@ The next process has the following structure:
 
     ??? solution
 
-        ```groovy linenums="1" hl_lines="5-29 74-77"
+        ```groovy linenums="1" hl_lines="5-29 75-78"
         /*
          * Processes 7: Allele-Specific Expression analysis with GATK ASEReadCounter
          */
@@ -1579,7 +1589,8 @@ The next process has the following structure:
 
             // New channel to aggregate bam from different replicates
             // into sample level.
-            rnaseq_gatk_recalibrate.out
+            rnaseq_gatk_recalibrate
+                .out
                 | groupTuple
                 | set { recalibrated_samples }
 

--- a/docs/hands_on/04_implementation.md
+++ b/docs/hands_on/04_implementation.md
@@ -124,7 +124,7 @@ The first process has the following structure:
 
 !!! exercise "Problem #2"
 
-    Copy the code below and paste it at the end of `main.nf`, removing the previous workflow block. Be careful not to accidently have multiple workflow blocks.
+    Copy the code below and paste it at the end of `main.nf`, removing the previous workflow block. Be careful not to accidentally ave multiple workflow blocks.
 
     Your aim is to replace the `BLANK` placeholder with the the correct process call.
 
@@ -609,7 +609,7 @@ The process has the following structure:
 
     !!! info
 
-        The final command produces an bam index which is the full filename with an additional `.bai` suffix.
+        The final command produces a bam index which is the full filename with an additional `.bai` suffix.
 
     ??? solution
 
@@ -1030,7 +1030,7 @@ The next process has the following structure:
 
 !!! exercise "Problem #9"
 
-    Copy the code below and paste it at the end of `main.nf`, removing the previous workflow block. Be careful not to accidently have multiple workflow blocks.
+    Copy the code below and paste it at the end of `main.nf`, removing the previous workflow block. Be careful not to accidentally have multiple workflow blocks.
 
     !!! warning
 
@@ -1430,7 +1430,7 @@ The final step is the GATK ASEReadCounter.
     < sample_id, output.vcf >
     ```
 
-    In the first operation, the BAMs are grouped together by sample id.
+    In the first operation, the BAM files are grouped together by sample id.
 
     Next, this resulting channel is merged with the VCFs having the same sample id.
 

--- a/docs/hands_on/04_implementation.md
+++ b/docs/hands_on/04_implementation.md
@@ -35,10 +35,10 @@ Edit this file to specify the input files as script parameters. Using this notat
  * Define the default parameters (1)
  */
 
-params.genome     = "$baseDir/data/genome.fa" // (2)!
-params.variants   = "$baseDir/data/known_variants.vcf.gz"
-params.blacklist  = "$baseDir/data/blacklist.bed"
-params.reads      = "$baseDir/data/reads/ENCSR000COQ1_{1,2}.fastq.gz" // (3)!
+params.genome     = "${baseDir}/data/genome.fa" // (2)!
+params.variants   = "${baseDir}/data/known_variants.vcf.gz"
+params.blacklist  = "${baseDir}/data/blacklist.bed"
+params.reads      = "${baseDir}/data/reads/ENCSR000COQ1_{1,2}.fastq.gz" // (3)!
 params.results    = "results" // (4)!
 ```
 
@@ -246,7 +246,7 @@ The next process should have the following structure:
 
         script:
         """
-        picard CreateSequenceDictionary R= $genome O= ${genome.baseName}.dict
+        picard CreateSequenceDictionary R= ${genome} O= ${genome.baseName}.dict
         """
     }
 
@@ -280,7 +280,7 @@ The next process should have the following structure:
 
             script:
             """
-            picard CreateSequenceDictionary R= $genome O= ${genome.baseName}.dict
+            picard CreateSequenceDictionary R= ${genome} O= ${genome.baseName}.dict
             """
         }
 
@@ -430,7 +430,7 @@ The next process has the following structure:
 
         script:
         """
-        vcftools --gzvcf $variantsFile -c \
+        vcftools --gzvcf ${variantsFile} -c \
                  --exclude-bed ${blacklisted} \
                  --recode | bgzip -c \
                  > ${variantsFile.baseName}.filtered.recode.vcf.gz
@@ -453,7 +453,7 @@ The next process has the following structure:
     Broken down, here is what the script is doing:
 
     ```bash
-    vcftools --gzvcf $variantsFile -c \ # (1)!
+    vcftools --gzvcf ${variantsFile} -c \ # (1)!
              --exclude-bed ${blacklisted} \ # (2)!
              --recode | bgzip -c \
              > ${variantsFile.baseName}.filtered.recode.vcf.gz # (3)!
@@ -461,8 +461,8 @@ The next process has the following structure:
     tabix ${variantsFile.baseName}.filtered.recode.vcf.gz # (4)!
     ```
 
-    1.   The `$variantsFile` variable contains the path to the file with the known variants
-    2.   The `$blacklisted` variable contains the path to the file with the genomic locations which are known to produce artifacts and spurious variants
+    1.   The `variantsFile` variable contains the path to the file with the known variants
+    2.   The `blacklisted` variable contains the path to the file with the genomic locations which are known to produce artifacts and spurious variants
     3.   The `>` symbol is used to redirect the output to the file specified after it
     4.   `tabix` is used here to create the second output that we want to consider from this process
 
@@ -492,7 +492,7 @@ The next process has the following structure:
 
             script:
             """
-            vcftools --gzvcf $variantsFile -c \
+            vcftools --gzvcf ${variantsFile} -c \
                      --exclude-bed ${blacklisted} \
                      --recode | bgzip -c \
                      > ${variantsFile.baseName}.filtered.recode.vcf.gz
@@ -560,8 +560,8 @@ The process has the following structure:
         script:
         """
         # ngs-nf-dev Align reads to genome
-        STAR --genomeDir $genomeDir \
-             --readFilesIn $reads \
+        STAR --genomeDir ${genomeDir} \
+             --readFilesIn ${reads} \
              --runThreadN ${task.cpus} \
              --readFilesCommand zcat \
              --outFilterType BySJout \
@@ -573,14 +573,14 @@ The process has the following structure:
         mkdir genomeDir
         STAR --runMode genomeGenerate \
              --genomeDir genomeDir \
-             --genomeFastaFiles $genome \
+             --genomeFastaFiles ${genome} \
              --sjdbFileChrStartEnd SJ.out.tab \
              --sjdbOverhang 75 \
              --runThreadN ${task.cpus}
 
         # Final read alignments
         STAR --genomeDir genomeDir \
-             --readFilesIn $reads \
+             --readFilesIn ${reads} \
              --runThreadN ${task.cpus} \
              --readFilesCommand zcat \
              --outFilterType BySJout \
@@ -588,7 +588,7 @@ The process has the following structure:
              --alignSJDBoverhangMin 1 \
              --outFilterMismatchNmax 999 \
              --outSAMtype BAM SortedByCoordinate \
-             --outSAMattrRGline ID:$replicateId LB:library PL:illumina PU:machine SM:GM12878
+             --outSAMattrRGline ID:${replicateId} LB:library PL:illumina PU:machine SM:GM12878
 
         # Index the BAM file
         samtools index Aligned.sortedByCoord.out.bam
@@ -632,8 +632,8 @@ The process has the following structure:
             script:
             """
             # ngs-nf-dev Align reads to genome
-            STAR --genomeDir $genomeDir \
-                 --readFilesIn $reads \
+            STAR --genomeDir ${genomeDir} \
+                 --readFilesIn ${reads} \
                  --runThreadN ${task.cpus} \
                  --readFilesCommand zcat \
                  --outFilterType BySJout \
@@ -645,14 +645,14 @@ The process has the following structure:
             mkdir genomeDir
             STAR --runMode genomeGenerate \
                  --genomeDir genomeDir \
-                 --genomeFastaFiles $genome \
+                 --genomeFastaFiles ${genome} \
                  --sjdbFileChrStartEnd SJ.out.tab \
                  --sjdbOverhang 75 \
                  --runThreadN ${task.cpus}
 
             # Final read alignments
             STAR --genomeDir genomeDir \
-                 --readFilesIn $reads \
+                 --readFilesIn ${reads} \
                  --runThreadN ${task.cpus} \
                  --readFilesCommand zcat \
                  --outFilterType BySJout \
@@ -660,7 +660,7 @@ The process has the following structure:
                  --alignSJDBoverhangMin 1 \
                  --outFilterMismatchNmax 999 \
                  --outSAMtype BAM SortedByCoordinate \
-                 --outSAMattrRGline ID:$replicateId LB:library PL:illumina PU:machine SM:GM12878
+                 --outSAMattrRGline ID:${replicateId} LB:library PL:illumina PU:machine SM:GM12878
 
             # Index the BAM file
             samtools index Aligned.sortedByCoord.out.bam
@@ -716,7 +716,7 @@ The next process has the following structure:
 
     process rnaseq_gatk_splitNcigar {
         container 'quay.io/broadinstitute/gotc-prod-gatk:1.0.0-4.1.8.0-1626439571'
-        tag "$replicateId"
+        tag "${replicateId}"
 
         input:
         path genome
@@ -731,7 +731,7 @@ The next process has the following structure:
         """
         # SplitNCigarReads and reassign mapping qualities
         java -jar /usr/gitc/GATK35.jar -T SplitNCigarReads \
-                                       -R $genome -I $bam \
+                                       -R ${genome} -I ${bam} \
                                        -o split.bam \
                                        -rf ReassignOneMappingQuality \
                                        -RMQF 255 -RMQT 60 \
@@ -774,7 +774,7 @@ The next process has the following structure:
 
         process rnaseq_gatk_splitNcigar {
             container 'quay.io/broadinstitute/gotc-prod-gatk:1.0.0-4.1.8.0-1626439571'
-            tag "$replicateId"
+            tag "${replicateId}"
 
             input:
             path genome
@@ -789,7 +789,7 @@ The next process has the following structure:
             """
             # SplitNCigarReads and reassign mapping qualities
             java -jar /usr/gitc/GATK35.jar -T SplitNCigarReads \
-                                           -R $genome -I $bam \
+                                           -R ${genome} -I ${bam} \
                                            -o split.bam \
                                            -rf ReassignOneMappingQuality \
                                            -RMQF 255 -RMQT 60 \
@@ -858,7 +858,7 @@ The next process has the following structure:
 
     process rnaseq_gatk_recalibrate {
         container 'quay.io/biocontainers/mulled-v2-aa1d7bddaee5eb6c4cbab18f8a072e3ea7ec3969:f963c36fd770e89d267eeaa27cad95c1c3dbe660-0'
-        tag "$replicateId"
+        tag "${replicateId}"
 
         input:
         path genome
@@ -922,9 +922,6 @@ The next process has the following structure:
     }
     ```
 
-    -   The unique bam file
-    -   The index of the unique bam file (bam file name + `.bai`)
-
     ??? solution
 
 
@@ -935,7 +932,7 @@ The next process has the following structure:
 
         process rnaseq_gatk_recalibrate {
             container 'quay.io/biocontainers/mulled-v2-aa1d7bddaee5eb6c4cbab18f8a072e3ea7ec3969:f963c36fd770e89d267eeaa27cad95c1c3dbe660-0'
-            tag "$replicateId"
+            tag "${replicateId}"
 
             input:
             path genome
@@ -1045,7 +1042,7 @@ The next process has the following structure:
 
     process rnaseq_call_variants {
         container 'quay.io/broadinstitute/gotc-prod-gatk:1.0.0-4.1.8.0-1626439571'
-        tag "$sampleId"
+        tag "${sampleId}"
 
         input:
         path genome
@@ -1062,14 +1059,14 @@ The next process has the following structure:
 
         # Variant calling
         java -jar /usr/gitc/GATK35.jar -T HaplotypeCaller \
-                                       -R $genome -I bam.list \
+                                       -R ${genome} -I bam.list \
                                        -dontUseSoftClippedBases \
                                        -stand_call_conf 20.0 \
                                        -o output.gatk.vcf.gz
 
         # Variant filtering
         java -jar /usr/gitc/GATK35.jar -T VariantFiltration \
-                                       -R $genome -V output.gatk.vcf.gz \
+                                       -R ${genome} -V output.gatk.vcf.gz \
                                        -window 35 -cluster 3 \
                                        -filterName FS -filter "FS > 30.0" \
                                        -filterName QD -filter "QD < 2.0" \
@@ -1113,7 +1110,7 @@ The next process has the following structure:
 
         process rnaseq_call_variants {
             container 'quay.io/broadinstitute/gotc-prod-gatk:1.0.0-4.1.8.0-1626439571'
-            tag "$sampleId"
+            tag "${sampleId}"
 
             input:
             path genome
@@ -1130,14 +1127,14 @@ The next process has the following structure:
 
             # Variant calling
             java -jar /usr/gitc/GATK35.jar -T HaplotypeCaller \
-                                           -R $genome -I bam.list \
+                                           -R ${genome} -I bam.list \
                                            -dontUseSoftClippedBases \
                                            -stand_call_conf 20.0 \
                                            -o output.gatk.vcf.gz
 
             # Variant filtering
             java -jar /usr/gitc/GATK35.jar -T VariantFiltration \
-                                           -R $genome -V output.gatk.vcf.gz \
+                                           -R ${genome} -V output.gatk.vcf.gz \
                                            -window 35 -cluster 3 \
                                            -filterName FS -filter "FS > 30.0" \
                                            -filterName QD -filter "QD < 2.0" \
@@ -1226,8 +1223,8 @@ You should implement two processes having the following structure:
 
     process post_process_vcf {
         container 'quay.io/biocontainers/mulled-v2-b9358559e3ae3b9d7d8dbf1f401ae1fcaf757de3:ac05763cf181a5070c2fdb9bb5461f8d08f7b93b-0'
-        tag "$sampleId"
-        publishDir "$params.results/$sampleId" // (1)!
+        tag "${sampleId}"
+        publishDir "${params.results}/${sampleId}" // (1)!
 
         input:
         tuple val(sampleId), path('final.vcf')
@@ -1246,8 +1243,8 @@ You should implement two processes having the following structure:
 
     process prepare_vcf_for_ase {
         container 'cbcrg/callings-with-gatk:latest'
-        tag "$sampleId"
-        publishDir "$params.results/$sampleId"
+        tag "${sampleId}"
+        publishDir "${params.results}/${sampleId}"
 
         input:
         tuple val(sampleId), path('final.vcf'), path('commonSNPs.diff.sites_in_files')
@@ -1323,8 +1320,8 @@ You should implement two processes having the following structure:
 
         process post_process_vcf {
             container 'quay.io/biocontainers/mulled-v2-b9358559e3ae3b9d7d8dbf1f401ae1fcaf757de3:ac05763cf181a5070c2fdb9bb5461f8d08f7b93b-0'
-            tag "$sampleId"
-            publishDir "$params.results/$sampleId"
+            tag "${sampleId}"
+            publishDir "${params.results}/${sampleId}"
 
             input:
             tuple val(sampleId), path('final.vcf')
@@ -1343,8 +1340,8 @@ You should implement two processes having the following structure:
 
         process prepare_vcf_for_ase {
             container 'cbcrg/callings-with-gatk:latest'
-            tag "$sampleId"
-            publishDir "$params.results/$sampleId"
+            tag "${sampleId}"
+            publishDir "${params.results}/${sampleId}"
 
             input:
             tuple val(sampleId), path('final.vcf'), path('commonSNPs.diff.sites_in_files')
@@ -1540,8 +1537,8 @@ The next process has the following structure:
 
         process ASE_knownSNPs {
             container 'quay.io/broadinstitute/gotc-prod-gatk:1.0.0-4.1.8.0-1626439571'
-            tag "$sampleId"
-            publishDir "$params.results/$sampleId"
+            tag "${sampleId}"
+            publishDir "${params.results}/${sampleId}"
 
             input:
             path genome

--- a/docs/hands_on/04_implementation.md
+++ b/docs/hands_on/04_implementation.md
@@ -1418,7 +1418,7 @@ The final step is the GATK ASEReadCounter.
 
     Before we perform the GATK ASEReadCounter process, we must group the data for allele-specific expression. To do this we must combine channels.
 
-    The `bam_for_ASE_ch` channel emites tuples having the following structure, holding the final BAM/BAI files:
+    The output channel of the `rnaseq_gatk_recalibrate` process (`rnaseq_gatk_recalibrate.out`) emites tuples having the following structure, holding the final BAM/BAI files:
 
     ```bash
     < sample_id, file_bam, file_bai >

--- a/docs/hands_on/04_implementation.md
+++ b/docs/hands_on/04_implementation.md
@@ -425,7 +425,7 @@ The next process has the following structure:
         path blacklisted
 
         output:
-        tuple path("${variantsFile.baseName}.filtered.recode.vcf.gz"), \
+        tuple path("${variantsFile.baseName}.filtered.recode.vcf.gz"),
               path("${variantsFile.baseName}.filtered.recode.vcf.gz.tbi")
 
         script:
@@ -483,12 +483,12 @@ The next process has the following structure:
             container 'quay.io/biocontainers/mulled-v2-b9358559e3ae3b9d7d8dbf1f401ae1fcaf757de3:ac05763cf181a5070c2fdb9bb5461f8d08f7b93b-0'
 
             input:
-            path variantsFile
-            path blacklisted
+            path variantsFile // (1)!
+            path blacklisted // (2)!
 
-            output:
-            tuple path("${variantsFile.baseName}.filtered.recode.vcf.gz"), \
-                  path("${variantsFile.baseName}.filtered.recode.vcf.gz.tbi")
+            output: // (3)!
+            tuple path("${variantsFile.baseName}.filtered.recode.vcf.gz"), // (4)!
+                  path("${variantsFile.baseName}.filtered.recode.vcf.gz.tbi") // (5)!
 
             script:
             """
@@ -511,11 +511,11 @@ The next process has the following structure:
         }
         ```
 
-        - Take as input the variants file, assigning the name `${variantsFile}`.
-        - Take as input the blacklisted file, assigning the name `${blacklisted}`.
-        - Out a tuple of two files
-        - Defines the name of the first output file.
-        - Generates the second output file (with `.tbi` suffix).
+        1. Take as input the variants file, assigning the name `variantsFile`.
+        2. Take as input the blacklisted file, assigning the name `blacklisted`.
+        3. Out a tuple of two files
+        4. Defines the name of the first output file.
+        5. Generates the second output file (with `.tbi` suffix).
 
 Congratulations! Part 1 is now complete.
 
@@ -541,7 +541,7 @@ The process has the following structure:
 
     You must fill the `BLANK` space with the correct process call and inputs.
 
-    ```groovy linenums="1" hl_lines="62"
+    ```groovy linenums="1" hl_lines="66"
     /*
      * Process 2: Align RNA-Seq reads to the genome with STAR
      */
@@ -555,7 +555,9 @@ The process has the following structure:
         tuple val(replicateId), path(reads)
 
         output:
-        tuple val(replicateId), path('Aligned.sortedByCoord.out.bam'), path('Aligned.sortedByCoord.out.bam.bai')
+        tuple val(replicateId),
+              path('Aligned.sortedByCoord.out.bam'),
+              path('Aligned.sortedByCoord.out.bam.bai')
 
         script:
         """
@@ -569,7 +571,8 @@ The process has the following structure:
              --alignSJDBoverhangMin 1 \
              --outFilterMismatchNmax 999
 
-        # 2nd pass (improve alignments using table of splice junctions and create a new index)
+        # 2nd pass (improve alignments using table of splice
+        # junctions and create a new index)
         mkdir genomeDir
         STAR --runMode genomeGenerate \
              --genomeDir genomeDir \
@@ -588,7 +591,8 @@ The process has the following structure:
              --alignSJDBoverhangMin 1 \
              --outFilterMismatchNmax 999 \
              --outSAMtype BAM SortedByCoordinate \
-             --outSAMattrRGline ID:${replicateId} LB:library PL:illumina PU:machine SM:GM12878
+             --outSAMattrRGline ID:${replicateId} LB:library PL:illumina \
+                                PU:machine SM:GM12878
 
         # Index the BAM file
         samtools index Aligned.sortedByCoord.out.bam
@@ -613,7 +617,7 @@ The process has the following structure:
 
     ??? solution
 
-        ```groovy linenums="1" hl_lines="62-64"
+        ```groovy linenums="1" hl_lines="66-68"
         /*
          * Process 2: Align RNA-Seq reads to the genome with STAR
          */
@@ -627,7 +631,9 @@ The process has the following structure:
             tuple val(replicateId), path(reads)
 
             output:
-            tuple val(replicateId), path('Aligned.sortedByCoord.out.bam'), path('Aligned.sortedByCoord.out.bam.bai')
+            tuple val(replicateId),
+                  path('Aligned.sortedByCoord.out.bam'),
+                  path('Aligned.sortedByCoord.out.bam.bai')
 
             script:
             """
@@ -641,7 +647,8 @@ The process has the following structure:
                  --alignSJDBoverhangMin 1 \
                  --outFilterMismatchNmax 999
 
-            # 2nd pass (improve alignments using table of splice junctions and create a new index)
+            # 2nd pass (improve alignments using table of splice
+            # junctions and create a new index)
             mkdir genomeDir
             STAR --runMode genomeGenerate \
                  --genomeDir genomeDir \
@@ -660,7 +667,8 @@ The process has the following structure:
                  --alignSJDBoverhangMin 1 \
                  --outFilterMismatchNmax 999 \
                  --outSAMtype BAM SortedByCoordinate \
-                 --outSAMattrRGline ID:${replicateId} LB:library PL:illumina PU:machine SM:GM12878
+                 --outSAMattrRGline ID:${replicateId} LB:library PL:illumina \
+                                    PU:machine SM:GM12878
 
             # Index the BAM file
             samtools index Aligned.sortedByCoord.out.bam
@@ -777,13 +785,13 @@ The next process has the following structure:
             tag "${replicateId}"
 
             input:
-            path genome
-            path index
-            path genome_dict
-            tuple val(replicateId), path(bam), path(bai)
+            path genome // (2)!
+            path index // (3)!
+            path genome_dict // (4)!
+            tuple val(replicateId), path(bam), path(bai) // (5)!
 
             output:
-            tuple val(replicateId), path('split.bam'), path('split.bai')
+            tuple val(replicateId), path('split.bam'), path('split.bai') // (6)!
 
             script:
             """
@@ -818,14 +826,14 @@ The next process has the following structure:
         }
         ```
 
-        - [`tag`](https://www.nextflow.io/docs/latest/process.html#tag) line using the replicate id as the tag.
-        - the genome fasta file
-        - the genome index in the output channel from the `prepare_genome_samtools` process
-        - the genome dictionary in the output channel from the `prepare_genome_picard` process
-        - the set containing the aligned reads in the output channel from the `rnaseq_mapping_star` process
-        - a set containing the sample id, the split bam file and the split bam index
-        - specifies the input file names `$genome` and `$bam` to GATK
-        - specifies the output file names to GATK
+        1. [`tag`](https://www.nextflow.io/docs/latest/process.html#tag) line using the replicate id as the tag.
+        2. the genome fasta file
+        3. the genome index in the output channel from the `prepare_genome_samtools` process
+        4. the genome dictionary in the output channel from the `prepare_genome_picard` process
+        5. the tuple containing the aligned reads in the output channel from the `rnaseq_mapping_star` process
+        6. a tuple containing the sample id, the split bam file and the split bam index
+        7. specifies the input file names `genome` and `bam` to GATK
+        8. specifies the output file names to GATK
 
 Next we perform a Base Quality Score Recalibration step using GATK.
 
@@ -851,7 +859,7 @@ The next process has the following structure:
 
     Your aim is to replace the `BLANK` placeholder with the the correct process call.
 
-    ```groovy linenums="1" hl_lines="67"
+    ```groovy linenums="1" hl_lines="69"
     /*
      * Process 4: GATK Recalibrate
      */
@@ -868,7 +876,9 @@ The next process has the following structure:
         tuple path(prepared_variants_file), path(prepared_variants_file_index)
 
         output:
-        tuple val(sampleId), path("${replicateId}.final.uniq.bam"), path("${replicateId}.final.uniq.bam.bai")
+        tuple val(sampleId),
+              path("${replicateId}.final.uniq.bam"),
+              path("${replicateId}.final.uniq.bam.bai")
 
         script:
         sampleId = replicateId.replaceAll(/[12]$/,'')
@@ -893,8 +903,8 @@ The next process has the following structure:
               -o final.bam
 
         # Select only unique alignments, no multimaps
-        (samtools view -H final.bam; samtools view final.bam| grep -w 'NH:i:1') \
-        |samtools view -Sb -  > ${replicateId}.final.uniq.bam
+        (samtools view -H final.bam; samtools view final.bam | \
+        grep -w 'NH:i:1') | samtools view -Sb -  > ${replicateId}.final.uniq.bam
 
         # Index BAM files
         samtools index ${replicateId}.final.uniq.bam
@@ -925,7 +935,7 @@ The next process has the following structure:
     ??? solution
 
 
-        ```groovy linenums="1" hl_lines="67-71"
+        ```groovy linenums="1" hl_lines="70-74"
         /*
          * Process 4: GATK Recalibrate
          */
@@ -935,17 +945,20 @@ The next process has the following structure:
             tag "${replicateId}"
 
             input:
-            path genome
-            path index
-            path dict
-            tuple val(replicateId), path(bam), path(bai)
-            tuple path(prepared_variants_file), path(prepared_variants_file_index)
+            path genome // (1)!
+            path index // (2)!
+            path dict // (3)!
+            tuple val(replicateId), path(bam), path(bai) // (4)!
+            tuple path(prepared_variants_file), // (5)!
+                  path(prepared_variants_file_index)
 
-            output:
-            tuple val(sampleId), path("${replicateId}.final.uniq.bam"), path("${replicateId}.final.uniq.bam.bai")
+            output: // (6)!
+            tuple val(sampleId),
+                  path("${replicateId}.final.uniq.bam"),
+                  path("${replicateId}.final.uniq.bam.bai")
 
             script:
-            sampleId = replicateId.replaceAll(/[12]$/,'')
+            sampleId = replicateId.replaceAll(/[12]$/,'') // (7)!
             """
             # Indel Realignment and Base Recalibration
             gatk3 -T BaseRecalibrator \
@@ -967,8 +980,8 @@ The next process has the following structure:
                   -o final.bam
 
             # Select only unique alignments, no multimaps
-            (samtools view -H final.bam; samtools view final.bam| grep -w 'NH:i:1') \
-            |samtools view -Sb -  > ${replicateId}.final.uniq.bam
+            (samtools view -H final.bam; samtools view final.bam | \
+            grep -w 'NH:i:1') | samtools view -Sb -  > ${replicateId}.final.uniq.bam
 
             # Index BAM files
             samtools index ${replicateId}.final.uniq.bam
@@ -1000,13 +1013,13 @@ The next process has the following structure:
         }
         ```
 
-        - the genome fasta file.
-        - the genome index in the output channel from the `prepare_genome_samtools` process.
-        - the genome dictionary in the output channel from the `prepare_genome_picard` process.
-        - the set containing the split reads in the output channel from the `rnaseq_gatk_splitNcigar` process.
-        - the set containing the filtered/recoded VCF file and the tab index (TBI) file in the output channel from the `prepare_vcf_file` process.
-        - the set containing the replicate id, the unique bam file and the unique bam index file which goes into two channels.
-        - line specifying the filename of the output bam file
+        1. the genome fasta file.
+        2. the genome index in the output channel from the `prepare_genome_samtools` process.
+        3. the genome dictionary in the output channel from the `prepare_genome_picard` process.
+        4. the tupe containing the split reads in the output channel from the `rnaseq_gatk_splitNcigar` process.
+        5. the tuple containing the filtered/recoded VCF file and the tab index (TBI) file in the output channel from the `prepare_vcf_file` process.
+        6. the tuple containing the replicate id, the unique bam file and the unique bam index file which goes into two channels.
+        7. line specifying the filename of the output bam file
 
 Now we are ready to perform the variant calling with GATK.
 
@@ -1110,16 +1123,16 @@ The next process has the following structure:
 
         process rnaseq_call_variants {
             container 'quay.io/broadinstitute/gotc-prod-gatk:1.0.0-4.1.8.0-1626439571'
-            tag "${sampleId}"
+            tag "${sampleId}" // (1)!
 
             input:
-            path genome
-            path index
-            path dict
-            tuple val(sampleId), path(bam), path(bai)
+            path genome // (2)!
+            path index // (3)!
+            path dict // (4)!
+            tuple val(sampleId), path(bam), path(bai) // (5)!
 
             output:
-            tuple val(sampleId), path('final.vcf')
+            tuple val(sampleId), path('final.vcf') // (6)!
 
             script:
             """
@@ -1165,12 +1178,10 @@ The next process has the following structure:
                                     rnaseq_gatk_splitNcigar.out,
                                     prepare_vcf_file.out)
 
-            // New channel to aggregate bam from different replicates
-            // into sample level.
             rnaseq_gatk_recalibrate
                 .out
                 | groupTuple
-                | set { recalibrated_samples }
+                | set { recalibrated_samples } // (7)!
 
             rnaseq_call_variants(params.genome,
                                  prepare_genome_samtools.out,
@@ -1179,13 +1190,13 @@ The next process has the following structure:
         }
         ```
 
-        -   [`tag`](https://www.nextflow.io/docs/latest/process.html#tag) line with the using the sample id as the tag.
-        -   the genome fasta file.
-        -   the genome index in the output channel from the `prepare_genome_samtools` process.
-        -   the genome dictionary in the output channel from the `prepare_genome_picard` process.
-        -   the sets grouped by sampleID in the output channel from the `rnaseq_gatk_recalibrate` process.
-        -   the set containing the sample ID and final VCF file.
-        -   the line specifying the name resulting final VCF file.
+        1.   [`tag`](https://www.nextflow.io/docs/latest/process.html#tag) line with the using the sample id as the tag.
+        2.   the genome fasta file.
+        3.   the genome index in the output channel from the `prepare_genome_samtools` process.
+        4.   the genome dictionary in the output channel from the `prepare_genome_picard` process.
+        5.   the tuples grouped by sampleID in the output channel from the `rnaseq_gatk_recalibrate` process.
+        6.   the tuple containing the sample ID and final VCF file.
+        7.   new channel to aggregate the `bam` files from different replicates into sample level.
 
 ## Processes 6A and 6B: ASE & RNA Editing
 
@@ -1216,7 +1227,7 @@ You should implement two processes having the following structure:
 
     You must have the output of process 6A become the input of process 6B.
 
-    ```groovy linenums="1" hl_lines="88"
+    ```groovy linenums="1" hl_lines="96"
     /*
      * Processes 6: ASE & RNA Editing
      */
@@ -1228,16 +1239,22 @@ You should implement two processes having the following structure:
 
         input:
         tuple val(sampleId), path('final.vcf')
-        tuple path('filtered.recode.vcf.gz'), path('filtered.recode.vcf.gz.tbi')
+        tuple path('filtered.recode.vcf.gz'),
+              path('filtered.recode.vcf.gz.tbi')
 
         output:
-        tuple val(sampleId), path('final.vcf'), path('commonSNPs.diff.sites_in_files')
+        tuple val(sampleId),
+              path('final.vcf'),
+              path('commonSNPs.diff.sites_in_files')
 
         script:
         '''
-        grep -v '#' final.vcf | awk '$7~/PASS/' |perl -ne 'chomp($_); ($dp)=$_=~/DP\\=(\\d+)\\;/; if($dp>=8){print $_."\\n"};' > result.DP8.vcf
+        grep -v '#' final.vcf | awk '$7~/PASS/' | perl -ne 'chomp($_); \
+             ($dp)=$_=~/DP\\=(\\d+)\\;/; if($dp>=8){print $_."\\n"};' \
+             > result.DP8.vcf
 
-        vcftools --vcf result.DP8.vcf --gzdiff filtered.recode.vcf.gz  --diff-site --out commonSNPs
+        vcftools --vcf result.DP8.vcf --gzdiff filtered.recode.vcf.gz \
+                 --diff-site --out commonSNPs
         '''
     }
 
@@ -1247,22 +1264,26 @@ You should implement two processes having the following structure:
         publishDir "${params.results}/${sampleId}"
 
         input:
-        tuple val(sampleId), path('final.vcf'), path('commonSNPs.diff.sites_in_files')
+        tuple val(sampleId),
+              path('final.vcf'),
+              path('commonSNPs.diff.sites_in_files')
 
         output:
         tuple val(sampleId), path('known_snps.vcf'), emit: vcf_for_ASE
-        path 'AF.histogram.pdf'                    , emit: gghist_pdfs
+        path 'AF.histogram.pdf'     , emit: gghist_pdfs
 
         script:
         '''
-        awk 'BEGIN{OFS="\t"} $4~/B/{print $1,$2,$3}' commonSNPs.diff.sites_in_files  > test.bed
+        awk 'BEGIN{OFS="\t"} $4~/B/{print $1,$2,$3}' \
+            commonSNPs.diff.sites_in_files  > test.bed
 
-        vcftools --vcf final.vcf --bed test.bed --recode --keep-INFO-all --stdout > known_snps.vcf
+        vcftools --vcf final.vcf --bed test.bed --recode --keep-INFO-all \
+                 --stdout > known_snps.vcf
 
         grep -v '#'  known_snps.vcf | awk -F '\\t' '{print $10}' \
-                    |awk -F ':' '{print $2}'|perl -ne 'chomp($_); \
+                    | awk -F ':' '{print $2}' | perl -ne 'chomp($_); \
                     @v=split(/\\,/,$_); if($v[0]!=0 ||$v[1] !=0)\
-                    {print  $v[1]/($v[1]+$v[0])."\\n"; }' |awk '$1!=1' \
+                    {print  $v[1]/($v[1]+$v[0])."\\n"; }' | awk '$1!=1' \
                     >AF.4R
 
         gghist.R -i AF.4R -o AF.histogram.pdf
@@ -1292,8 +1313,6 @@ You should implement two processes having the following structure:
                                 rnaseq_gatk_splitNcigar.out,
                                 prepare_vcf_file.out)
 
-        // New channel to aggregate bam from different replicates
-        // into sample level.
         rnaseq_gatk_recalibrate
             .out
             | groupTuple
@@ -1313,7 +1332,7 @@ You should implement two processes having the following structure:
     ??? solution
 
 
-        ```groovy linenums="1" hl_lines="88-90"
+        ```groovy linenums="1" hl_lines="96-98"
         /*
          * Processes 6: ASE & RNA Editing
          */
@@ -1325,16 +1344,22 @@ You should implement two processes having the following structure:
 
             input:
             tuple val(sampleId), path('final.vcf')
-            tuple path('filtered.recode.vcf.gz'), path('filtered.recode.vcf.gz.tbi')
+            tuple path('filtered.recode.vcf.gz'),
+                  path('filtered.recode.vcf.gz.tbi')
 
             output:
-            tuple val(sampleId), path('final.vcf'), path('commonSNPs.diff.sites_in_files')
+            tuple val(sampleId),
+                  path('final.vcf'),
+                  path('commonSNPs.diff.sites_in_files')
 
             script:
             '''
-            grep -v '#' final.vcf | awk '$7~/PASS/' |perl -ne 'chomp($_); ($dp)=$_=~/DP\\=(\\d+)\\;/; if($dp>=8){print $_."\\n"};' > result.DP8.vcf
+            grep -v '#' final.vcf | awk '$7~/PASS/' | perl -ne 'chomp($_); \
+                    ($dp)=$_=~/DP\\=(\\d+)\\;/; if($dp>=8){print $_."\\n"};' \
+                    > result.DP8.vcf
 
-            vcftools --vcf result.DP8.vcf --gzdiff filtered.recode.vcf.gz  --diff-site --out commonSNPs
+            vcftools --vcf result.DP8.vcf --gzdiff filtered.recode.vcf.gz \
+                     --diff-site --out commonSNPs
             '''
         }
 
@@ -1344,7 +1369,9 @@ You should implement two processes having the following structure:
             publishDir "${params.results}/${sampleId}"
 
             input:
-            tuple val(sampleId), path('final.vcf'), path('commonSNPs.diff.sites_in_files')
+            tuple val(sampleId),
+                  path('final.vcf'),
+                  path('commonSNPs.diff.sites_in_files')
 
             output:
             tuple val(sampleId), path('known_snps.vcf'), emit: vcf_for_ASE
@@ -1352,14 +1379,16 @@ You should implement two processes having the following structure:
 
             script:
             '''
-            awk 'BEGIN{OFS="\t"} $4~/B/{print $1,$2,$3}' commonSNPs.diff.sites_in_files  > test.bed
+            awk 'BEGIN{OFS="\t"} $4~/B/{print $1,$2,$3}' \
+                commonSNPs.diff.sites_in_files  > test.bed
 
-            vcftools --vcf final.vcf --bed test.bed --recode --keep-INFO-all --stdout > known_snps.vcf
+            vcftools --vcf final.vcf --bed test.bed --recode --keep-INFO-all \
+                     --stdout > known_snps.vcf
 
             grep -v '#'  known_snps.vcf | awk -F '\\t' '{print $10}' \
-                        |awk -F ':' '{print $2}'|perl -ne 'chomp($_); \
+                        | awk -F ':' '{print $2}' | perl -ne 'chomp($_); \
                         @v=split(/\\,/,$_); if($v[0]!=0 ||$v[1] !=0)\
-                        {print  $v[1]/($v[1]+$v[0])."\\n"; }' |awk '$1!=1' \
+                        {print  $v[1]/($v[1]+$v[0])."\\n"; }' | awk '$1!=1' \
                         >AF.4R
 
             gghist.R -i AF.4R -o AF.histogram.pdf
@@ -1389,8 +1418,6 @@ You should implement two processes having the following structure:
                                     rnaseq_gatk_splitNcigar.out,
                                     prepare_vcf_file.out)
 
-            // New channel to aggregate bam from different replicates
-            // into sample level.
             rnaseq_gatk_recalibrate
                 .out
                 | groupTuple
@@ -1452,7 +1479,7 @@ The final step is the GATK ASEReadCounter.
 
     ??? solution
 
-        ```groovy linenums="1" hl_lines="41-43"
+        ```groovy linenums="1" hl_lines="38-41"
         workflow {
             reads_ch = Channel.fromFilePairs(params.reads)
 
@@ -1476,8 +1503,6 @@ The final step is the GATK ASEReadCounter.
                                     rnaseq_gatk_splitNcigar.out,
                                     prepare_vcf_file.out)
 
-            // New channel to aggregate bam from different replicates
-            // into sample level.
             rnaseq_gatk_recalibrate
                 .out
                 | groupTuple
@@ -1530,7 +1555,7 @@ The next process has the following structure:
 
     ??? solution
 
-        ```groovy linenums="1" hl_lines="5-29 75-78"
+        ```groovy linenums="1" hl_lines="5-29 73-76"
         /*
          * Processes 7: Allele-Specific Expression analysis with GATK ASEReadCounter
          */
@@ -1584,8 +1609,6 @@ The next process has the following structure:
                                     rnaseq_gatk_splitNcigar.out,
                                     prepare_vcf_file.out)
 
-            // New channel to aggregate bam from different replicates
-            // into sample level.
             rnaseq_gatk_recalibrate
                 .out
                 | groupTuple

--- a/docs/hands_on/04_implementation.md
+++ b/docs/hands_on/04_implementation.md
@@ -1455,7 +1455,7 @@ The final step is the GATK ASEReadCounter.
 
     ??? solution
 
-        ```groovy linenums="1" hl_lines="40-42"
+        ```groovy linenums="1" hl_lines="41-43"
         workflow {
             reads_ch = Channel.fromFilePairs(params.reads)
 

--- a/docs/hands_on/index.md
+++ b/docs/hands_on/index.md
@@ -11,3 +11,11 @@ This hands-on session shows how to implement a Nextflow Variant Calling analysis
 !!! warning
 
     The content and pipeline in this course is aimed at teaching Nextflow, not bioinformatics. Software versions are outdated, among other things, so if you want a variant calling Nextflow pipeline for production you should use [nf-core/sarek](https://nf-co.re/sarek), [nf-core/viralrecon](https://nf-co.re/viralrecon) or [nf-core/rnavar](https://nf-co.re/rnavar) instead.
+
+## Follow the training video
+
+We run a free online training event for this course approximately every six months. Videos are streamed to YouTube and questions are handled in the nf-core Slack community. You can watch the recording of the most recent training ([September, 2023](https://nf-co.re/events/2023/training-hands-on-2023/)) below:
+
+<div style="text-align: center;">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/x5klpxczAXA?si=moNZUFGd4veMdtC8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" data-ruffle-polyfilled=""></iframe>
+</div>


### PR DESCRIPTION
- [X] Split .out line
- [X] Change the admonition of `example` to `tip` when mentioning tag
- [X] Add hands-on recording to the tutorial intro
- [X] At the end of some solutions in section 4, bullet points should be (+) in the source code. Do that.
- [X] Fix instructions including old variable name (`bam_for_ASE_ch`)
- [X] Shorten expressions to fit the average screen size
- [X] Fix indentation from shortening
- [X] Fix source code highlights due to improvements above
