### PR TITLE
Fixing minor errors

### DIFF
--- a/docs/basic_training/index.md
+++ b/docs/basic_training/index.md
@@ -44,6 +44,6 @@ To get you started with Nextflow as quickly as possible, you will be walked thro
 2. Explore Nextflow concepts using some basic workflows, including a multi-step RNA-Seq analysis
 3. Build and use Docker containers to encapsulate all workflow dependencies
 4. Dive deeper into the core Nextflow syntax, including Channels, Processes, and Operators
-5. Cover cluster and cloud deployment scenarios and explore Nextflow Tower capabilities
+5. Cover cluster and cloud deployment scenarios and explore Seqera Platform's capabilities
 
 This will give you a broad understanding of Nextflow, to start writing your own workflows. We hope you enjoy the course! This is an ever-evolving document - feedback is always welcome.

--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -325,6 +325,8 @@ result.large.view { "$it is large" }
 
 ## Text files
 
+### `splitText()`
+
 The `splitText` operator allows you to split multi-line strings or text file items, emitted by a source channel into chunks containing _n_ lines, which will be emitted by the resulting channel.
 
 ```groovy linenums="1" title="snippet.nf"
@@ -382,7 +384,7 @@ IT HAS SURVIVED NOT ONLY FIVE CENTURIES, BUT ALSO THE LEAP INTO ELECTRONIC TYPES
 ...
 ```
 
-### `splitText()`
+### `splitCsv()`
 
 The `splitCsv` operator allows you to parse text items emitted by a channel, that are CSV formatted.
 

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -89,7 +89,7 @@ workflow {
 
 !!! tip
 
-    In the snippet above the directive `debug` is used to enable the debug mode for the process. This is useful to print the output of the process script in the console.
+    In the snippet below the directive `debug` is used to enable the debug mode for the process. This is useful to print the output of the process script in the console.
 
 By default, the `process` command is interpreted as a **Bash** script. However, any other scripting language can be used by simply starting the script with the corresponding [Shebang](<https://en.wikipedia.org/wiki/Shebang_(Unix)>) declaration. For example:
 
@@ -1139,7 +1139,7 @@ workflow {
 }
 ```
 
-The above example will copy all blast script files created by the `BLASTSEQ` process into the directory path `my-results`.
+The above example will copy all blast script files created by the `BLASTSEQ` process into the directory path `results`.
 
 !!! tip
 


### PR DESCRIPTION
This PR fixes three very small erroneous references:
- Welcome: Changed Nextflow tower to Seqera Platform
- Opeartors: Fixed missreferencing of `splitText()` and added `splitCsv()` header
- Processes: Fixed wrong referencing to snippet above when it was the snippet below

Two additional things:
1) `publishDir` gets asked for in an exercise before its introduced. Is this wanted?

2) The gitpod for the training doesn't have singularity, but in general, singularity can work in Gitpod. This [statement](https://github.com/nextflow-io/training/blob/2cd5a8c32919cf6e4bd4f198e378cc57417bac3e/docs/basic_training/containers.md?plain=1#L333) in Dependencies and containers sections makes it sound as if singularity can't work in Gitpod at all. Any reason singularity is not included in the Gitpod image? It is part of the `nfcore/gitpod:dev` image used in nf-core/modules.