### PR TITLE
Update Nextflow version to latest stable (24.10.0)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM ghcr.io/nextflow-io/training:latest
+
+ENV NXF_VER=24.10.0
+ENV NXF_EDGE=0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
     "name": "nfcore",
-    "image": "ghcr.io/nextflow-io/training:latest",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
     "remoteUser": "gitpod",
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}

--- a/docs/hello_nextflow/02_hello_world.md
+++ b/docs/hello_nextflow/02_hello_world.md
@@ -159,7 +159,7 @@ nextflow run hello-world.nf
 You console output should look something like this:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [reverent_carson] DSL2 - revision: 463b611a35
 
@@ -307,7 +307,7 @@ nextflow run hello-world.nf
 The log output should be very similar to the first time your ran the workflow:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [cranky_sinoussi] DSL2 - revision: 30b437bb96
 
@@ -369,7 +369,7 @@ nextflow run hello-world.nf
 The log output should start looking very familiar:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [mighty_lovelace] DSL2 - revision: 6654bc1327
 
@@ -412,7 +412,7 @@ nextflow run hello-world.nf -resume
 The console output should look similar.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [thirsty_gautier] DSL2 - revision: 6654bc1327
 
@@ -557,7 +557,7 @@ nextflow run hello-world.nf
 If you made all four edits correctly, you should get another successful execution:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [prickly_avogadro] DSL2 - revision: b58b6ab94b
 
@@ -613,7 +613,7 @@ nextflow run hello-world.nf --greeting 'Bonjour le monde!'
 Running this should feel extremely familiar by now.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [cheesy_engelbart] DSL2 - revision: b58b6ab94b
 
@@ -652,7 +652,7 @@ nextflow run hello-world.nf
 The output should look the same.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [wise_waddington] DSL2 - revision: 988fc779cf
 
@@ -671,7 +671,7 @@ nextflow run hello-world.nf --greeting 'Konnichiwa!'
 Nextflow's not complaining, that's a good sign:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [prickly_miescher] DSL2 - revision: 988fc779cf
 
@@ -806,7 +806,7 @@ nextflow run hello-world.nf --greeting 'Hello World!'
 Oh, how exciting! There is now an extra line in the log output, which corresponds to the new process we just added:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [magical_brenner] DSL2 - revision: 0e18f34798
 
@@ -876,7 +876,7 @@ nextflow run hello-world.nf
 Well, it certainly seems to run just fine.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [lonely_pare] DSL2 - revision: b9f1d96905
 
@@ -988,7 +988,7 @@ nextflow run hello-world.nf
 Reverting back to the summary view, the output looks like this again:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [jovial_mccarthy] DSL2 - revision: 53f20aeb70
 
@@ -1159,7 +1159,7 @@ nextflow run hello-world.nf
 Once again we see each process get executed three times:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-world.nf` [angry_spence] DSL2 - revision: d171cc0193
 

--- a/docs/hello_nextflow/04_hello_genomics.md
+++ b/docs/hello_nextflow/04_hello_genomics.md
@@ -257,7 +257,7 @@ nextflow run hello-genomics.nf
 The command should produce something like this:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-genomics.nf` [reverent_sinoussi] DSL2 - revision: 41d43ad7fe
 
@@ -407,7 +407,7 @@ nextflow run hello-genomics.nf -resume
 Now if we look at the console output, we see the two processes listed:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-genomics.nf` [grave_volta] DSL2 - revision: 4790abc96a
 
@@ -496,7 +496,7 @@ Funny thing: this _might work_, OR it _might fail_.
 If your workflow run succeeded, run it again until you get an error like this:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-genomics.nf` [loving_pasteur] DSL2 - revision: d2a8e63076
 
@@ -677,7 +677,7 @@ nextflow run hello-genomics.nf
 This time (and every time) everything should run correctly:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-genomics.nf` [special_goldstine] DSL2 - revision: 4cbbf6ea3e
 
@@ -795,7 +795,7 @@ nextflow run hello-genomics.nf -resume
 This should produce the same result as before, right?
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-genomics.nf` [sick_albattani] DSL2 - revision: 46d84642f6
 

--- a/docs/hello_nextflow/05_hello_operators.md
+++ b/docs/hello_nextflow/05_hello_operators.md
@@ -301,7 +301,7 @@ nextflow run hello-operators.nf
 And the output is... all red! Oh no.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-operators.nf` [nice_gates] DSL2 - revision: 43c7de9890
 
@@ -354,7 +354,7 @@ nextflow run hello-operators.nf -resume
 Ah, this time it works.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-operators.nf` [elated_carlsson] DSL2 - revision: 6a5786a6fa
 
