### PR TITLE
`nextflow format hello-nextflow/`

### DIFF
--- a/hello-nextflow/hello-channels.nf
+++ b/hello-nextflow/hello-channels.nf
@@ -1,24 +1,4 @@
 #!/usr/bin/env nextflow
-
-/*
- * Use echo to print 'Hello World!' to a file
- */
-process sayHello {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        val greeting
-
-    output:
-        path 'output.txt'
-
-    script:
-    """
-    echo '$greeting' > output.txt
-    """
-}
-
 /*
  * Pipeline parameters
  */
@@ -28,4 +8,24 @@ workflow {
 
     // emit a greeting
     sayHello(params.greeting)
+}
+
+
+/*
+ * Use echo to print 'Hello World!' to a file
+ */
+process sayHello {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    val greeting
+
+    output:
+    path 'output.txt'
+
+    script:
+    """
+    echo '${greeting}' > output.txt
+    """
 }

--- a/hello-nextflow/hello-config.nf
+++ b/hello-nextflow/hello-config.nf
@@ -1,4 +1,10 @@
 #!/usr/bin/env nextflow
+// Include modules
+include { sayHello } from './modules/sayHello.nf'
+include { convertToUpper } from './modules/convertToUpper.nf'
+include { collectGreetings } from './modules/collectGreetings.nf'
+include { cowpy } from './modules/cowpy.nf'
+
 
 /*
  * Pipeline parameters
@@ -7,18 +13,13 @@ params.greeting = 'greetings.csv'
 params.batch = 'test-batch'
 params.character = 'turkey'
 
-// Include modules
-include { sayHello } from './modules/sayHello.nf'
-include { convertToUpper } from './modules/convertToUpper.nf'
-include { collectGreetings } from './modules/collectGreetings.nf'
-include { cowpy } from './modules/cowpy.nf'
-
 workflow {
 
     // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
 
     // emit a greeting
     sayHello(greeting_ch)
@@ -30,7 +31,7 @@ workflow {
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // emit a message about the size of the batch
-    collectGreetings.out.count.view { "There were $it greetings in this batch" }
+    collectGreetings.out.count.view { "There were ${it} greetings in this batch" }
 
     // generate ASCII art of the greetings with cowpy
     cowpy(collectGreetings.out.outfile, params.character)

--- a/hello-nextflow/hello-containers.nf
+++ b/hello-nextflow/hello-containers.nf
@@ -1,4 +1,9 @@
 #!/usr/bin/env nextflow
+// Include modules
+include { sayHello } from './modules/sayHello.nf'
+include { convertToUpper } from './modules/convertToUpper.nf'
+include { collectGreetings } from './modules/collectGreetings.nf'
+
 
 /*
  * Pipeline parameters
@@ -6,17 +11,13 @@
 params.greeting = 'greetings.csv'
 params.batch = 'test-batch'
 
-// Include modules
-include { sayHello } from './modules/sayHello.nf'
-include { convertToUpper } from './modules/convertToUpper.nf'
-include { collectGreetings } from './modules/collectGreetings.nf'
-
 workflow {
 
     // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
 
     // emit a greeting
     sayHello(greeting_ch)
@@ -28,5 +29,5 @@ workflow {
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // emit a message about the size of the batch
-    collectGreetings.out.count.view { "There were $it greetings in this batch" }
+    collectGreetings.out.count.view { "There were ${it} greetings in this batch" }
 }

--- a/hello-nextflow/hello-modules.nf
+++ b/hello-nextflow/hello-modules.nf
@@ -1,65 +1,4 @@
 #!/usr/bin/env nextflow
-
-/*
- * Use echo to print 'Hello World!' to a file
- */
-process sayHello {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        val greeting
-
-    output:
-        path "${greeting}-output.txt"
-
-    script:
-    """
-    echo '$greeting' > '$greeting-output.txt'
-    """
-}
-
-/*
- * Use a text replacement tool to convert the greeting to uppercase
- */
-process convertToUpper {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        path input_file
-
-    output:
-        path "UPPER-${input_file}"
-
-    script:
-    """
-    cat '$input_file' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
-    """
-}
-
-/*
- * Collect uppercase greetings into a single output file
- */
-process collectGreetings {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        path input_files
-        val batch_name
-
-    output:
-        path "COLLECTED-${batch_name}-output.txt" , emit: outfile
-        val count_greetings , emit: count
-
-    script:
-        count_greetings = input_files.size()
-    """
-    cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
-    """
-}
-
 /*
  * Pipeline parameters
  */
