### PR TITLE
make clear that specific output channel must be specified for view()

### DIFF
--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -924,7 +924,7 @@ workflow {
 }
 ```
 
-This command will produce an error message, because `.view()` operates on single channels, and FOO.out contains multiple channels. 
+This command will produce an error message, because `.view()` operates on single channels, and FOO.out contains multiple channels.
 
 If a process defines two or more output channels, each channel can be accessed by indexing the `.out` attribute, e.g., `.out[0]`, `.out[1]`, etc. In this example you only have the `[0]'th` output:
 

--- a/docs/basic_training/processes.md
+++ b/docs/basic_training/processes.md
@@ -924,6 +924,8 @@ workflow {
 }
 ```
 
+This command will produce an error message, because `.view()` operates on single channels, and FOO.out contains multiple channels. 
+
 If a process defines two or more output channels, each channel can be accessed by indexing the `.out` attribute, e.g., `.out[0]`, `.out[1]`, etc. In this example you only have the `[0]'th` output:
 
 ```groovy linenums="1" title="snippet.nf"


### PR DESCRIPTION
Currently, the command example here is jarring, it fails with an error with no explanation. The correct form is cited below, we should just warn the user that the failure was intentional. 