### PR TITLE
Correction for groovy If statement snippet

### DIFF
--- a/docs/basic_training/groovy.md
+++ b/docs/basic_training/groovy.md
@@ -371,8 +371,8 @@ else {
 The `else` branch is optional. Also, the curly brackets are optional when the branch defines just a single statement.
 
 ```groovy linenums="1" title="snippet.nf"
-x = 1
-if (x < 10)
+x = 11
+if (x > 10)
     println 'Hello'
 ```
 

--- a/docs/basic_training/groovy.md
+++ b/docs/basic_training/groovy.md
@@ -372,7 +372,7 @@ The `else` branch is optional. Also, the curly brackets are optional when the br
 
 ```groovy linenums="1" title="snippet.nf"
 x = 1
-if (x > 10)
+if (x < 10)
     println 'Hello'
 ```
 

--- a/docs/basic_training/groovy.pt.md
+++ b/docs/basic_training/groovy.pt.md
@@ -254,8 +254,8 @@ else {
 O ramo `else` é opcional. Além disso, as chaves são opcionais quando a ramificação define apenas uma única instrução.
 
 ```groovy linenums="1"
-x = 1
-if (x < 10)
+x = 11
+if (x > 10)
     println 'Olá'
 ```
 

--- a/docs/basic_training/groovy.pt.md
+++ b/docs/basic_training/groovy.pt.md
@@ -264,6 +264,7 @@ Olá
 ```
 
 !!! tip
+
     `null`, strings vazias e coleções (mapas e listas) vazias são avaliadas como `false`.
 
     Portanto, uma declaração como:

--- a/docs/basic_training/groovy.pt.md
+++ b/docs/basic_training/groovy.pt.md
@@ -255,12 +255,15 @@ O ramo `else` é opcional. Além disso, as chaves são opcionais quando a ramifi
 
 ```groovy linenums="1"
 x = 1
-if (x > 10)
+if (x < 10)
     println 'Olá'
 ```
 
-!!! tip
+```console title="Output"
+Olá
+```
 
+!!! tip
     `null`, strings vazias e coleções (mapas e listas) vazias são avaliadas como `false`.
 
     Portanto, uma declaração como:


### PR DESCRIPTION
Fixes this error in [basic training doc](https://training.nextflow.io/basic_training/groovy/#if-statement), where snippet.nf does not generate the Output:
![image](https://github.com/user-attachments/assets/7dfb9a1b-4a96-46f6-8467-61a9097f462e)



- Corrected If statement snippet in groovy.md, so that code gives the result shown in the Output block
- Updated If statement snippet in groovy.pt.md, to match the updated code in groovy.md
- Added missing output code block to If statement example in groovy.pt.md, to match the output code block in groovy.md