### PR TITLE
devcontainers/ci build+push - split by newline not comma for `eventFilterForPush`

### DIFF
--- a/.github/workflows/devcontainer-build-and-push.yml
+++ b/.github/workflows/devcontainer-build-and-push.yml
@@ -59,4 +59,7 @@ jobs:
           cacheFrom: ghcr.io/${{ github.repository }}
           platform: linux/amd64,linux/arm64
           push: filter
-          eventFilterForPush: push,release,workflow_dispatch
+          eventFilterForPush: |
+            push
+            release
+            workflow_dispatch


### PR DESCRIPTION
Hotfix for https://github.com/nextflow-io/training/pull/569 - the image build + push did not push:

https://github.com/nextflow-io/training/actions/runs/13954931238/job/39063529578

```
Post job cleanup.
Image push skipped because GITHUB_EVENT_NAME (push) is not in eventFilterForPush
```

Doing some searches on GitHub finds [this](https://github.com/trxcllnt/devcontainers-ci/blob/be3fd68d800b48cf9a78571fe318c53bfd42aa88/.github/workflows/ci_common.yml#L472-L474), so I guess it needs to split by newlines instead of commas. Undocumented, but trying anyway.