### PR TITLE
Hide announcement with JS if date is past

### DIFF
--- a/docs/assets/overrides/main.html
+++ b/docs/assets/overrides/main.html
@@ -16,10 +16,36 @@
     ></span>
   </a>
 </div>
-{% if not config.extra.announcement.active %}
 <style type="text/css">
   .md-banner {
     display: none;
   }
 </style>
+{% if config.extra.announcement.active %}
+<script>
+  (function () {
+    function hideAnnouncement() {
+      var announcementDate = new Date(
+        "{{ config.extra.announcement.hide_after }}T00:00:00Z",
+      );
+      var currentDate = new Date();
+      var banner = document.querySelector(".md-banner");
+      if (banner && currentDate <= announcementDate) {
+        banner.style.display = "block";
+      }
+    }
+
+    // Run on initial load
+    hideAnnouncement();
+
+    // Hook into XHR to run after each page update
+    var originalOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function () {
+      this.addEventListener("load", function () {
+        setTimeout(hideAnnouncement, 0); // Ensure it runs after the request completes
+      });
+      return originalOpen.apply(this, arguments);
+    };
+  })();
+</script>
 {% endif %} {% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,7 @@ extra:
     text_bold: March 10-14, 2025
     url: https://community.seqera.io/t/nextflow-training-week-2025-q1/1775/6
     url_text: More info
+    hide_after: 2025-03-15
   # Analytics
   analytics:
     provider: google


### PR DESCRIPTION
Use some Javascript to automatically hide the announcement banner if a specified date has passed.

Means that we can still have the banner active even in fixed statically built releases.

Downside is that there is a slight flicker on page load for the banner, I can't get around that though. I've prioritised the flicker for when it's active, vs. when it's inactive (figure it'll be inactive more of the time).