### PR TITLE
Update gitpod defaults + training portal home page and related

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -23,7 +23,7 @@ tasks:
     - before: printf 'unset JAVA_TOOL_OPTIONS\n' >> $HOME/.bashrc && exit
 
     - name: Start web server
-      command: gp ports await 23000 && gp preview https://training.nextflow.io/hello-nextflow
+      command: gp ports await 23000 && gp preview https://training.nextflow.io/hello_nextflow
 
     - name: Load Nextflow Tutorial
       command: docker pull -q nextflow/rnaseq-nf

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -23,14 +23,14 @@ tasks:
     - before: printf 'unset JAVA_TOOL_OPTIONS\n' >> $HOME/.bashrc && exit
 
     - name: Start web server
-      command: gp ports await 23000 && gp preview https://training.nextflow.io
+      command: gp ports await 23000 && gp preview https://training.nextflow.io/hello-nextflow
 
     - name: Load Nextflow Tutorial
       command: docker pull -q nextflow/rnaseq-nf
 
     - name: Start Nextflow Tutorial
       command: |
-          cd nf-training
+          cd hello-nextflow
           source $HOME/.bashrc
           export PS1='\[\e[3;36m\]${PWD/*\//} ->\[\e[0m\] '
           unset JAVA_TOOL_OPTIONS

--- a/README.md
+++ b/README.md
@@ -9,20 +9,20 @@ We are excited to have you on the path to writing reproducible and scalable scie
 
 -   👉🏻 Written training material: <https://training.nextflow.io>
 
--   👩🏻‍💻 Instructions on loading this repository within a GitPod environment: <https://training.nextflow.io/basic_training/setup/>
+-   👩🏻‍💻 Instructions on loading this repository within a GitPod environment: <https://training.nextflow.io/envsetup/>
 
 -   📚 Nextflow documentation: <https://www.nextflow.io/docs/latest/>
 
 ## Contributions
 
-We welcome fixes and improvements from the community. Please fork the repository and create pull-requests with any improvements to the docs.
+We welcome fixes and improvements from the community. Please fork the repository and create pull-requests with any improvements you'd like to suggest to the docs.
 
 You can find instructions about how to develop the training material code in [`CONTRIBUTING.md`](CONTRIBUTING.md). If you want to contribute with a translation instead, check [`TRANSLATING.md`](TRANSLATING.md).
 
 ## Credits & Copyright
 
