### PR TITLE
Add docker runOptions to fix default root ownership issues

### DIFF
--- a/nf4-science/genomics/nextflow.config
+++ b/nf4-science/genomics/nextflow.config
@@ -1,1 +1,2 @@
 docker.enabled = true
+docker.runOptions = '-u $(id -u):$(id -g)'


### PR DESCRIPTION
I think we might need to add docker runOptions, this seems to be an issue. cf: https://nextflow.slack.com/archives/C02TH6KNBCN/p1741604416453299