### PR TITLE
docs: add bucket-dir param details for hybrid deployment

### DIFF
--- a/docs/basic_training/executors.md
+++ b/docs/basic_training/executors.md
@@ -409,6 +409,8 @@ Nextflow allows the use of multiple executors in the same workflow application. 
 
 To enable this feature use one or more [process selectors](https://www.nextflow.io/docs/latest/config.html#config-process-selectors) in your Nextflow configuration file.
 
+When running a hybrid workflow, `-bucket-dir` and `-work-dir` should be used to define separate work directories for remote tasks and local tasks, respectively.
+
 For example, apply the [AWS Batch configuration](https://www.nextflow.io/docs/latest/awscloud.html#awscloud-batch-config) only to a subset of processes in your workflow. You can try the following:
 
 ```groovy linenums="1" title="nextflow.config"
@@ -435,6 +437,12 @@ aws {
 5. Set the queue for the process(es) with the `bigTask` label
 6. Set the container image to deploy for the process(es) with the `bigTask` label
 7. Define the region for Batch execution
+
+The workflow can then be executed with:
+
+```bash
+nextflow run <script> -bucket-dir 's3://my-bucket' -work-dir /path/to/scratch/dir
+```
 
 !!! cboard-list-2 "Summary"
 


### PR DESCRIPTION
Addresses a missing detail about hybrid deployments and using `-bucket-dir` to specify a path to remote object storage required as the work directory for all cloud executor jobs, in addition to a local path through `-work-dir` for locally executed jobs. 

This is mentioned in the CLI details in Nextflow docs [here](https://www.nextflow.io/docs/latest/cli.html).