### PR TITLE
devcontainer support with docker-outside-docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,14 @@
 {
     "name": "nfcore",
-    "image": "nfcore/gitpod:latest",
+    "image": "ghcr.io/nextflow-io/training:latest",
     "remoteUser": "gitpod",
-
-    "postCreateCommand": "pre-commit install --install-hooks",
-
+    "features": {
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    },
+    "remoteEnv": {
+        "NXF_HOME": "/workspaces/.nextflow",
+        "HOST_PROJECT_PATH": "${localWorkspaceFolder}"
+    },
     // Configure tool-specific properties.
     "customizations": {
         // Configure properties specific to VS Code.
@@ -13,12 +17,13 @@
             "settings": {
                 "python.defaultInterpreterPath": "/opt/conda/bin/python"
             },
-
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": [
                 "ms-python.python",
                 "ms-python.vscode-pylance",
-                "nf-core.nf-core-extensionpack"
+                "nf-core.nf-core-extensionpack",
+                "nextflow.nextflow",
+                "codezombiech.gitignore",
             ]
         }
     },


### PR DESCRIPTION
This PR adds support for a devcontainer which allows docker-outside-docker, therefore users can run hello-genomics etc.

The only limitation so far is the paths in the samplesheet don't match (`/workspace/gitpod/`), I've tried to fix it but no luck so far. We could add this right now to provide a backup before we solve the gitpod absolute path problem in the repository.