@@ -502,7 +502,7 @@ nextflow run hello-operators.nf -resume
 It run fairly quickly, since we're running with `-resume`, but...
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-operators.nf` [mad_edison] DSL2 - revision: 6aea0cfded
 
@@ -627,7 +627,7 @@ nextflow run hello-operators.nf -resume
 Aha! It seems to be working now.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-operators.nf` [special_noyce] DSL2 - revision: 11f7a51bbe
 
@@ -824,7 +824,7 @@ nextflow run hello-operators.nf -resume
 And it works!
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-operators.nf` [modest_gilbert] DSL2 - revision: 4f49922223
 

--- a/docs/hello_nextflow/06_hello_config.md
+++ b/docs/hello_nextflow/06_hello_config.md
@@ -93,7 +93,7 @@ This should run successfully:
 ```console title="Output"
 Nextflow 24.09.2-edge is available - Please consider updating your version to it
 
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [tender_brahmagupta] DSL2 - revision: 848ff2f9b5
 
@@ -152,7 +152,7 @@ nextflow run main.nf
 As expected, the run fails with an error message that looks like this:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `hello-config/main.nf` [silly_ramanujan] DSL2 - revision: 9129bc4618
 
@@ -310,7 +310,7 @@ nextflow run main.nf
 This will take a bit longer than usual the first time, and you might see the console output stay 'stuck' at this stage for a minute or so:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [extravagant_thompson] DSL2 - revision: 848ff2f9b5
 
@@ -325,7 +325,7 @@ That's because Nextflow has to retrieve the Conda packages and create the enviro
 After a few moments, it should spit out some more output, and eventually complete without error.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [silly_goldstine] DSL2 - revision: a60f9fd6af
 
@@ -402,7 +402,7 @@ nextflow run main.nf -profile conda_on
 It works! Convenient, isn't it?
 
 ```
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [sharp_gauss] DSL2 - revision: 66cd7c255a
 
@@ -478,7 +478,7 @@ As expected, this fails with a fairly unambiguous error:
 
 ```console title="Output"
 nextflow
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [grave_gauss] DSL2 - revision: 66cd7c255a
 
@@ -581,7 +581,7 @@ nextflow run main.nf -profile docker_on,local_exec
 With that, we've returned to the original configuration of using Docker containers with local execution, not that you can tell from the console output:
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [irreverent_bassi] DSL2 - revision: 66cd7c255a
 
@@ -903,7 +903,7 @@ nextflow run main.nf -profile my_laptop -resume
 Not only does everything work, but all of the process calls are recognized as having been run previously.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [modest_kay] DSL2 - revision: 328869237b
 
@@ -976,7 +976,7 @@ nextflow run main.nf -profile my_laptop -params-file demo-params.json
 It works! And as expected, this produces the same outputs as previously.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [marvelous_mandelbrot] DSL2 - revision: 328869237b
 
@@ -1126,7 +1126,7 @@ nextflow run main.nf -profile my_laptop,demo
 And it works perfectly!
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [cheesy_shaw] DSL2 - revision: 328869237b
 

--- a/docs/hello_nextflow/07_hello_modules.md
+++ b/docs/hello_nextflow/07_hello_modules.md
@@ -73,7 +73,7 @@ nextflow run main.nf -profile my_laptop,demo
 And so it does.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [special_brenner] DSL2 - revision: 5a07b4894b
 
@@ -220,7 +220,7 @@ nextflow run main.nf -profile my_laptop,demo -resume
 Sure enough, Nextflow recognizes that it's still all the same work to be done, even if the code is split up into multiple files.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [agitated_cuvier] DSL2 - revision: 0ce0cd0c04
 

--- a/docs/hello_nextflow/08_hello_nf-test.md
+++ b/docs/hello_nextflow/08_hello_nf-test.md
@@ -70,7 +70,7 @@ nextflow run main.nf -profile my_laptop,demo
 This should look very familiar by now if you've been working through this training course from the start.
 
 ```console title="Output"
- N E X T F L O W   ~  version 24.02.0-edge
+ N E X T F L O W   ~  version 24.10.0
 
  ┃ Launching `main.nf` [special_brenner] DSL2 - revision: 5a07b4894b
 


### PR DESCRIPTION
I would argue that training should not be done on an edge version of Nextflow. This was originally set so that we could get early access to Phil's very fancy coloured outputs. This feature has been in stable Nextflow for some time, so we can safely move to a stable version of Nextflow.

This will also (temporarily) prevent the ugly message about a new Nextflow version on every run.