### PR TITLE
Better handle assets dir in nf-core section

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -30,7 +30,7 @@ tasks:
 
     - name: Start Nextflow Tutorial
       env:
-          NXF_HOME: "/home/gitpod/.nextflow"
+          NXF_HOME: "/workspace/gitpod/.nextflow"
       command: |
           cd hello-nextflow
           source $HOME/.bashrc

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -29,6 +29,8 @@ tasks:
       command: docker pull -q nextflow/rnaseq-nf
 
     - name: Start Nextflow Tutorial
+      env:
+          NXF_HOME: "/home/gitpod/.nextflow"
       command: |
           cd hello-nextflow
           source $HOME/.bashrc

--- a/docs/hello_nextflow/09_hello_nf-core.md
+++ b/docs/hello_nextflow/09_hello_nf-core.md
@@ -63,7 +63,7 @@ However nf-core is the largest open curated collection of Nextflow pipelines.
 
 !!!tip
 
-    One detail that sometimes trips people up is that the pipelines you pull this way are stored in a hidden assets folder. By default this is at `$HOME/.nextflow/assets`, but in this training environment you can check `$NXF_HOME/assets`:
+    Pulled pipelines are stored in a hidden assets folder. By default, this folder is `$HOME/.nextflow/assets`, but in this training environment the folder has been set to `$NXF_HOME/assets`:
 
     ```bash
     tree $NXF_HOME/assets/ -L 2

--- a/docs/hello_nextflow/09_hello_nf-core.md
+++ b/docs/hello_nextflow/09_hello_nf-core.md
@@ -66,7 +66,7 @@ However nf-core is the largest open curated collection of Nextflow pipelines.
     One detail that sometimes trips people up is that the pipelines you pull this way are stored in a hidden assets folder:
 
     ```bash
-    tree $HOME/.nextflow/assets/ -L 2
+    tree $NXF_HOME/assets/ -L 2
     ```
 
     ```console title="Output"

--- a/docs/hello_nextflow/09_hello_nf-core.md
+++ b/docs/hello_nextflow/09_hello_nf-core.md
@@ -63,7 +63,7 @@ However nf-core is the largest open curated collection of Nextflow pipelines.
 
 !!!tip
 
-    One detail that sometimes trips people up is that the pipelines you pull this way are stored in a hidden assets folder:
+    One detail that sometimes trips people up is that the pipelines you pull this way are stored in a hidden assets folder. By default this is at `$HOME/.nextflow/assets`, but in this training environment you can check `$NXF_HOME/assets`:
 
     ```bash
     tree $NXF_HOME/assets/ -L 2


### PR DESCRIPTION
Tweak materials to view the assets folder correctly in hello-nf-core.

I've set NXF_HOME in the Gitpod config so we can do something consistent with devcontainers. 