### PR TITLE
Add tls client environment variable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,6 @@
         "NXF_HOME": "/workspaces/.nextflow",
         "NXF_EDGE": "0",
         "NXF_VER": "24.10.4",
-        "NXF_OPTS": "'-Djdk.tls.client.protocols=TLSv1.2'"
         // Other env vars
         "HOST_PROJECT_PATH": "/workspaces/training",
         "SHELL": "/bin/bash" // Ush bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,7 @@
         "NXF_HOME": "/workspaces/.nextflow",
         "NXF_EDGE": "0",
         "NXF_VER": "24.10.4",
+        "NXF_OPTS": "'-Djdk.tls.client.protocols=TLSv1.2'"
         // Other env vars
         "HOST_PROJECT_PATH": "/workspaces/training",
         "SHELL": "/bin/bash" // Ush bash

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -13,6 +13,9 @@ printf 'export JAVA_HOME=/opt/conda\nexport JAVA_CMD=/opt/conda/bin/java\n' >> $
 export JAVA_HOME=/opt/conda
 export JAVA_CMD=/opt/conda/bin/java
 
+# Force Java to use TLS 1.2 for outgoing connections to avoid PSK-not-found-errors
+printf "export NXF_OPTS='-Djdk.tls.client.protocols=TLSv1.2'" >> $HOME/.bashrc
+
 # Update Nextflow
 nextflow self-update
 nextflow -version

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -15,6 +15,7 @@ export JAVA_CMD=/opt/conda/bin/java
 
 # Force Java to use TLS 1.2 for outgoing connections to avoid PSK-not-found-errors
 printf "export NXF_OPTS='-Djdk.tls.client.protocols=TLSv1.2'" >> $HOME/.bashrc
+export NXF_OPTS='-Djdk.tls.client.protocols=TLSv1.2'
 
 # Update Nextflow
 nextflow self-update

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -13,6 +13,10 @@ printf 'export JAVA_HOME=/opt/conda\nexport JAVA_CMD=/opt/conda/bin/java\n' >> $
 export JAVA_HOME=/opt/conda
 export JAVA_CMD=/opt/conda/bin/java
 
+# Force Java to use TLS 1.2 for outgoing connections to avoid PSK-not-found-errors
+printf "export NXF_OPTS='-Djdk.tls.client.protocols=TLSv1.2'" >> $HOME/.bashrc
+export NXF_OPTS='-Djdk.tls.client.protocols=TLSv1.2'
+
 # Update Nextflow
 nextflow self-update
 nextflow -version

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -13,10 +13,6 @@ printf 'export JAVA_HOME=/opt/conda\nexport JAVA_CMD=/opt/conda/bin/java\n' >> $
 export JAVA_HOME=/opt/conda
 export JAVA_CMD=/opt/conda/bin/java
 
-# Force Java to use TLS 1.2 for outgoing connections to avoid PSK-not-found-errors
-printf "export NXF_OPTS='-Djdk.tls.client.protocols=TLSv1.2'" >> $HOME/.bashrc
-export NXF_OPTS='-Djdk.tls.client.protocols=TLSv1.2'
-
 # Update Nextflow
 nextflow self-update
 nextflow -version


### PR DESCRIPTION
This should avoid the 

```
WARN: Unable to stage foreign file: https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample2_R1.fastq.gz (try 1 of 3) -- Cause: No PSK available. Unable to resume.
```
error

I tested this on a codespace generated with that branch, and the warning is gone
