### PR TITLE
Make cd less specific

### DIFF
--- a/docs/hello_nextflow/03_hello_containers.md
+++ b/docs/hello_nextflow/03_hello_containers.md
@@ -112,11 +112,7 @@ When you run a container, it is isolated from the host system by default.
 This means that the container can't access any files on the host system unless you explicitly tell it to.
 One way to do this is to **mount** a **volume** from the host system into the container.
 
-Prior to working on the next task, confirm that you are in the `hello-nextflow` directory.
-
-```bash
-cd /workspace/gitpod/hello-nextflow
-```
+Prior to working on the next task, confirm that you are in the `hello-nextflow` directory. Thelast part of the path shown when you type `pwd` should be `hello-nextflow`.
 
 Then run:
 

--- a/docs/hello_nextflow/03_hello_containers.md
+++ b/docs/hello_nextflow/03_hello_containers.md
@@ -112,7 +112,7 @@ When you run a container, it is isolated from the host system by default.
 This means that the container can't access any files on the host system unless you explicitly tell it to.
 One way to do this is to **mount** a **volume** from the host system into the container.
 
-Prior to working on the next task, confirm that you are in the `hello-nextflow` directory. Thelast part of the path shown when you type `pwd` should be `hello-nextflow`.
+Prior to working on the next task, confirm that you are in the `hello-nextflow` directory. The last part of the path shown when you type `pwd` should be `hello-nextflow`.
 
 Then run:
 

--- a/docs/hello_nextflow/04_hello_genomics.md
+++ b/docs/hello_nextflow/04_hello_genomics.md
@@ -54,8 +54,7 @@ The tools we need (Samtools and GATK) are not installed in the Gitpod environmen
 
 !!! note
 
-     Make sure you're in the correct working directory:
-     `cd /workspace/gitpod/hello-nextflow`
+     Make sure you're in the `hello-nextflow` directory so that the last part of the path shown when you type `pwd` is `hello-nextflow`.
 
 ### 0.1. Index a BAM input file with Samtools
 


### PR DESCRIPTION
This is a fudge, but while we transition to GitPod Flex/ devcontainers, it would be helpful in the first instance if we didn't direct users to do breaking 'cd' operations.

While we have symlinked the alternative gitpod location in https://github.com/nextflow-io/training/pull/462, working within those symlinks will not work (e.g. paths are not valid when we do docker-outside-docker). 

So it would be good if we kept the instructions more generic.