### PR TITLE
🔧 config: add issue template config and bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,48 @@
+name: Bug Report
+description: Report a problem in the training materials.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to report a problem in the training materials.
+              Note: If you are learning Nextflow and need help with the content, ask your questions in the [Seqera community forum](https://community.seqera.io/c/help/37).
+    - type: input
+      id: version
+      attributes:
+          label: Training materials version
+          description: What's the git commit hash of the training materials you are using?
+          placeholder: ex. email@example.com
+      validations:
+          required: false
+    - type: textarea
+      id: whats-wrong
+      attributes:
+          label: What's wrong?
+          description: What's the problem in the training materials?
+          placeholder: Tell us what you see!
+          value: "A bug happened!"
+      validations:
+          required: true
+    - type: textarea
+      id: nextflow-code
+      attributes:
+          label: Nextflow code
+          description: |
+              If relevant, please copy and paste the Nextflow code that you used or constructed following the training materials directions.
+              This will be automatically formatted as Nextflow, so no need for backticks.
+          render: nextflow
+    - type: textarea
+      id: logs
+      attributes:
+          label: Relevant log output
+          description: |
+              Please copy and paste any relevant log output.
+              This will be automatically formatted as shell output, so no need for backticks.
+          render: shell
+    - type: textarea
+      id: additional-info
+      attributes:
+          label: Additional Info
+          description: Any additional information that you think might be helpful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+    - name: Ask for help
+      url: https://community.seqera.io/c/help/37
+      about: If you are learning Nextflow and need help with the content, ask your questions in the Seqera community forum.


### PR DESCRIPTION
This adds an issue template chooser config (see [docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) along with a bug report issue template. 

Together these will encourage folks learning Nextflow to get help in the correct location and ensure we have the info needed for looking into real bugs. 

Might be worth adding a new content and/or improvement issue template as part of a separate PR. In the meantime, this config is set to allow blank issues that don't aren't one of the defined issue types (bug-report). 