### PR TITLE
More specific workspaceMounts for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,10 @@
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
     },
+    "workspaceFolder": "${localWorkspaceFolder}",
+    "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
     "remoteEnv": {
-        "NXF_HOME": "/workspaces/training/.nextflow",
+        "NXF_HOME": "/workspaces/.nextflow",
         "HOST_PROJECT_PATH": "${localWorkspaceFolder}"
     },
     // Configure tool-specific properties.


### PR DESCRIPTION
This fix resolves an issue where Gitpod was mounting the repository at `/workspaces/workspaces/training`, which causes issues with the Docker mounting. 

This change in the devcontainers.json mounts the training material at the same location in the container as it exists in the host, which ensures that mount paths to docker when run inside the container also resolve in the host.