### PR TITLE
Fix 03_hello_gatk.md

### DIFF
--- a/docs/hello_nextflow/03_hello_gatk.md
+++ b/docs/hello_nextflow/03_hello_gatk.md
@@ -511,7 +511,7 @@ _After:_
 // Create input channel from samplesheet in CSV format
 reads_ch = Channel.fromPath(params.reads_bam)
                     .splitCsv(header: true)
-                    .map{row -> [row.id, file(row.reads_bam)]}
+                    .map{row -> [file(row.ID), file(row.reads_bam)]}
 ```
 
 #### 5.4. Add the sample ID to the SAMTOOLS_INDEX input definition


### PR DESCRIPTION
Change addresses error from not being able to find 'row.id' which leads to an error when running section 6 as the ID is then passed as null.

Error in question is in GATK_JOINTGENOTYPING:
![image](https://github.com/nextflow-io/training/assets/170017315/30142a35-fb32-4b91-a3eb-64e1f626db44)
