### PR TITLE
Adjust paths so that Gitpod (original) mounting points 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,5 +34,6 @@
             "label": "Application",
             "onAutoForward": "openPreview"
         }
-    }
+    },
+    "postCreateCommand": "mkdir -p /workspace && ln -s /workspaces /workspace/gitpod"
 }


### PR DESCRIPTION
Symlink to required so that paths in the materials that expect the Gitpod (classic) paths still resolve in devcontainers.

In the medium term, we should remove paths and that are specific to the original Gitpod implementation.