### PR TITLE
No nav tabs

### DIFF
--- a/docs/index.es.md
+++ b/docs/index.es.md
@@ -2,7 +2,6 @@
 title: Nextflow Training
 description: ¡Bienvenido al portal de capacitación de la comunidad Nextflow!
 hide:
-  - navigation
   - toc
   - footer
 ---

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -2,7 +2,6 @@
 title: Formation Nextflow
 description: Bienvenue sur le portail de formation de la communauté Nextflow !
 hide:
-  - navigation
   - toc
   - footer
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,6 @@
 title: Nextflow Training
 description: Welcome to the Nextflow community training portal!
 hide:
-  - navigation
   - toc
   - footer
 ---

--- a/docs/index.pt.md
+++ b/docs/index.pt.md
@@ -2,7 +2,6 @@
 title: Portal de Treinamento Nextflow
 description: Seja bem vindo ao portal de treinamento da comunidade do Nextflow!
 hide:
-  - navigation
   - toc
   - footer
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ theme:
     - content.code.annotate
     - content.code.copy
     - navigation.footer
+    - navigation.instant
     - navigation.top
     - navigation.tracking
     - search.share

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,6 @@ theme:
     - content.code.annotate
     - content.code.copy
     - navigation.footer
-    - navigation.tabs
     - navigation.top
     - navigation.tracking
     - search.share


### PR DESCRIPTION
Stacked on top of https://github.com/nextflow-io/training/pull/486

One-line change to remove `- navigation.tabs` from `mkdocs.yml` so that we can see how the nav would look without the Navigation Tabs top-nav.