### PR TITLE
Additional curly bracket in hello-nf-test doc

### DIFF
--- a/docs/hello_nextflow/08_hello_nf-test.md
+++ b/docs/hello_nextflow/08_hello_nf-test.md
@@ -975,7 +975,6 @@ test("family_trio [vcf] [idx]") {
             """
         }
     }
-}
 ```
 
 ### 3.4. Use content assertions


### PR DESCRIPTION
There is an additional curly bracket in hello-nf-test. This removes it.