### PR TITLE
Update devcontainer.json for new path structure

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,5 @@
             "onAutoForward": "openPreview"
         }
     },
-    "postCreateCommand": "mkdir -p /workspace && ln -s /workspaces /workspace/gitpod"
+    "postCreateCommand": "mkdir -p /workspace && ln -s /workspaces/training /workspace/gitpod"
 }


### PR DESCRIPTION
Recently created GitPod flex envs suggest we need to update this symlinking, since e.g. /workspace/gitpod/hello-nextflow/data/bam/reads_mother.bam is no longer valid.

I'm not sure why the change occurred, maybe https://github.com/nextflow-io/training/pull/463, we should probably double-check with a fresh org + project in GitPod Flex to be sure. 

**Edit: this seems to be the correct symlinking for quite a fresh org in Flex**