### PR TITLE
Training small fixes

### DIFF
--- a/docs/hello_nextflow/02_hello_channels.md
+++ b/docs/hello_nextflow/02_hello_channels.md
@@ -540,12 +540,25 @@ _After:_
 ```groovy title="hello-channels.nf" linenums="31"
     // create a channel for inputs
     greeting_ch = Channel.of(greetings_array)
-                         .view { "Before flatten: $it" }
+                         .view { greeting -> "Before flatten: $greeting" }
                          .flatten()
-                         .view { "After flatten: $it" }
+                         .view { greeting -> "After flatten: $greeting" }
 ```
 
-Here `$it` is an implicit variable that represents each individual item loaded in a channel.
+We are using an operator _closure_ here - the squiggly brackets.
+This code executes for each item in the channel.
+We define a temporary variable for the inner value, here called `greeting` (it could be anything).
+This variable is only used within the scope of that closure.
+
+In this example, `$greeting` represents each individual item loaded in a channel.
+
+!!! note "Note on `$it`"
+
+    In some pipelines you may see a special variable called `$it` used inside operator closures.
+    This is an _implicit_ variable that allows a short-hand access to the inner variable,
+    without needing to define it with a `->`.
+
+    We prefer to be explicit to aid code clarity, as such the `$it` syntax is discouraged and will slowly be phased out of the Nextflow language.
 
 #### 3.2.3. Run the workflow
 
@@ -723,9 +736,9 @@ _After:_
 ```groovy title="hello-channels.nf" linenums="31"
 // create a channel for inputs from a CSV file
 greeting_ch = Channel.fromPath(params.greeting)
-                     .view { "Before splitCsv: $it" }
+                     .view { csv -> "Before splitCsv: $csv" }
                      .splitCsv()
-                     .view { "After splitCsv: $it" }
+                     .view { csv -> "After splitCsv: $csv" }
 ```
 
 As you can see, we also include before/after view statements while we're at it.
@@ -798,9 +811,9 @@ _Before:_
 ```groovy title="hello-channels.nf" linenums="31"
 // create a channel for inputs from a CSV file
 greeting_ch = Channel.fromPath(params.greeting)
-                     .view { "Before splitCsv: $it" }
+                     .view { csv -> "Before splitCsv: $csv" }
                      .splitCsv()
-                     .view { "After splitCsv: $it" }
+                     .view { csv -> "After splitCsv: $csv" }
 ```
 
 _After:_
@@ -808,11 +821,11 @@ _After:_
 ```groovy title="hello-channels.nf" linenums="31"
 // create a channel for inputs from a CSV file
 greeting_ch = Channel.fromPath(params.greeting)
-                     .view { "Before splitCsv: $it" }
+                     .view { csv -> "Before splitCsv: $csv" }
                      .splitCsv()
-                     .view { "After splitCsv: $it" }
+                     .view { csv -> "After splitCsv: $csv" }
                      .map { item -> item[0] }
-                     .view { "After map: $it" }
+                     .view { csv -> "After map: $csv" }
 ```
 
 Once again we include another `view()` call to confirm that the operator does what we expect.

--- a/docs/hello_nextflow/02_hello_channels.md
+++ b/docs/hello_nextflow/02_hello_channels.md
@@ -545,7 +545,7 @@ _After:_
                          .view { greeting -> "After flatten: $greeting" }
 ```
 
-We are using an operator _closure_ here - the squiggly brackets.
+We are using an operator _closure_ here - the curly brackets.
 This code executes for each item in the channel.
 We define a temporary variable for the inner value, here called `greeting` (it could be anything).
 This variable is only used within the scope of that closure.

--- a/docs/hello_nextflow/02_hello_channels.md
+++ b/docs/hello_nextflow/02_hello_channels.md
@@ -522,7 +522,7 @@ Here we added the operator on the next line for readability, but you can add ope
 
 #### 3.2.2. Add `view()` to inspect channel contents
 
-We could run this right away to test if it works, but while we're at it, we're also going to add a couple of [`view()`](https://www.nextflow.io/docs/latest/reference/operator.html#view) directives, which allow us to inspect the contents of a channel.
+We could run this right away to test if it works, but while we're at it, we're also going to add a couple of [`view()`](https://www.nextflow.io/docs/latest/reference/operator.html#view) operators, which allow us to inspect the contents of a channel.
 You can think of `view()` as a debugging tool, like a `print()` statement in Python, or its equivalent in other languages.
 
 In the workflow block, make the following code change:
@@ -787,7 +787,7 @@ This is what the syntax looks like:
 
 This means 'for each element in the channel, take the first of any items it contains'.
 
-So let's apply that to our CVS parsing.
+So let's apply that to our CSV parsing.
 
 #### 4.3.1. Apply `map()` to the channel
 

--- a/docs/hello_nextflow/03_hello_workflow.md
+++ b/docs/hello_nextflow/03_hello_workflow.md
@@ -485,8 +485,8 @@ _After:_
     collectGreetings(convertToUpper.out.collect())
 
     // optional view statements
-    convertToUpper.out.view { "Before collect: $it" }
-    convertToUpper.out.collect().view { "After collect: $it" }
+    convertToUpper.out.view { greeting -> "Before collect: $greeting" }
+    convertToUpper.out.collect().view { greeting -> "After collect: $greeting" }
 }
 ```
 
@@ -816,10 +816,8 @@ _After:_
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // emit a message about the size of the batch
-    collectGreetings.out.count.view { "There were $it greetings in this batch" }
+    collectGreetings.out.count.view { num_greetings -> "There were $num_greetings greetings in this batch" }
 ```
-
-Here we are using `$it` in the same way we did earlier, as an implicit variable to access the contents of the channel.
 
 !!! note
 

--- a/docs/hello_nextflow/05_hello_containers.md
+++ b/docs/hello_nextflow/05_hello_containers.md
@@ -434,7 +434,7 @@ _Before:_
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // emit a message about the size of the batch
-    collectGreetings.out.count.view{ "There were $it greetings in this batch" }
+    collectGreetings.out.count.view{ num_greetings -> "There were $num_greetings greetings in this batch" }
 ```
 
 _After:_
@@ -444,7 +444,7 @@ _After:_
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // emit a message about the size of the batch
-    collectGreetings.out.count.view{ "There were $it greetings in this batch" }
+    collectGreetings.out.count.view{ num_greetings -> "There were $num_greetings greetings in this batch" }
 
     // generate ASCII art of the greetings with cowpy
     cowpy(collectGreetings.out.outfile, params.character)

--- a/docs/hello_nextflow/05_hello_containers.md
+++ b/docs/hello_nextflow/05_hello_containers.md
@@ -189,7 +189,7 @@ You can see that the filesystem inside the container is different from the files
     When you run a container, it is isolated from the host system by default.
     This means that the container can't access any files on the host system unless you explicitly allow it to do so.
 
-You will learn how to do that in a minute.
+    You will learn how to do that in a minute.
 
 #### 1.3.2. Run the desired tool command(s)
 


### PR DESCRIPTION
Some minor fixes for things that I spotted whilst recording the new training. I made these edits locally before recording, so they are included in the video footage already.

The main change was removing use of the implicit `$it` variable. See https://nextflow.io/docs/latest/updating-syntax.html#deprecated-syntax for details:

![CleanShot 2025-03-05 at 09 44 48@2x](https://github.com/user-attachments/assets/88923262-9e12-4911-9113-c7a36fe575a9)
