### PR TITLE
Added singularity to Gitpod container build

### DIFF
--- a/.github/gitpod.Dockerfile
+++ b/.github/gitpod.Dockerfile
@@ -17,6 +17,13 @@ RUN apt-get update --quiet && \
         graphviz \
         software-properties-common
 
+
+# Taken from: https://github.com/nf-core/tools/blob/master/nf_core/gitpod/gitpod.Dockerfile
+# Install Apptainer (Singularity)
+RUN add-apt-repository -y ppa:apptainer/ppa && \
+    apt-get update --quiet && \
+    apt install -y apptainer
+
 # Install Conda
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \

--- a/docs/basic_training/containers.md
+++ b/docs/basic_training/containers.md
@@ -328,10 +328,6 @@ Singularity implements a container execution model similar to Docker. However, i
 
 A Singularity container image is archived as a plain file that can be stored in a shared file system and accessed by many computing nodes managed using a batch scheduler.
 
-!!! warning
-
-    Singularity will not work with Gitpod. If you wish to try this section, please do it locally, or on an HPC.
-
 ### Create a Singularity images
 
 Singularity images are created using a `Singularity` file in a similar manner to Docker but using a different syntax.


### PR DESCRIPTION
As discussed in #307 with @mribeirodantas, this PR adds:
- singularity / apptainer to the gitpod container so that participants can use singularity / apptainer instead of docker to do the training
- Removes the warning that singularity does not work in Gitpod: https://github.com/nextflow-io/training/blob/5b1112fedcb2d97d3e8b20755ac114a6c528b94f/docs/basic_training/containers.md?plain=1#L331

I have tested all of the singularity commands given in the training material (including running the nextflow/rnaseq-nf workflow with singularity) and they all worked within the updated container.