@@ -69,9 +8,10 @@ params.batch = 'test-batch'
 workflow {
 
     // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
 
     // emit a greeting
     sayHello(greeting_ch)
@@ -83,5 +23,66 @@ workflow {
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // emit a message about the size of the batch
-    collectGreetings.out.count.view { "There were $it greetings in this batch" }
+    collectGreetings.out.count.view { "There were ${it} greetings in this batch" }
+}
+
+
+/*
+ * Use echo to print 'Hello World!' to a file
+ */
+process sayHello {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    val greeting
+
+    output:
+    path "${greeting}-output.txt"
+
+    script:
+    """
+    echo '${greeting}' > '${greeting}-output.txt'
+    """
+}
+
+/*
+ * Use a text replacement tool to convert the greeting to uppercase
+ */
+process convertToUpper {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    path input_file
+
+    output:
+    path "UPPER-${input_file}"
+
+    script:
+    """
+    cat '${input_file}' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    """
+}
+
+/*
+ * Collect uppercase greetings into a single output file
+ */
+process collectGreetings {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    path input_files
+    val batch_name
+
+    output:
+    path "COLLECTED-${batch_name}-output.txt", emit: outfile
+    val count_greetings, emit: count
+
+    script:
+    count_greetings = input_files.size()
+    """
+    cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+    """
 }

--- a/hello-nextflow/hello-workflow.nf
+++ b/hello-nextflow/hello-workflow.nf
@@ -1,4 +1,21 @@
 #!/usr/bin/env nextflow
+/*
+ * Pipeline parameters
+ */
+params.greeting = 'greetings.csv'
+
+workflow {
+
+    // create a channel for inputs from a CSV file
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
+
+    // emit a greeting
+    sayHello(greeting_ch)
+}
+
 
 /*
  * Use echo to print 'Hello World!' to a file
@@ -8,29 +25,13 @@ process sayHello {
     publishDir 'results', mode: 'copy'
 
     input:
-        val greeting
+    val greeting
 
     output:
-        path "${greeting}-output.txt"
+    path "${greeting}-output.txt"
 
     script:
     """
-    echo '$greeting' > '$greeting-output.txt'
+    echo '${greeting}' > '${greeting}-output.txt'
     """
-}
-
-/*
- * Pipeline parameters
- */
-params.greeting = 'greetings.csv'
-
-workflow {
-
-    // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
-
-    // emit a greeting
-    sayHello(greeting_ch)
 }

--- a/hello-nextflow/hello-world.nf
+++ b/hello-nextflow/hello-world.nf
@@ -1,21 +1,20 @@
 #!/usr/bin/env nextflow
+workflow {
+
+    // emit a greeting
+    sayHello()
+}
+
 
 /*
  * Use echo to print 'Hello World!' to a file
  */
 process sayHello {
-
     output:
-        path 'output.txt'
+    path 'output.txt'
 
     script:
     """
     echo 'Hello World!' > output.txt
     """
-}
-
-workflow {
-
-    // emit a greeting
-    sayHello()
 }

--- a/hello-nextflow/solutions/1-hello-world/hello-world-3.nf
+++ b/hello-nextflow/solutions/1-hello-world/hello-world-3.nf
@@ -1,4 +1,10 @@
 #!/usr/bin/env nextflow
+workflow {
+
+    // emit a greeting
+    sayHello()
+}
+
 
 /*
  * Use echo to print 'Hello World!' to a file
@@ -8,16 +14,10 @@ process sayHello {
     publishDir 'results', mode: 'copy'
 
     output:
-        path 'output.txt'
+    path 'output.txt'
 
     script:
     """
     echo 'Hello World!' > output.txt
     """
-}
-
-workflow {
-
-    // emit a greeting
-    sayHello()
 }

--- a/hello-nextflow/solutions/1-hello-world/hello-world-4.nf
+++ b/hello-nextflow/solutions/1-hello-world/hello-world-4.nf
@@ -1,24 +1,4 @@
 #!/usr/bin/env nextflow
-
-/*
- * Use echo to print 'Hello World!' to a file
- */
-process sayHello {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        val greeting
-
-    output:
-        path 'output.txt'
-
-    script:
-    """
-    echo '$greeting' > output.txt
-    """
-}
-
 /*
  * Pipeline parameters
  */
@@ -28,4 +8,24 @@ workflow {
 
     // emit a greeting
     sayHello(params.greeting)
+}
+
+
+/*
+ * Use echo to print 'Hello World!' to a file
+ */
+process sayHello {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    val greeting
+
+    output:
+    path 'output.txt'
+
+    script:
+    """
+    echo '${greeting}' > output.txt
+    """
 }

--- a/hello-nextflow/solutions/2-hello-channels/hello-channels-1.nf
+++ b/hello-nextflow/solutions/2-hello-channels/hello-channels-1.nf
@@ -1,24 +1,4 @@
 #!/usr/bin/env nextflow
-
-/*
- * Use echo to print 'Hello World!' to a file
- */
-process sayHello {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        val greeting
-
-    output:
-        path 'output.txt'
-
-    script:
-    """
-    echo '$greeting' > output.txt
-    """
-}
-
 /*
  * Pipeline parameters
  */
@@ -31,4 +11,24 @@ workflow {
 
     // emit a greeting
     sayHello(greeting_ch)
+}
+
+
+/*
+ * Use echo to print 'Hello World!' to a file
+ */
+process sayHello {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    val greeting
+
+    output:
+    path 'output.txt'
+
+    script:
+    """
+    echo '${greeting}' > output.txt
+    """
 }

--- a/hello-nextflow/solutions/2-hello-channels/hello-channels-2.nf
+++ b/hello-nextflow/solutions/2-hello-channels/hello-channels-2.nf
@@ -1,4 +1,18 @@
 #!/usr/bin/env nextflow
+/*
+ * Pipeline parameters
+ */
+params.greeting = 'Holà mundo!'
+
+workflow {
+
+    // create a channel for inputs
+    greeting_ch = Channel.of('Hello', 'Bonjour', 'Holà')
+
+    // emit a greeting
+    sayHello(greeting_ch)
+}
+
 
 /*
  * Use echo to print 'Hello World!' to a file
@@ -8,27 +22,13 @@ process sayHello {
     publishDir 'results', mode: 'copy'
 
     input:
-        val greeting
+    val greeting
 
     output:
-        path "${greeting}-output.txt"
+    path "${greeting}-output.txt"
 
     script:
     """
-    echo '$greeting' > '$greeting-output.txt'
+    echo '${greeting}' > '${greeting}-output.txt'
     """
-}
-
-/*
- * Pipeline parameters
- */
-params.greeting = 'Holà mundo!'
-
-workflow {
-
-    // create a channel for inputs
-    greeting_ch = Channel.of('Hello','Bonjour','Holà')
-
-    // emit a greeting
-    sayHello(greeting_ch)
 }

--- a/hello-nextflow/solutions/2-hello-channels/hello-channels-3.nf
+++ b/hello-nextflow/solutions/2-hello-channels/hello-channels-3.nf
@@ -1,4 +1,24 @@
 #!/usr/bin/env nextflow
+/*
+ * Pipeline parameters
+ */
+params.greeting = 'Holà mundo'
+
+workflow {
+
+    greetings_array = ['Hello', 'Bonjour', 'Holà']
+
+    // create a channel for inputs
+    greeting_ch = Channel
+        .of(greetings_array)
+        .view { "Before flatten: ${it}" }
+        .flatten()
+        .view { "After flatten: ${it}" }
+
+    // emit a greeting
+    sayHello(greeting_ch)
+}
+
 
 /*
  * Use echo to print 'Hello World!' to a file
@@ -8,32 +28,13 @@ process sayHello {
     publishDir 'results', mode: 'copy'
 
     input:
-        val greeting
+    val greeting
 
     output:
-        path "${greeting}-output.txt"
+    path "${greeting}-output.txt"
 
     script:
     """
-    echo '$greeting' > '$greeting-output.txt'
+    echo '${greeting}' > '${greeting}-output.txt'
     """
-}
-
-/*
- * Pipeline parameters
- */
-params.greeting = 'Holà mundo'
-
-workflow {
-
-    greetings_array = ['Hello','Bonjour','Holà']
-
-    // create a channel for inputs
-    greeting_ch = Channel.of(greetings_array)
-                    .view { "Before flatten: $it" }
-                    .flatten()
-                    .view { "After flatten: $it" }
-
-    // emit a greeting
-    sayHello(greeting_ch)
 }

--- a/hello-nextflow/solutions/2-hello-channels/hello-channels-4.nf
+++ b/hello-nextflow/solutions/2-hello-channels/hello-channels-4.nf
@@ -1,4 +1,26 @@
 #!/usr/bin/env nextflow
+/*
+ * Pipeline parameters
+ */
+params.greeting = 'greetings.csv'
+
+workflow {
+
+    greetings_array = ['Hello', 'Bonjour', 'Holà']
+
+    // create a channel for inputs from a CSV file
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .view { "Before splitCsv: ${it}" }
+        .splitCsv()
+        .view { "After splitCsv: ${it}" }
+        .map { line -> line[0] }
+        .view { "After map: ${it}" }
+
+    // emit a greeting
+    sayHello(greeting_ch)
+}
+
 
 /*
  * Use echo to print 'Hello World!' to a file
@@ -8,34 +30,13 @@ process sayHello {
     publishDir 'results', mode: 'copy'
 
     input:
-        val greeting
+    val greeting
 
     output:
-        path "${greeting}-output.txt"
+    path "${greeting}-output.txt"
 
     script:
     """
-    echo '$greeting' > '$greeting-output.txt'
+    echo '${greeting}' > '${greeting}-output.txt'
     """
-}
-
-/*
- * Pipeline parameters
- */
-params.greeting = 'greetings.csv'
-
-workflow {
-
-    greetings_array = ['Hello','Bonjour','Holà']
-
-    // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .view { "Before splitCsv: $it" }
-                        .splitCsv()
-                        .view { "After splitCsv: $it" }
-                        .map { line -> line[0] }
-                        .view { "After map: $it" }
-
-    // emit a greeting
-    sayHello(greeting_ch)
 }

--- a/hello-nextflow/solutions/3-hello-workflow/hello-workflow-1.nf
+++ b/hello-nextflow/solutions/3-hello-workflow/hello-workflow-1.nf
@@ -1,4 +1,24 @@
 #!/usr/bin/env nextflow
+/*
+ * Pipeline parameters
+ */
+params.greeting = 'greetings.csv'
+
+workflow {
+
+    // create a channel for inputs from a CSV file
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
+
+    // emit a greeting
+    sayHello(greeting_ch)
+
+    // convert the greeting to uppercase
+    convertToUpper(sayHello.out)
+}
+
 
 /*
  * Use echo to print 'Hello World!' to a file
@@ -8,14 +28,14 @@ process sayHello {
     publishDir 'results', mode: 'copy'
 
     input:
-        val greeting
+    val greeting
 
     output:
-        path "${greeting}-output.txt"
+    path "${greeting}-output.txt"
 
     script:
     """
-    echo '$greeting' > '$greeting-output.txt'
+    echo '${greeting}' > '${greeting}-output.txt'
     """
 }
 
@@ -27,32 +47,13 @@ process convertToUpper {
     publishDir 'results', mode: 'copy'
 
     input:
-        path input_file
+    path input_file
 
     output:
-        path "UPPER-${input_file}"
+    path "UPPER-${input_file}"
 
     script:
     """
-    cat '$input_file' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    cat '${input_file}' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
     """
-}
-
-/*
- * Pipeline parameters
- */
-params.greeting = 'greetings.csv'
-
-workflow {
-
-    // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
-
-    // emit a greeting
-    sayHello(greeting_ch)
-
-    // convert the greeting to uppercase
-    convertToUpper(sayHello.out)
 }

--- a/hello-nextflow/solutions/3-hello-workflow/hello-workflow-2.nf
+++ b/hello-nextflow/solutions/3-hello-workflow/hello-workflow-2.nf
@@ -1,62 +1,4 @@
 #!/usr/bin/env nextflow
-
-/*
- * Use echo to print 'Hello World!' to a file
- */
-process sayHello {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        val greeting
-
-    output:
-        path "${greeting}-output.txt"
-
-    script:
-    """
-    echo '$greeting' > '$greeting-output.txt'
-    """
-}
-
-/*
- * Use a text replacement tool to convert the greeting to uppercase
- */
-process convertToUpper {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        path input_file
-
-    output:
-        path "UPPER-${input_file}"
-
-    script:
-    """
-    cat '$input_file' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
-    """
-}
-
-/*
- * Collect uppercase greetings into a single output file
- */
-process collectGreetings {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        path input_files
-
-    output:
-        path "COLLECTED-output.txt"
-
-    script:
-    """
-    cat ${input_files} > 'COLLECTED-output.txt'
-    """
-}
-
 /*
  * Pipeline parameters
  */
@@ -65,9 +7,10 @@ params.greeting = 'greetings.csv'
 workflow {
 
     // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
 
     // emit a greeting
     sayHello(greeting_ch)
@@ -79,6 +22,64 @@ workflow {
     collectGreetings(convertToUpper.out.collect())
 
     // optional view statements
-    convertToUpper.out.view { "Before collect: $it" }
-    convertToUpper.out.collect().view { "After collect: $it" }
+    convertToUpper.out.view { "Before collect: ${it}" }
+    convertToUpper.out.collect().view { "After collect: ${it}" }
+}
+
+
+/*
+ * Use echo to print 'Hello World!' to a file
+ */
+process sayHello {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    val greeting
+
+    output:
+    path "${greeting}-output.txt"
+
+    script:
+    """
+    echo '${greeting}' > '${greeting}-output.txt'
+    """
+}
+
+/*
+ * Use a text replacement tool to convert the greeting to uppercase
+ */
+process convertToUpper {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    path input_file
+
+    output:
+    path "UPPER-${input_file}"
+
+    script:
+    """
+    cat '${input_file}' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    """
+}
+
+/*
+ * Collect uppercase greetings into a single output file
+ */
+process collectGreetings {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    path input_files
+
+    output:
+    path "COLLECTED-output.txt"
+
+    script:
+    """
+    cat ${input_files} > 'COLLECTED-output.txt'
+    """
 }

--- a/hello-nextflow/solutions/3-hello-workflow/hello-workflow-3.nf
+++ b/hello-nextflow/solutions/3-hello-workflow/hello-workflow-3.nf
@@ -1,63 +1,4 @@
 #!/usr/bin/env nextflow
-
-/*
- * Use echo to print 'Hello World!' to a file
- */
-process sayHello {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        val greeting
-
-    output:
-        path "${greeting}-output.txt"
-
-    script:
-    """
-    echo '$greeting' > '$greeting-output.txt'
-    """
-}
-
-/*
- * Use a text replacement tool to convert the greeting to uppercase
- */
-process convertToUpper {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        path input_file
-
-    output:
-        path "UPPER-${input_file}"
-
-    script:
-    """
-    cat '$input_file' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
-    """
-}
-
-/*
- * Collect uppercase greetings into a single output file
- */
-process collectGreetings {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        path input_files
-        val batch_name
-
-    output:
-        path "COLLECTED-${batch_name}-output.txt"
-
-    script:
-    """
-    cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
-    """
-}
-
 /*
  * Pipeline parameters
  */
@@ -67,9 +8,10 @@ params.batch = 'test-batch'
 workflow {
 
     // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
 
     // emit a greeting
     sayHello(greeting_ch)
@@ -81,6 +23,65 @@ workflow {
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // optional view statements
-    convertToUpper.out.view { "Before collect: $it" }
-    convertToUpper.out.collect().view { "After collect: $it" }
+    convertToUpper.out.view { "Before collect: ${it}" }
+    convertToUpper.out.collect().view { "After collect: ${it}" }
+}
+
+
+/*
+ * Use echo to print 'Hello World!' to a file
+ */
+process sayHello {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    val greeting
+
+    output:
+    path "${greeting}-output.txt"
+
+    script:
+    """
+    echo '${greeting}' > '${greeting}-output.txt'
+    """
+}
+
+/*
+ * Use a text replacement tool to convert the greeting to uppercase
+ */
+process convertToUpper {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    path input_file
+
+    output:
+    path "UPPER-${input_file}"
+
+    script:
+    """
+    cat '${input_file}' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    """
+}
+
+/*
+ * Collect uppercase greetings into a single output file
+ */
+process collectGreetings {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    path input_files
+    val batch_name
+
+    output:
+    path "COLLECTED-${batch_name}-output.txt"
+
+    script:
+    """
+    cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+    """
 }

--- a/hello-nextflow/solutions/3-hello-workflow/hello-workflow-4.nf
+++ b/hello-nextflow/solutions/3-hello-workflow/hello-workflow-4.nf
@@ -1,65 +1,4 @@
 #!/usr/bin/env nextflow
-
-/*
- * Use echo to print 'Hello World!' to a file
- */
-process sayHello {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        val greeting
-
-    output:
-        path "${greeting}-output.txt"
-
-    script:
-    """
-    echo '$greeting' > '$greeting-output.txt'
-    """
-}
-
-/*
- * Use a text replacement tool to convert the greeting to uppercase
- */
-process convertToUpper {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        path input_file
-
-    output:
-        path "UPPER-${input_file}"
-
-    script:
-    """
-    cat '$input_file' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
-    """
-}
-
-/*
- * Collect uppercase greetings into a single output file
- */
-process collectGreetings {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        path input_files
-        val batch_name
-
-    output:
-        path "COLLECTED-${batch_name}-output.txt" , emit: outfile
-        val count_greetings , emit: count
-
-    script:
-        count_greetings = input_files.size()
-    """
-    cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
-    """
-}
-
 /*
  * Pipeline parameters
  */
@@ -69,9 +8,10 @@ params.batch = 'test-batch'
 workflow {
 
     // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
 
     // emit a greeting
     sayHello(greeting_ch)
@@ -83,9 +23,66 @@ workflow {
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // emit a message about the size of the batch
-    collectGreetings.out.count.view { "There were $it greetings in this batch" }
+    collectGreetings.out.count.view { "There were ${it} greetings in this batch" }
+}
 
-    // optional view statements
-    //convertToUpper.out.view { "Before collect: $it" }
-    //convertToUpper.out.collect().view { "After collect: $it" }
+
+/*
+ * Use echo to print 'Hello World!' to a file
+ */
+process sayHello {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    val greeting
+
+    output:
+    path "${greeting}-output.txt"
+
+    script:
+    """
+    echo '${greeting}' > '${greeting}-output.txt'
+    """
+}
+
+/*
+ * Use a text replacement tool to convert the greeting to uppercase
+ */
+process convertToUpper {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    path input_file
+
+    output:
+    path "UPPER-${input_file}"
+
+    script:
+    """
+    cat '${input_file}' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    """
+}
+
+/*
+ * Collect uppercase greetings into a single output file
+ */
+process collectGreetings {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    path input_files
+    val batch_name
+
+    output:
+    path "COLLECTED-${batch_name}-output.txt", emit: outfile
+    val count_greetings, emit: count
+
+    script:
+    count_greetings = input_files.size()
+    """
+    cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+    """
 }

--- a/hello-nextflow/solutions/4-hello-modules/hello-modules-2.nf
+++ b/hello-nextflow/solutions/4-hello-modules/hello-modules-2.nf
@@ -1,45 +1,6 @@
 #!/usr/bin/env nextflow
-
-/*
- * Use a text replacement tool to convert the greeting to uppercase
- */
-process convertToUpper {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        path input_file
-
-    output:
-        path "UPPER-${input_file}"
-
-    script:
-    """
-    cat '$input_file' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
-    """
-}
-
-/*
- * Collect uppercase greetings into a single output file
- */
-process collectGreetings {
-
-    publishDir 'results', mode: 'copy'
-
-    input:
-        path input_files
-        val batch_name
-
-    output:
-        path "COLLECTED-${batch_name}-output.txt" , emit: outfile
-        val count_greetings , emit: count
-
-    script:
-        count_greetings = input_files.size()
-    """
-    cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
-    """
-}
+// Include modules
+include { sayHello } from './modules/sayHello.nf'
 
 /*
  * Pipeline parameters
@@ -47,15 +8,13 @@ process collectGreetings {
 params.greeting = 'greetings.csv'
 params.batch = 'test-batch'
 
-// Include modules
-include { sayHello } from './modules/sayHello.nf'
-
 workflow {
 
     // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
 
     // emit a greeting
     sayHello(greeting_ch)
@@ -67,5 +26,47 @@ workflow {
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // emit a message about the size of the batch
-    collectGreetings.out.count.view { "There were $it greetings in this batch" }
+    collectGreetings.out.count.view { "There were ${it} greetings in this batch" }
+}
+
+
+/*
+ * Use a text replacement tool to convert the greeting to uppercase
+ */
+process convertToUpper {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    path input_file
+
+    output:
+    path "UPPER-${input_file}"
+
+    script:
+    """
+    cat '${input_file}' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    """
+}
+
+/*
+ * Collect uppercase greetings into a single output file
+ */
+process collectGreetings {
+
+    publishDir 'results', mode: 'copy'
+
+    input:
+    path input_files
+    val batch_name
+
+    output:
+    path "COLLECTED-${batch_name}-output.txt", emit: outfile
+    val count_greetings, emit: count
+
+    script:
+    count_greetings = input_files.size()
+    """
+    cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+    """
 }

--- a/hello-nextflow/solutions/4-hello-modules/hello-modules-4.nf
+++ b/hello-nextflow/solutions/4-hello-modules/hello-modules-4.nf
@@ -1,4 +1,9 @@
 #!/usr/bin/env nextflow
+// Include modules
+include { sayHello } from './modules/sayHello.nf'
+include { convertToUpper } from './modules/convertToUpper.nf'
+include { collectGreetings } from './modules/collectGreetings.nf'
+
 
 /*
  * Pipeline parameters
@@ -6,17 +11,13 @@
 params.greeting = 'greetings.csv'
 params.batch = 'test-batch'
 
-// Include modules
-include { sayHello } from './modules/sayHello.nf'
-include { convertToUpper } from './modules/convertToUpper.nf'
-include { collectGreetings } from './modules/collectGreetings.nf'
-
 workflow {
 
     // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
 
     // emit a greeting
     sayHello(greeting_ch)
@@ -28,5 +29,5 @@ workflow {
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // emit a message about the size of the batch
-    collectGreetings.out.count.view { "There were $it greetings in this batch" }
+    collectGreetings.out.count.view { "There were ${it} greetings in this batch" }
 }

--- a/hello-nextflow/solutions/4-hello-modules/modules/collectGreetings.nf
+++ b/hello-nextflow/solutions/4-hello-modules/modules/collectGreetings.nf
@@ -6,15 +6,15 @@ process collectGreetings {
     publishDir 'results', mode: 'copy'
 
     input:
-        path input_files
-        val batch_name
+    path input_files
+    val batch_name
 
     output:
-        path "COLLECTED-${batch_name}-output.txt" , emit: outfile
-        val count_greetings , emit: count
+    path "COLLECTED-${batch_name}-output.txt", emit: outfile
+    val count_greetings, emit: count
 
     script:
-        count_greetings = input_files.size()
+    count_greetings = input_files.size()
     """
     cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
     """

--- a/hello-nextflow/solutions/4-hello-modules/modules/convertToUpper.nf
+++ b/hello-nextflow/solutions/4-hello-modules/modules/convertToUpper.nf
@@ -8,13 +8,13 @@ process convertToUpper {
     publishDir 'results', mode: 'copy'
 
     input:
-        path input_file
+    path input_file
 
     output:
-        path "UPPER-${input_file}"
+    path "UPPER-${input_file}"
 
     script:
     """
-    cat '$input_file' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    cat '${input_file}' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
     """
 }

--- a/hello-nextflow/solutions/4-hello-modules/modules/sayHello.nf
+++ b/hello-nextflow/solutions/4-hello-modules/modules/sayHello.nf
@@ -8,13 +8,13 @@ process sayHello {
     publishDir 'results', mode: 'copy'
 
     input:
-        val greeting
+    val greeting
 
     output:
-        path "${greeting}-output.txt"
+    path "${greeting}-output.txt"
 
     script:
     """
-    echo '$greeting' > '$greeting-output.txt'
+    echo '${greeting}' > '${greeting}-output.txt'
     """
 }

--- a/hello-nextflow/solutions/5-hello-containers/hello-containers-2.nf
+++ b/hello-nextflow/solutions/5-hello-containers/hello-containers-2.nf
@@ -1,4 +1,10 @@
 #!/usr/bin/env nextflow
+// Include modules
+include { sayHello } from './modules/sayHello.nf'
+include { convertToUpper } from './modules/convertToUpper.nf'
+include { collectGreetings } from './modules/collectGreetings.nf'
+include { cowpy } from './modules/cowpy.nf'
+
 
 /*
  * Pipeline parameters
@@ -7,18 +13,13 @@ params.greeting = 'greetings.csv'
 params.batch = 'test-batch'
 params.character = 'turkey'
 
-// Include modules
-include { sayHello } from './modules/sayHello.nf'
-include { convertToUpper } from './modules/convertToUpper.nf'
-include { collectGreetings } from './modules/collectGreetings.nf'
-include { cowpy } from './modules/cowpy.nf'
-
 workflow {
 
     // create a channel for inputs from a CSV file
-    greeting_ch = Channel.fromPath(params.greeting)
-                        .splitCsv()
-                        .map { line -> line[0] }
+    greeting_ch = Channel
+        .fromPath(params.greeting)
+        .splitCsv()
+        .map { line -> line[0] }
 
     // emit a greeting
     sayHello(greeting_ch)
@@ -30,7 +31,7 @@ workflow {
     collectGreetings(convertToUpper.out.collect(), params.batch)
 
     // emit a message about the size of the batch
-    collectGreetings.out.count.view { "There were $it greetings in this batch" }
+    collectGreetings.out.count.view { "There were ${it} greetings in this batch" }
 
     // generate ASCII art of the greetings with cowpy
     cowpy(collectGreetings.out.outfile, params.character)

--- a/hello-nextflow/solutions/5-hello-containers/modules/cowpy.nf
+++ b/hello-nextflow/solutions/5-hello-containers/modules/cowpy.nf
@@ -8,14 +8,14 @@ process cowpy {
     container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
 
     input:
-        path input_file
-        val character
+    path input_file
+    val character
 
     output:
-        path "cowpy-${input_file}"
+    path "cowpy-${input_file}"
 
     script:
     """
-    cat $input_file | cowpy -c "$character" > cowpy-${input_file}
+    cat ${input_file} | cowpy -c "${character}" > cowpy-${input_file}
     """
 }

--- a/hello-nextflow/solutions/6-hello-config/modules/cowpy.nf
+++ b/hello-nextflow/solutions/6-hello-config/modules/cowpy.nf
@@ -9,14 +9,14 @@ process cowpy {
     conda 'conda-forge::cowpy==1.1.5'
 
     input:
-        path input_file
-        val character
+    path input_file
+    val character
 
     output:
-        path "cowpy-${input_file}"
+    path "cowpy-${input_file}"
 
     script:
     """
-    cat $input_file | cowpy -c "$character" > cowpy-${input_file}
+    cat ${input_file} | cowpy -c "${character}" > cowpy-${input_file}
     """
 }


### PR DESCRIPTION
Ran the new upcoming `nextflow format` command on the `hello-nextflow` directory.
Once this is out, we'll start to run this formatter on a lot of nf-core code and it should quickly become the established formatting style for Nextflow code. I figure it's good to get ahead of the game and get the training to follow this style too.

No manual changes here at all, purely the automated formatting changes. We'll need to update the markdown code to reflect these changes.

Note that in other docs I've used mkdocs material "snippets" to directly include code files into the markdown without copying + pasting, which makes these kinds of changes easier, not sure if it's worth considering here as we update or not worth the effort.. See [docs](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#snippets), [docs](https://facelessuser.github.io/pymdown-extensions/extensions/snippets/) and example:

https://github.com/nextflow-io/training/blob/ce85956786801eb5cdf5df050bd27cf9eb1157dd/docs/basic_training/containers.md?plain=1#L447-L449

Once we have sign off on the use of this formatting tool and the code style it produces, I can update this PR to also adjust the markdown.

Once that's done we should apply it to all other material, then set up pre-commit to automatically check (/ apply on comment) this auto-formatting.

Phil