### PR TITLE
Disable java settings causing wrong Java to be used

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -3,6 +3,8 @@
 # Fix for Java options
 printf 'unset JAVA_TOOL_OPTIONS\n' >> $HOME/.bashrc
 unset JAVA_TOOL_OPTIONS
+unset JAVA_CMD
+unset JAVA_HOME
 
 # Customise the terminal command prompt
 printf "export PS1='\\[\\e[3;36m\\]\${PWD#/workspaces/} ->\\[\\e[0m\\] '\n" >> $HOME/.bashrc


### PR DESCRIPTION
Avoid:

```
ERROR: Cannot find Java or it's a wrong version -- please make sure that Java 8 or later (up to 22) is installed
NOTE: Nextflow is trying to use the Java VM defined by the following environment variables:
 JAVA_CMD: /usr/local/sdkman/candidates/java/current/bin/java
 JAVA_HOME: /usr/local/sdkman/candidates/java/current
```

Edit: doesn't seem effective, JAVA_HOME is still set (incorrectly).