-All training material was originally written by [Seqera](https://seqera.io) but has been made open-source ([CC BY-NC-ND](https://creativecommons.org/licenses/by-nc-nd/4.0/)) for the community.
+This training material is developed and maintained by [Seqera](https://seqera.io) and released under an open-source license ([CC BY-NC-ND](https://creativecommons.org/licenses/by-nc-nd/4.0/)) for the benefit of the community. You are welcome to reuse these materials according to the terms of the license. If you are an instructor running your own trainings, we'd love to hear about how it goes and what we could do to make it easier.
 
 <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/"><img alt="Creative Commons License" src="docs/assets/img/cc_by-nc-nd.svg" /></a>
 
-> Copyright 2020-2023, Seqera. All examples and descriptions are licensed under the <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.
+> Copyright 2024, Seqera. All examples and descriptions are licensed under the <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -1,4 +1,4 @@
-# Introduction
+# Advanced Training
 
 Welcome to our Nextflow workshop for intermediate and advanced users!
 

--- a/docs/basic_training/index.md
+++ b/docs/basic_training/index.md
@@ -1,4 +1,4 @@
-# Introduction
+# Fundamentals Training
 
 You are now on the path to writing reproducible and scalable scientific workflows using Nextflow. This guide complements the full [Nextflow documentation](https://www.nextflow.io/docs/latest) - if you ever have any doubts, please refer to that.
 

--- a/docs/envsetup/index.md
+++ b/docs/envsetup/index.md
@@ -1,6 +1,6 @@
-# Introduction
+# Environment Setup
 
-Training on the Nextflow community training portal are optimized for use within our Gitpod environment.
+The training courses offered on the Nextflow community training portal are optimized for use within our Gitpod environment.
 
 Gitpod offers a virtual machine with everything already set up for you, accessible from your web browser or built into your code editor (e.g., VSCode).
 

--- a/docs/hello_nextflow/index.md
+++ b/docs/hello_nextflow/index.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Hello Nextflow
 hide:
     - toc
 ---

--- a/docs/help.md
+++ b/docs/help.md
@@ -2,32 +2,18 @@
 
 ## Nextflow Documentation
 
-Even the most proficient developers need documentation.
-Nextflow is no different, and has an excellent set of docs.
-You can find the Nextflow docs at <https://nextflow.io/docs/latest/> - we recommend keeping them open in a tab whilst you follow the training!
+Nextflow has an excellent set of [docs](https://nextflow.io/docs/latest/), which should be your first destination whenever you run into something you don't understand or want to learn more about. You can browse topics or search for specific terms. 
 
 ## community.seqera.io
 
-The [Seqera community forum](https://community.seqera.io) is a great place to ask questions about Nextflow. It's also a great place to find answers to questions that have already been asked!
+If you're struggling with the training, please don't hesitate to reach out for help. Our amazing community is one of the great strengths of Nextflow!
 
-Questions about Nextflow can be asked under the [Nextflow category](https://community.seqera.io/c/nextflow/5) with any relevant tags.
+The [Seqera community forum](https://community.seqera.io) is a great place to ask questions about Nextflow. It's also a great place to find answers to questions that have already been asked! 
 
-## Slack
+If you can't find a solution to your problem, just log in and click the "New Topic" button to post your question in the [Ask for Help](https://community.seqera.io/c/help/37) category. Feel free to include any tags you think might be relevant, since those can help our team and your peers find and answer your question.
 
-If you're struggling with the training please don't hesitate to reach out for help.
-Our amazing community is one of the great strengths of Nextflow!
+## Professional support
 
-There are two relevant Slack instances:
+Nextflow is a free and open-source software developed by [Seqera](https://seqera.io/), a company headquartered in Spain with satellite offices in the UK and the US.
 
--   Nextflow ([register here](https://www.nextflow.io/slack-invite.html))
--   nf-core ([register here](https://nf-co.re/join/slack))
-
-Generally, the Nextflow slack is best as it caters for the entire community.
-The exception is if you're following the training with a workshop organised by nf-core, in which case you should have been told about where to ask questions.
-
-## Ask the professionals
-
-Nextflow is a free and open-source software, developed by [Seqera](https://seqera.io/).
-Seqera offers a professional support service for Nextflow and associated products, as well as running bespoke training sessions.
-
-If this sounds like something that might be of interest, please [Get in touch](https://seqera.io/demo/).
+Seqera offers professional support services for Nextflow and associated products, including bespoke training sessions. If this sounds like something that might be of interest to you, please [Get in touch](https://seqera.io/demo/).

--- a/docs/help.md
+++ b/docs/help.md
@@ -2,13 +2,13 @@
 
 ## Nextflow Documentation
 
-Nextflow has an excellent set of [docs](https://nextflow.io/docs/latest/), which should be your first destination whenever you run into something you don't understand or want to learn more about. You can browse topics or search for specific terms. 
+Nextflow has an excellent set of [docs](https://nextflow.io/docs/latest/), which should be your first destination whenever you run into something you don't understand or want to learn more about. You can browse topics or search for specific terms.
 
 ## community.seqera.io
 
 If you're struggling with the training, please don't hesitate to reach out for help. Our amazing community is one of the great strengths of Nextflow!
 
-The [Seqera community forum](https://community.seqera.io) is a great place to ask questions about Nextflow. It's also a great place to find answers to questions that have already been asked! 
+The [Seqera community forum](https://community.seqera.io) is a great place to ask questions about Nextflow. It's also a great place to find answers to questions that have already been asked!
 
 If you can't find a solution to your problem, just log in and click the "New Topic" button to post your question in the [Ask for Help](https://community.seqera.io/c/help/37) category. Feel free to include any tags you think might be relevant, since those can help our team and your peers find and answer your question.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ The training courses listed below are designed to be useable as a self-service r
 
         :material-lightbulb: Comprehensive training material for exploring the full scope of Nextflow's capabilities.
 
-    The fundamentals training material covers all things Nextflow. Excellent reference material for anyone looking build complex workflows with Nextflow.
+    The fundamentals training material covers all things Nextflow. Excellent reference material for anyone looking to build complex workflows with Nextflow.
 
     [Launch the fundamentals training :material-arrow-right:](basic_training/index.md){ .md-button .md-button--primary }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,8 @@ The training courses listed below are designed to be useable as a self-service r
 -   Seqera (the company that develops Nextflow) runs a variety of training events, see the [Seqera Events](https://seqera.io/events/) page and look for 'Seqera Sessions' and 'Nextflow Summit'.
 -   Our Community team also regularly teaches trainings hosted by third party organizations; announcements and signups for those are typically managed by the third-party hosts.
 
+When you're ready to get down to work, click on the 'Open in Gitpod' button, either on this page or on the index page of the course you chose, to open a web-based training environment (requires a free Github account). 
+
 [![Open in Gitpod](https://img.shields.io/badge/Gitpod-%20Open%20in%20Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/nextflow-io/training)
 
 ## Training Environment Setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,9 +107,7 @@ The training courses listed below are designed to be useable as a self-service r
 
         :material-run-fast: A short hands-on tutorial focused on a concrete analysis pipeline example.
 
-    This course was developed as a "learn by doing" tutorial intended as a fast, hands-on way to get to grips with Nextflow using a very concrete analysis pipeline example. It is no longer being maintained and will eventually be removed from the training portal.
-
-    [Launch the simple RNA-seq variant calling training :material-arrow-right:](hands_on/index.md){ .md-button }
+    This course was developed as a "learn by doing" tutorial intended as a fast, hands-on way to get to grips with Nextflow using a very concrete analysis pipeline example. You can still find the materials in the Github repository, but it is no longer being maintained and can no longer be launched in Gitpod or in the training portal.
 
 ## Resources
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,15 +9,15 @@ hide:
 
 # Nextflow Training
 
-Welcome to the Nextflow community training portal! 
+Welcome to the Nextflow community training portal!
 
 We have several distinct training courses available on this website. Scroll down to find the one that's right for you!
 
 The training courses listed below are designed to be useable as a self-service resource; you can work through them on your own at any time (see Training Environment Setup for practical details). However, you may get even more out of them by joining a group training event.
 
-- Free online events are run regularly by the nf-core community, see the [nf-core events page](https://nf-co.re/events) for more.
-- Seqera (the company that develops Nextflow) runs a variety of training events, see the [Seqera Events](https://seqera.io/events/) page and look for 'Seqera Sessions' and 'Nextflow Summit'.
-- Our Community team also regularly teaches trainings hosted by third party organizations; announcements and signups for those are typically managed by the third-party hosts. 
+-   Free online events are run regularly by the nf-core community, see the [nf-core events page](https://nf-co.re/events) for more.
+-   Seqera (the company that develops Nextflow) runs a variety of training events, see the [Seqera Events](https://seqera.io/events/) page and look for 'Seqera Sessions' and 'Nextflow Summit'.
+-   Our Community team also regularly teaches trainings hosted by third party organizations; announcements and signups for those are typically managed by the third-party hosts.
 
 [![Open in Gitpod](https://img.shields.io/badge/Gitpod-%20Open%20in%20Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/nextflow-io/training)
 
@@ -41,7 +41,7 @@ The training courses listed below are designed to be useable as a self-service r
 
         :material-run-fast: A modular training series for getting started with Nextflow.
 
-    This is a foundational course for those who are completely new to Nextflow. It consists of a series of training modules that are designed to help learners build up their skills progressively. The series covers the core components of the Nextflow language as well as essential pipeline design and development practices, and effective use of third-party resources. 
+    This is a foundational course for those who are completely new to Nextflow. It consists of a series of training modules that are designed to help learners build up their skills progressively. The series covers the core components of the Nextflow language as well as essential pipeline design and development practices, and effective use of third-party resources.
 
     [Launch the Hello Nextflow training :material-arrow-right:](hello_nextflow/index.md){ .md-button }
 
@@ -119,7 +119,7 @@ Quick reference to some handy links:
 | ----------------------------------------------------------- | ------------------------------------------------------------ |
 | [Nextflow Docs](https://nextflow.io/docs/latest/index.html) | [Nextflow Slack](https://www.nextflow.io/slack-invite.html)  |
 | [Nextflow Homepage](https://nextflow.io/)                   | [nf-core](https://nf-co.re/)                                 |
-| [Seqera](https://seqera.io/)                                | [Seqera Community Forum](https://community.seqera.io)              |
+| [Seqera](https://seqera.io/)                                | [Seqera Community Forum](https://community.seqera.io)        |
 
 Not sure where to go? Check out the [Getting help](help.md) page.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,15 +9,15 @@ hide:
 
 # Nextflow Training
 
-Welcome to the Nextflow community training portal!
+Welcome to the Nextflow community training portal! 
 
-These training materials are open source and free to use for anyone.
-They are hosted in a [GitHub repository](https://github.com/nextflow-io/training) along with example scripts and development configuration.
+We have several distinct training courses available on this website. Scroll down to find the one that's right for you!
 
-Whilst you can follow the materials any time, you'll probably get the most out of them by joining an organized training event.
-Free online events are organized regularly with the nf-core community, see the [nf-core events page](https://nf-co.re/events) for more.
+The training courses listed below are designed to be useable as a self-service resource; you can work through them on your own at any time (see Training Environment Setup for practical details). However, you may get even more out of them by joining a group training event.
 
-We have several workshops available on this website - find the one that's right for you!
+- Free online events are run regularly by the nf-core community, see the [nf-core events page](https://nf-co.re/events) for more.
+- Seqera (the company that develops Nextflow) runs a variety of training events, see the [Seqera Events](https://seqera.io/events/) page and look for 'Seqera Sessions' and 'Nextflow Summit'.
+- Our Community team also regularly teaches trainings hosted by third party organizations; announcements and signups for those are typically managed by the third-party hosts. 
 
 [![Open in Gitpod](https://img.shields.io/badge/Gitpod-%20Open%20in%20Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/nextflow-io/training)
 
@@ -27,21 +27,33 @@ We have several workshops available on this website - find the one that's right 
 
     !!! quote inline end ""
 
-        :material-lightbulb: Essential for setting up your Gitpod for the first time.
+        :material-lightbulb: Essential for setting up your environment for the first time.
 
-    An essential tutorial for setting up your Gitpod environment for the first time.
+    Instructions for setting up your environment to work through training materials (all courses). Provides an orientation to Gitpod as well as alternate installation instructions for working on your own local machine.
 
     [Launch the environment setup training :material-arrow-right:](envsetup/index.md){ .md-button .md-button--primary }
 
-## Nextflow Training
+## Nextflow for Newcomers
+
+!!! exercise "Hello Nextflow"
+
+    !!! quote inline end ""
+
+        :material-run-fast: A modular training series for getting started with Nextflow.
+
+    This is a foundational course for those who are completely new to Nextflow. It consists of a series of training modules that are designed to help learners build up their skills progressively. The series covers the core components of the Nextflow language as well as essential pipeline design and development practices, and effective use of third-party resources. 
+
+    [Launch the Hello Nextflow training :material-arrow-right:](hello_nextflow/index.md){ .md-button }
+
+## In-depth Nextflow Training
 
 !!! exercise "Fundamentals Training"
 
     !!! tip inline end ""
 
-        :material-lightbulb: This is the primary Nextflow training material used in most Nextflow and nf-core training events.
+        :material-lightbulb: Comprehensive training material for exploring the full scope of Nextflow's capabilities.
 
-    The fundamentals training material includes all things Nextflow. Perfect for anyone looking to get to grips with using Nextflow to run analyses and build workflows.
+    The fundamentals training material covers all things Nextflow. Excellent reference material for anyone looking build complex workflows with Nextflow.
 
     [Launch the fundamentals training :material-arrow-right:](basic_training/index.md){ .md-button .md-button--primary }
 
@@ -49,23 +61,13 @@ We have several workshops available on this website - find the one that's right 
 
     !!! quote inline end ""
 
-        :material-lightbulb: This is the Nextflow training material used in advanced training events.
+        :material-lightbulb: Advanced training material for mastering Nextflow.
 
-    Advanced material exploring the advanced features of the Nextflow language and runtime, and how to use them to write efficient and scalable data-intensive workflows.
+    Advanced material exploring the more advanced features of the Nextflow language and runtime, and how to use them to write efficient and scalable data-intensive workflows.
 
     [Launch the advanced training :material-arrow-right:](advanced/index.md){ .md-button .md-button--primary }
 
-## Applied Training
-
-!!! exercise "Hello Nextflow"
-
-    !!! quote inline end ""
-
-        :material-run-fast: This course is a short workshop to introduce you to Nextflow.
-
-    A "learn by doing" tutorial that will take you from running tools on the command line into running your first Nextflow pipelines.
-
-    [Launch the Hello Nextflow training :material-arrow-right:](hello_nextflow/index.md){ .md-button }
+## Other/Experimental
 
 !!! exercise "Configure the execution of an nf-core pipeline"
 
@@ -87,16 +89,6 @@ We have several workshops available on this website - find the one that's right 
 
     [Launch the nf-core template training :material-arrow-right:](nf_develop/index.md){ .md-button }
 
-!!! exercise "Simple RNA-seq variant calling"
-
-    !!! quote inline end ""
-
-        :material-run-fast: This course is quite short and hands-on, great if you want to practice your Nextflow skills.
-
-    A "learn by doing" tutorial focusing on theory, instead of leading through exercises of slowly increasing complexity.
-
-    [Launch the simple RNA-seq variant calling training :material-arrow-right:](hands_on/index.md){ .md-button }
-
 !!! exercise "Troubleshooting exercises"
 
     !!! quote inline end ""
@@ -107,6 +99,18 @@ We have several workshops available on this website - find the one that's right 
 
     [Launch the troubleshooting training :material-arrow-right:](troubleshoot/index.md){ .md-button }
 
+## Deprecated
+
+!!! exercise "Simple RNA-seq variant calling"
+
+    !!! quote inline end ""
+
+        :material-run-fast: A short hands-on tutorial focused on a concrete analysis pipeline example.
+
+    This course was developed as a "learn by doing" tutorial intended as a fast, hands-on way to get to grips with Nextflow using a very concrete analysis pipeline example. It is no longer being maintained and will eventually be removed from the training portal.
+
+    [Launch the simple RNA-seq variant calling training :material-arrow-right:](hands_on/index.md){ .md-button }
+
 ## Resources
 
 Quick reference to some handy links:
@@ -115,7 +119,7 @@ Quick reference to some handy links:
 | ----------------------------------------------------------- | ------------------------------------------------------------ |
 | [Nextflow Docs](https://nextflow.io/docs/latest/index.html) | [Nextflow Slack](https://www.nextflow.io/slack-invite.html)  |
 | [Nextflow Homepage](https://nextflow.io/)                   | [nf-core](https://nf-co.re/)                                 |
-| [Seqera](https://seqera.io/)                                | [Seqera Community](https://community.seqera.io)              |
+| [Seqera](https://seqera.io/)                                | [Seqera Community Forum](https://community.seqera.io)              |
 
 Not sure where to go? Check out the [Getting help](help.md) page.
 
@@ -123,10 +127,9 @@ Not sure where to go? Check out the [Getting help](help.md) page.
 
 [![Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0](assets/img/cc_by-nc-nd.svg){ align=right }](https://creativecommons.org/licenses/by-nc-nd/4.0/)
 
-All training material was originally written by [Seqera](https://seqera.io) but has been made open-source ([CC BY-NC-ND](https://creativecommons.org/licenses/by-nc-nd/4.0/)) for the community.
+This training material is developed and maintained by [Seqera](https://seqera.io) and released under an open-source license ([CC BY-NC-ND](https://creativecommons.org/licenses/by-nc-nd/4.0/)) for the benefit of the community. You are welcome to reuse these materials according to the terms of the license. If you are an instructor running your own trainings, we'd love to hear about how it goes and what we could do to make it easier.
 
-We welcome fixes and improvements from the community.
-Every page has a :material-file-edit-outline: icon in the top right of the page, which will take you to GitHub where you can edit the training source material via a pull request.
+We welcome fixes and improvements from the community. Every page has a :material-file-edit-outline: icon in the top right of the page, which will take you to GitHub where you can propose changes to the training source material via a pull request.
 
 <div markdown class="homepage_logos">
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ The training courses listed below are designed to be useable as a self-service r
 -   Seqera (the company that develops Nextflow) runs a variety of training events, see the [Seqera Events](https://seqera.io/events/) page and look for 'Seqera Sessions' and 'Nextflow Summit'.
 -   Our Community team also regularly teaches trainings hosted by third party organizations; announcements and signups for those are typically managed by the third-party hosts.
 
-When you're ready to get down to work, click on the 'Open in Gitpod' button, either on this page or on the index page of the course you chose, to open a web-based training environment (requires a free Github account). 
+When you're ready to get down to work, click on the 'Open in Gitpod' button, either on this page or on the index page of the course you chose, to open a web-based training environment (requires a free Github account).
 
 [![Open in Gitpod](https://img.shields.io/badge/Gitpod-%20Open%20in%20Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/nextflow-io/training)
 

--- a/docs/nf_customize/index.md
+++ b/docs/nf_customize/index.md
@@ -1,4 +1,4 @@
-# Introduction
+# Configure nf-core
 
 nf-core is a community effort to collaborate on a curated set of analysis pipelines built using Nextflow. It provides a standardized set of best practices, guidelines, and templates for building and sharing bioinformatics pipelines.
 

--- a/docs/nf_develop/index.md
+++ b/docs/nf_develop/index.md
@@ -1,4 +1,4 @@
-# Introduction
+# Develop nf-core
 
 Nextflow provides a powerful way to develop pipelines. However, it does not provide standards for how pipelines should be developed. This gap has led to the establishment of pipeline registries, such as [nf-core](https://nf-co.re/), with tools and implementation guidelines that provide support and standards for pipeline development.
 

--- a/docs/troubleshoot/index.md
+++ b/docs/troubleshoot/index.md
@@ -1,4 +1,4 @@
-# Introduction
+# Troubleshooting
 
 Effective troubleshooting strategies are essential for identifying and resolving issues efficiently, minimizing downtime, and ensuring smooth development cycles. Investing in troubleshooting strategies not only resolves immediate issues but also cultivates a culture of problem-solving and continuous improvement.
 

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -1,12 +1,11 @@
 {
     "folders": [
+        { "path": "./hello-nextflow" },
         { "path": "./nf-training" },
         { "path": "./nf-training-advanced" },
-        { "path": "./hands-on" },
-        { "path": "./hello-nextflow" },
-        { "path": "./troubleshoot" },
         { "path": "./nf-customize" },
         { "path": "./nf-develop" },
+        { "path": "./troubleshoot" },
     ],
     "settings": {
         "typescript.tsdk": "gitpod/node_modules/typescript/lib",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,13 +165,9 @@ plugins:
     - enumerate-headings:
           restart_increment_after:
               - envsetup/01_setup.md
+              - hello_nextflow/01_orientation.md
               - basic_training/orientation.md
               - advanced/orientation.md
-              - hello_nextflow/01_orientation.md
-              - nf_customize/01_orientation.md
-              - nf_develop/1_01_orientation.md
-              - troubleshoot/01_orientation.md
-              - hands_on/01_datasets.md
 
           exclude:
               - index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,14 @@ nav:
           - envsetup/index.md
           - envsetup/01_setup.md
           - envsetup/02_local.md
+    - Hello Nextflow:
+          - hello_nextflow/index.md
+          - hello_nextflow/01_orientation.md
+          - hello_nextflow/02_hello_world.md
+          - hello_nextflow/03_hello_gatk.md
+          - hello_nextflow/04_hello_modules.md
+          - hello_nextflow/05_hello_nf-test.md
+          - hello_nextflow/06_hello_config.md
     - Fundamentals Training:
           - basic_training/index.md
           - basic_training/orientation.md
@@ -36,14 +44,6 @@ nav:
           - advanced/configuration.md
           - advanced/summary.md
           - advanced/support.md
-    - Hello Nextflow:
-          - hello_nextflow/index.md
-          - hello_nextflow/01_orientation.md
-          - hello_nextflow/02_hello_world.md
-          - hello_nextflow/03_hello_gatk.md
-          - hello_nextflow/04_hello_modules.md
-          - hello_nextflow/05_hello_nf-test.md
-          - hello_nextflow/06_hello_config.md
     - Configure nf-core:
           - nf_customize/index.md
           - nf_customize/01_orientation.md
@@ -57,12 +57,6 @@ nav:
           - nf_develop/1_02_create.md
           - nf_develop/1_03_pipeline.md
           - nf_develop/1_04_parameters.md
-    - Simple RNA-seq:
-          - hands_on/index.md
-          - hands_on/01_datasets.md
-          - hands_on/02_workflow.md
-          - hands_on/03_setup.md
-          - hands_on/04_implementation.md
     - Troubleshooting:
           - troubleshoot/index.md
           - troubleshoot/01_orientation.md
@@ -168,6 +162,9 @@ plugins:
               - hello_nextflow/01_orientation.md
               - basic_training/orientation.md
               - advanced/orientation.md
+              - nf_customize/01_orientation.md
+              - nf_develop/1_01_orientation.md
+              - troubleshoot/01_orientation.md
 
           exclude:
               - index.md


### PR DESCRIPTION
**Gitpod**
- Switch default work directory to Hello Nextflow
- Also open the Hello Nextflow training page in the simple browser
- Reorder how the trainings are listed in the file explorer in gitpod
- Hide the hands-on training directory in the gitpod (deprecating it)

**Website**
- Reorganized order of courses + tweaked language on the training portal
- Updated language and links in Readme, Help