### PR TITLE
Replace numeric with named outputs for GATK_HAPLOTYPECALLER

### DIFF
--- a/hello-nextflow/hello-config/main.nf
+++ b/hello-nextflow/hello-config/main.nf
@@ -133,8 +133,8 @@ workflow {
     )
 
     // Collect variant calling outputs across samples
-    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out[0].collect()
-    all_idxs_ch = GATK_HAPLOTYPECALLER.out[1].collect()
+    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out.vcf.collect()
+    all_idxs_ch = GATK_HAPLOTYPECALLER.out.idx.collect()
 
     // Combine GVCFs into a GenomicsDB data store and apply joint genotyping
     GATK_JOINTGENOTYPING(

--- a/hello-nextflow/hello-modules/main.nf
+++ b/hello-nextflow/hello-modules/main.nf
@@ -117,8 +117,8 @@ workflow {
     )
 
     // Collect variant calling outputs across samples
-    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out[0].collect()
-    all_idxs_ch = GATK_HAPLOTYPECALLER.out[1].collect()
+    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out.vcf.collect()
+    all_idxs_ch = GATK_HAPLOTYPECALLER.out.idx.collect()
 
     // Combine GVCFs into a GenomicsDB data store and apply joint genotyping
     GATK_JOINTGENOTYPING(

--- a/hello-nextflow/hello-nf-test/main.nf
+++ b/hello-nextflow/hello-nf-test/main.nf
@@ -27,10 +27,10 @@ workflow {
         ref_dict_file,
         intervals_file
     )
-
+    
     // Collect variant calling outputs across samples
-    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out[0].collect()
-    all_idxs_ch = GATK_HAPLOTYPECALLER.out[1].collect()
+    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out.vcf.collect()
+    all_idxs_ch = GATK_HAPLOTYPECALLER.out.idx.collect()
 
     // Combine GVCFs into a GenomicsDB data store and apply joint genotyping
     GATK_JOINTGENOTYPING(

--- a/hello-nextflow/solutions/hello-config/final-main.nf
+++ b/hello-nextflow/solutions/hello-config/final-main.nf
@@ -117,8 +117,8 @@ workflow {
     )
 
     // Collect variant calling outputs across samples
-    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out[0].collect()
-    all_idxs_ch = GATK_HAPLOTYPECALLER.out[1].collect()
+    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out.vcf.collect()
+    all_idxs_ch = GATK_HAPLOTYPECALLER.out.idx.collect()
 
     // Combine GVCFs into a GenomicsDB data store and apply joint genotyping
     GATK_JOINTGENOTYPING(

--- a/hello-nextflow/solutions/hello-modules/final-main.nf
+++ b/hello-nextflow/solutions/hello-modules/final-main.nf
@@ -29,8 +29,8 @@ workflow {
     )
 
     // Collect variant calling outputs across samples
-    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out[0].collect()
-    all_idxs_ch = GATK_HAPLOTYPECALLER.out[1].collect()
+    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out.vcf.collect()
+    all_idxs_ch = GATK_HAPLOTYPECALLER.out.idx.collect()
 
     // Combine GVCFs into a GenomicsDB data store and apply joint genotyping
     GATK_JOINTGENOTYPING(

--- a/hello-nextflow/solutions/hello-operators/hello-operators-2.nf
+++ b/hello-nextflow/solutions/hello-operators/hello-operators-2.nf
@@ -120,8 +120,8 @@ workflow {
     )
 
     // Collect variant calling outputs across samples
-    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out[0].collect()
-    all_idxs_ch = GATK_HAPLOTYPECALLER.out[1].collect()
+    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out.vcf.collect()
+    all_idxs_ch = GATK_HAPLOTYPECALLER.out.idx.collect()
 
     // Combine GVCFs into a GenomicsDB datastore
     GATK_GENOMICSDB(

--- a/hello-nextflow/solutions/hello-operators/hello-operators-3.nf
+++ b/hello-nextflow/solutions/hello-operators/hello-operators-3.nf
@@ -130,8 +130,8 @@ workflow {
     )
 
     // Collect variant calling outputs across samples
-    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out[0].collect()
-    all_idxs_ch = GATK_HAPLOTYPECALLER.out[1].collect()
+    all_gvcfs_ch = GATK_HAPLOTYPECALLER.out.vcf.collect()
+    all_idxs_ch = GATK_HAPLOTYPECALLER.out.idx.collect()
 
     // Combine GVCFs into a GenomicsDB data store and apply joint genotyping
     GATK_JOINTGENOTYPING(


### PR DESCRIPTION
Some previous outputs of GATK_HAPLOTYPECALLER were still integer based instead of named. This PR replaces them.