### PR TITLE
Add GitHub action to publish new docs on GitHub Release

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,22 @@
+name: Publish docs [release]
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.10.6
+      - name: Install Dependencies
+        run: pip install -r requirements.txt
+      - name: Build Docs Website
+        run: mike deploy --push --alias-type copy --update-aliases ${{ github.event.release.tag_name }} latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pymdown-extensions
 pillow
 cairosvg
 mkdocs-enumerate-headings-plugin>=0.6.0
+mike


### PR DESCRIPTION
Should run whenever a new GitHub release is published.

Based largely on https://github.com/squidfunk/mkdocs-material/discussions/4759#discussioncomment-4405468 plus my own local expiermentation.