### PR TITLE
Add emits to outputs of processes with multiple outputs

### DIFF
--- a/docs/hello_nextflow/04_hello_genomics.md
+++ b/docs/hello_nextflow/04_hello_genomics.md
@@ -310,7 +310,7 @@ process GATK_HAPLOTYPECALLER {
 
     output:
         path "${input_bam}.vcf"     , emit: vcf
-        path "${input_bam}.vcf.idx" , emit: idx 
+        path "${input_bam}.vcf.idx" , emit: idx
 
     """
     gatk HaplotypeCaller \
@@ -322,7 +322,7 @@ process GATK_HAPLOTYPECALLER {
 }
 ```
 
-You'll notice that we've introduced some new syntax here (`emit:`) to uniquely name each of our output channels, and the reasons for this will become clear soon. 
+You'll notice that we've introduced some new syntax here (`emit:`) to uniquely name each of our output channels, and the reasons for this will become clear soon.
 
 This command takes quite a few more inputs, because GATK needs more information to perform the analysis compared to a simple indexing job.
 But you'll note that there are even more inputs defined in the inputs block than are listed in the GATK command. Why is that?

--- a/docs/hello_nextflow/04_hello_genomics.md
+++ b/docs/hello_nextflow/04_hello_genomics.md
@@ -309,8 +309,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.vcf"
-        path "${input_bam}.vcf.idx"
+        path "${input_bam}.vcf"     , emit: vcf
+        path "${input_bam}.vcf.idx" , emit: idx 
 
     """
     gatk HaplotypeCaller \
@@ -321,6 +321,8 @@ process GATK_HAPLOTYPECALLER {
     """
 }
 ```
+
+You'll notice that we've introduced some new syntax here (`emit:`) to uniquely name each of our output channels, and the reasons for this will become clear soon. 
 
 This command takes quite a few more inputs, because GATK needs more information to perform the analysis compared to a simple indexing job.
 But you'll note that there are even more inputs defined in the inputs block than are listed in the GATK command. Why is that?

--- a/docs/hello_nextflow/05_hello_operators.md
+++ b/docs/hello_nextflow/05_hello_operators.md
@@ -331,16 +331,16 @@ _Before:_
 
 ```groovy title="hello-operators.nf" linenums="52"
     output:
-        path "${input_bam}.vcf"
-        path "${input_bam}.vcf.idx"
+        path "${input_bam}.vcf"     , emit: vcf
+        path "${input_bam}.vcf.idx" , emit: idx
 ```
 
 _After:_
 
 ```groovy title="hello-operators.nf" linenums="52"
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx
 ```
 
 ### 1.3. Run the pipeline again
@@ -773,8 +773,8 @@ _After:_
 
 ```groovy title="hello-operators.nf" linenums="87"
 output:
-    path "${cohort_name}.joint.vcf"
-    path "${cohort_name}.joint.vcf.idx"
+    path "${cohort_name}.joint.vcf"     , emit: vcf
+    path "${cohort_name}.joint.vcf.idx" , emit: idx
 ```
 
 We're almost done!

--- a/docs/hello_nextflow/05_hello_operators.md
+++ b/docs/hello_nextflow/05_hello_operators.md
@@ -454,14 +454,14 @@ Good news: we can do that using the `collect()` channel operator. Let's add the 
 
 ```groovy title="hello-operators.nf" linenums="118"
 // Collect variant calling outputs across samples
-all_gvcfs_ch = GATK_HAPLOTYPECALLER.out[0].collect()
-all_idxs_ch = GATK_HAPLOTYPECALLER.out[1].collect()
+all_gvcfs_ch = GATK_HAPLOTYPECALLER.out.vcf.collect()
+all_idxs_ch = GATK_HAPLOTYPECALLER.out.idx.collect()
 ```
 
 Does that seem a bit complicated? Let's break this down and translate it into plain language.
 
 1. We're taking the output channel from the `GATK_HAPLOTYPECALLER` process, referred to using the `.out` property.
-2. Each 'element' coming out of the channel is a pair of files: the GVCF and its index file, in that order because that's the order they're listed in the process output block. Conveniently, we can pick out the GVCFs on one hand by adding `[0]` and the index files on the other by adding `[1]` after the `.out` property.
+2. Each 'element' coming out of the channel is a pair of files: the GVCF and its index file, in that order because that's the order they're listed in the process output block. Conveniently, because in the last session we named the outputs of this process (using `emit:`), we can pick out the GVCFs on one hand by adding `.vcf` and the index files on the other by adding `.idx` after the `.out` property. If we had not named those outputs, we would have had to refer to them by `.out[0]` and `.out[1]`, respectively.
 3. We append the `collect()` channel operator to bundle all the GVCF files together into a single element in a new channel called `all_gvcfs_ch`, and do the same with the index files to form the new channel called `all_idxs_ch`.
 
 !!!tip

--- a/docs/hello_nextflow/07_hello_modules.md
+++ b/docs/hello_nextflow/07_hello_modules.md
@@ -292,8 +292,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx 
 
     """
     gatk HaplotypeCaller \

--- a/docs/hello_nextflow/07_hello_modules.md
+++ b/docs/hello_nextflow/07_hello_modules.md
@@ -293,7 +293,7 @@ process GATK_HAPLOTYPECALLER {
 
     output:
         path "${input_bam}.g.vcf"     , emit: vcf
-        path "${input_bam}.g.vcf.idx" , emit: idx 
+        path "${input_bam}.g.vcf.idx" , emit: idx
 
     """
     gatk HaplotypeCaller \

--- a/docs/hello_nextflow/07_hello_modules.md
+++ b/docs/hello_nextflow/07_hello_modules.md
@@ -331,8 +331,8 @@ process GATK_JOINTGENOTYPING {
         path ref_dict
 
     output:
-        path "${cohort_name}.joint.vcf"
-        path "${cohort_name}.joint.vcf.idx"
+        path "${cohort_name}.joint.vcf"     , emit: vcf
+        path "${cohort_name}.joint.vcf.idx" , emit: idx
 
     script:
         def gvcfs_line = all_gvcfs.collect { gvcf -> "-V ${gvcf}" }.join(' ')

--- a/hello-nextflow/hello-config/main.nf
+++ b/hello-nextflow/hello-config/main.nf
@@ -53,8 +53,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/hello-modules/main.nf
+++ b/hello-nextflow/hello-modules/main.nf
@@ -39,8 +39,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/hello-nf-test/modules/local/gatk/haplotypecaller/main.nf
+++ b/hello-nextflow/hello-nf-test/modules/local/gatk/haplotypecaller/main.nf
@@ -18,8 +18,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/hello-nf-test/modules/local/gatk/jointgenotyping/main.nf
+++ b/hello-nextflow/hello-nf-test/modules/local/gatk/jointgenotyping/main.nf
@@ -18,8 +18,8 @@ process GATK_JOINTGENOTYPING {
         path ref_dict
 
     output:
-        path "${cohort_name}.joint.vcf"
-        path "${cohort_name}.joint.vcf.idx"
+        path "${cohort_name}.joint.vcf"     , emit: vcf
+        path "${cohort_name}.joint.vcf.idx" , emit: idx
 
     script:
         def gvcfs_line = all_gvcfs.collect { gvcf -> "-V ${gvcf}" }.join(' ')

--- a/hello-nextflow/hello-operators.nf
+++ b/hello-nextflow/hello-operators.nf
@@ -50,8 +50,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.vcf"
-        path "${input_bam}.vcf.idx"
+        path "${input_bam}.vcf"     , emit: vcf
+        path "${input_bam}.vcf.idx" , emit: idx
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/solutions/hello-config/final-main.nf
+++ b/hello-nextflow/solutions/hello-config/final-main.nf
@@ -39,8 +39,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/solutions/hello-genomics/hello-genomics-2.nf
+++ b/hello-nextflow/solutions/hello-genomics/hello-genomics-2.nf
@@ -51,8 +51,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.vcf"
-        path "${input_bam}.vcf.idx"
+        path "${input_bam}.vcf"     , emit: vcf
+        path "${input_bam}.vcf.idx" , emit: idx 
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/solutions/hello-genomics/hello-genomics-3.nf
+++ b/hello-nextflow/solutions/hello-genomics/hello-genomics-3.nf
@@ -54,8 +54,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.vcf"
-        path "${input_bam}.vcf.idx"
+        path "${input_bam}.vcf"     , emit: vcf
+        path "${input_bam}.vcf.idx" , emit: idx 
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/solutions/hello-genomics/hello-genomics-4.nf
+++ b/hello-nextflow/solutions/hello-genomics/hello-genomics-4.nf
@@ -50,8 +50,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.vcf"
-        path "${input_bam}.vcf.idx"
+        path "${input_bam}.vcf"     , emit: vcf
+        path "${input_bam}.vcf.idx" , emit: idx 
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/solutions/hello-modules/modules/local/gatk/GATK_HAPLOTYPECALLER/main.nf
+++ b/hello-nextflow/solutions/hello-modules/modules/local/gatk/GATK_HAPLOTYPECALLER/main.nf
@@ -18,8 +18,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/solutions/hello-modules/modules/local/gatk/GATK_JOINTGENOTYPING/main.nf
+++ b/hello-nextflow/solutions/hello-modules/modules/local/gatk/GATK_JOINTGENOTYPING/main.nf
@@ -18,8 +18,8 @@ process GATK_JOINTGENOTYPING {
         path ref_dict
 
     output:
-        path "${cohort_name}.joint.vcf"
-        path "${cohort_name}.joint.vcf.idx"
+        path "${cohort_name}.joint.vcf"    , emit: vcf
+        path "${cohort_name}.joint.vcf.idx", emit: idx
 
     script:
         def gvcfs_line = all_gvcfs.collect { gvcf -> "-V ${gvcf}" }.join(' ')

--- a/hello-nextflow/solutions/hello-nf-test/modules/local/gatk/haplotypecaller/main.nf
+++ b/hello-nextflow/solutions/hello-nf-test/modules/local/gatk/haplotypecaller/main.nf
@@ -18,8 +18,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx 
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/solutions/hello-nf-test/modules/local/gatk/jointgenotyping/main.nf
+++ b/hello-nextflow/solutions/hello-nf-test/modules/local/gatk/jointgenotyping/main.nf
@@ -18,8 +18,8 @@ process GATK_JOINTGENOTYPING {
         path ref_dict
 
     output:
-        path "${cohort_name}.joint.vcf"
-        path "${cohort_name}.joint.vcf.idx"
+        path "${cohort_name}.joint.vcf"    , emit: vcf
+        path "${cohort_name}.joint.vcf.idx", emit: idx
 
     script:
         def gvcfs_line = all_gvcfs.collect { gvcf -> "-V ${gvcf}" }.join(' ')

--- a/hello-nextflow/solutions/hello-operators/hello-operators-1.nf
+++ b/hello-nextflow/solutions/hello-operators/hello-operators-1.nf
@@ -50,8 +50,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx 
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/solutions/hello-operators/hello-operators-2.nf
+++ b/hello-nextflow/solutions/hello-operators/hello-operators-2.nf
@@ -53,8 +53,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx 
 
     """
     gatk HaplotypeCaller \

--- a/hello-nextflow/solutions/hello-operators/hello-operators-3.nf
+++ b/hello-nextflow/solutions/hello-operators/hello-operators-3.nf
@@ -53,8 +53,8 @@ process GATK_HAPLOTYPECALLER {
         path interval_list
 
     output:
-        path "${input_bam}.g.vcf"
-        path "${input_bam}.g.vcf.idx"
+        path "${input_bam}.g.vcf"     , emit: vcf
+        path "${input_bam}.g.vcf.idx" , emit: idx 
 
     """
     gatk HaplotypeCaller \


### PR DESCRIPTION
Suggest we use `emit:` on the multi outputs so participants done't think they'r stuck with `FOO.out[0]`.