### PR TITLE
Update configuration.md for minor errors

### DIFF
--- a/docs/advanced/configuration.md
+++ b/docs/advanced/configuration.md
@@ -36,10 +36,10 @@ These configuration values would be inherited by every run on that system withou
 
 ## Overriding for a run - `$PWD/nextflow.config`
 
-Move into the chapter example directory:
+Create a chapter example directory:
 
 ```
-cd configuration
+mkdir configuration && cd configuration
 ```
 
 ### Overriding Process Directives
@@ -72,7 +72,7 @@ Glob pattern matching can also be used:
 
 ```groovy
 process {
-    withLabel: '.*:INDEX' {
+    withName: '.*:INDEX' {
         cpus = 2
     }
 }


### PR DESCRIPTION
1. There is no 'configuration' directory
2. A `withLabel` example probably needs to be a `withName` 