### PR TITLE
Fix inconsistency in basic operators coverage

### DIFF
--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -506,7 +506,7 @@ for (List row : lines) {
 
         To a splitCsv channel factory input:
 
-        ```groovy linenums="1" hl_lines="2 3 4"
+        ```groovy linenums="1" title="script7.nf"
         Channel
             .fromPath("fastq.csv")
             .splitCsv()
@@ -514,27 +514,7 @@ for (List row : lines) {
             .set { read_pairs_ch }
         ```
 
-        Finally, change the cardinality of the processes that use the input data. For example, for the quantification process, change it from:
-
-        ```groovy linenums="1"
-        process QUANTIFICATION {
-            tag "$sample_id"
-
-            input:
-            path salmon_index
-            tuple val(sample_id), path(reads)
-
-            output:
-            path sample_id, emit: quant_ch
-
-            script:
-            """
-            salmon quant --threads $task.cpus --libType=U -i $salmon_index -1 ${reads[0]} -2 ${reads[1]} -o $sample_id
-            """
-        }
-        ```
-
-        To:
+        Finally, change the cardinality of the processes that use the input data:
 
         ```groovy linenums="1" hl_lines="6 13"
         process QUANTIFICATION {

--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -516,7 +516,7 @@ for (List row : lines) {
 
         Finally, change the cardinality of the processes that use the input data:
 
-        ```groovy linenums="1" hl_lines="6 13"
+        ```groovy linenums="1" title="script7.nf"
         process QUANTIFICATION {
             tag "$sample_id"
 
@@ -536,7 +536,7 @@ for (List row : lines) {
 
         Repeat the above for the fastqc step.
 
-        ```groovy linenums="1"  hl_lines="5 13"
+        ```groovy linenums="1" title="script7.nf"
         process FASTQC {
             tag "FASTQC on $sample_id"
 

--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -536,7 +536,7 @@ for (List row : lines) {
 
         Repeat the above for the fastqc step.
 
-        ```groovy linenums="1" title="script7.nf"
+        ```groovy linenums="1" hl_lines="5 13" title="script7.nf"
         process FASTQC {
             tag "FASTQC on $sample_id"
 

--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -476,21 +476,37 @@ ATX-TBL-001-GB-01-113   3
 
 Finally, you can also operate on CSV files outside the channel context:
 
+```groovy linenums="1"
+def f = file('data/meta/patients_1.csv')
+def lines = f.splitCsv()
+for (List row : lines) {
+    log.info "${row[0]} -- ${row[2]}"
+}
+```
+
 !!! question "Exercise"
 
-    Create a CSV file that can be used as an input for `script7.nf`.
+    Create a CSV file and use it as input for `script7.nf`, part of the [Simple RNA-Seq workflow tutorial](https://training.nextflow.io/basic_training/rnaseq_pipeline/).
 
     ??? solution
 
         Add a CSV text file containing the following, as an example input with the name "fastq.csv":
 
-        ```csv title="input.csv"
+        ```csv
         gut,/workspace/gitpod/nf-training/data/ggal/gut_1.fq,/workspace/gitpod/nf-training/data/ggal/gut_2.fq
         ```
 
-        Then, add a .splitCsv() operator:
+        Then replace the input channel for the reads in `script7.nf`. Changing the following lines:
 
-        ```groovy linenums="1" title="script7.nf"
+        ```groovy linenums="1"
+        Channel
+            .fromFilePairs(params.reads, checkIfExists: true)
+            .set { read_pairs_ch }
+        ```
+
+        To a splitCsv channel factory input:
+
+        ```groovy linenums="1" hl_lines="2 3 4"
         Channel
             .fromPath("fastq.csv")
             .splitCsv()
@@ -498,9 +514,29 @@ Finally, you can also operate on CSV files outside the channel context:
             .set { read_pairs_ch }
         ```
 
-        Finally, change the cardinality of the processes that use the input data:
+        Finally, change the cardinality of the processes that use the input data. For example, for the quantification process, change it from:
 
-        ```groovy linenums="1" title="script7.nf"
+        ```groovy linenums="1"
+        process QUANTIFICATION {
+            tag "$sample_id"
+
+            input:
+            path salmon_index
+            tuple val(sample_id), path(reads)
+
+            output:
+            path sample_id, emit: quant_ch
+
+            script:
+            """
+            salmon quant --threads $task.cpus --libType=U -i $salmon_index -1 ${reads[0]} -2 ${reads[1]} -o $sample_id
+            """
+        }
+        ```
+
+        To:
+
+        ```groovy linenums="1" hl_lines="6 13"
         process QUANTIFICATION {
             tag "$sample_id"
 
@@ -520,7 +556,7 @@ Finally, you can also operate on CSV files outside the channel context:
 
         Repeat the above for the fastqc step.
 
-        ```groovy linenums="1" hl_lines="5 13" title="script7.nf"
+        ```groovy linenums="1"  hl_lines="5 13"
         process FASTQC {
             tag "FASTQC on $sample_id"
 
@@ -537,6 +573,10 @@ Finally, you can also operate on CSV files outside the channel context:
             """
         }
         ```
+
+        Now the workflow should run from a CSV file.
+
+### Tab separated values (.tsv)
 
 Parsing TSV files works in a similar way. Simply add the `sep: '\t'` option in the `splitCsv` context:
 

--- a/docs/basic_training/operators.md
+++ b/docs/basic_training/operators.md
@@ -492,7 +492,7 @@ for (List row : lines) {
 
         Add a CSV text file containing the following, as an example input with the name "fastq.csv":
 
-        ```csv
+        ```csv title="fastq.csv"
         gut,/workspace/gitpod/nf-training/data/ggal/gut_1.fq,/workspace/gitpod/nf-training/data/ggal/gut_2.fq
         ```
 


### PR DESCRIPTION
Just fixing a glitch that I think might have come from a previous update, which removed the 'CSV files outside the channel context' example. 