### PR TITLE
Update devcontainer.json to set NXF_HOME to writable path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
     },
     "remoteEnv": {
-        "NXF_HOME": "/workspaces/.nextflow",
+        "NXF_HOME": "/workspaces/training/.nextflow",
         "HOST_PROJECT_PATH": "${localWorkspaceFolder}"
     },
     // Configure tool-specific properties.


### PR DESCRIPTION
```
$ export NXF_HOME=/workspaces/.nextflow
gitpod /workspaces/training (master) $ nextflow -v
/opt/conda/bin/mkdir: cannot create directory ‘/workspaces/.nextflow’: Permission denied
/opt/conda/bin/mkdir: cannot create directory ‘/workspaces/.nextflow’: Permission denied
```

```
$ export NXF_HOME=/workspaces/training/.nextflow
gitpod /workspaces/training (master) $ nextflow -v
...
CAPSULE: Downloading dependency com.fasterxml.jackson.core:jackson-core:jar:2.16.1
CAPSULE: Downloading dependency org.iq80.leveldb:leveldb:jar:0.12
CAPSULE: Downloading dependency org.apache.groovy:groovy:jar:4.0.19
nextflow version 24.02.0-edge.5907       
```
