### PR TITLE
No longer any need to pin to an outdated edge version of Nextflow.

### DIFF
--- a/.github/gitpod.Dockerfile
+++ b/.github/gitpod.Dockerfile
@@ -47,8 +47,8 @@ RUN curl -fSL https://github.com/seqeralabs/tower-agent/releases/latest/download
 USER gitpod
 
 # Uncomment if we need to pin the Nextflow version
-ENV NXF_EDGE=1
-ENV NXF_VER=24.02.0-edge
+# ENV NXF_EDGE=1
+# ENV NXF_VER=24.02.0-edge
 
 # Install nextflow, nf-core, Mamba, and pytest-workflow
 RUN conda config --add channels defaults && \


### PR DESCRIPTION
At present, the Dockerfile sets the NXF_VER and NXF_EDGE environment variables, which causes ugly message

```
Nextflow 24.09.2-edge is available - Please consider updating your version to it
```

For all runs. Unpinning these versions (and rebuilding the container) would remove these warnings.