### PR TITLE
Post training tweaks

### DIFF
--- a/docs/nf4_science/genomics/02_joint_calling.md
+++ b/docs/nf4_science/genomics/02_joint_calling.md
@@ -704,7 +704,7 @@ _Before:_
 
 _After:_
 
-```groovy title="genomics-2.nf" linenums="89"  hl_lines="6 7 8 9 10"
+```groovy title="genomics-2.nf" linenums="89"  hl_lines="6-10"
     """
     gatk GenomicsDBImport \
         ${gvcfs_line} \
@@ -737,7 +737,7 @@ input:
 
 _After:_
 
-```groovy title="genomics-2.nf" linenums="78"  hl_lines="5 6 7"
+```groovy title="genomics-2.nf" linenums="78"  hl_lines="5-7"
 input:
     path all_gvcfs
     path all_idxs

--- a/docs/nf4_science/genomics/02_joint_calling.md
+++ b/docs/nf4_science/genomics/02_joint_calling.md
@@ -256,7 +256,7 @@ Make sure you add a backslash (`\`) at the end of the previous line when you add
 
 _Before:_
 
-```groovy title="genomics-2.nf" linenums="56"
+```groovy title="genomics-2.nf" linenums="56" hl_lines="4"
     """
     gatk HaplotypeCaller \
         -R ${ref_fasta} \
@@ -268,7 +268,7 @@ _Before:_
 
 _After:_
 
-```groovy title="genomics-2.nf" linenums="56"
+```groovy title="genomics-2.nf" linenums="56" hl_lines="4 6"
     """
     gatk HaplotypeCaller \
         -R ${ref_fasta} \
@@ -580,7 +580,7 @@ Great, let's add our string manipulation line there then, and update the `gatk G
 
 _Before:_
 
-```groovy title="genomics-2.nf" linenums="87"
+```groovy title="genomics-2.nf" linenums="87"  hl_lines="2"
     script:
     """
     gatk GenomicsDBImport \
@@ -592,7 +592,7 @@ _Before:_
 
 _After:_
 
-```groovy title="genomics-2.nf" linenums="87"
+```groovy title="genomics-2.nf" linenums="87"  hl_lines="2"
     script:
     def gvcfs_line = all_gvcfs.collect { gvcf -> "-V ${gvcf}" }.join(' ')
     """
@@ -704,7 +704,7 @@ _Before:_
 
 _After:_
 
-```groovy title="genomics-2.nf" linenums="89"
+```groovy title="genomics-2.nf" linenums="89"  hl_lines="6 7 8 9 10"
     """
     gatk GenomicsDBImport \
         ${gvcfs_line} \
@@ -737,7 +737,7 @@ input:
 
 _After:_
 
-```groovy title="genomics-2.nf" linenums="78"
+```groovy title="genomics-2.nf" linenums="78"  hl_lines="5 6 7"
 input:
     path all_gvcfs
     path all_idxs

--- a/docs/nf4_science/genomics/04_testing.md
+++ b/docs/nf4_science/genomics/04_testing.md
@@ -1076,13 +1076,13 @@ Just correct the name to something meaningful (you'll see why this is useful sho
 
 _Before:_
 
-```groovy title="tests/nf-test.config" linenums="1" hl_lines="1"
+```groovy title="tests/genomics-4.nf.test" linenums="1" hl_lines="1"
     test("Should run without failures") {
 ```
 
 _After:_
 
-```groovy title="nf-test.config" linenums="1" hl_lines="1"
+```groovy title="tests/genomics-4.nf.test" linenums="1" hl_lines="1"
     test("Should run the pipeline without failures") {
 ```
 
@@ -1155,7 +1155,7 @@ nf-test has one more trick up it's sleeve. We can run all the tests at once! Mod
 
 _Before:_
 
-```groovy title="tests/nf-test.config" linenums="1" hl_lines="3"
+```groovy title="nf-test.config" linenums="1" hl_lines="3"
 config {
 
     testsDir "tests"

--- a/docs/nf4_science/genomics/04_testing.md
+++ b/docs/nf4_science/genomics/04_testing.md
@@ -523,7 +523,7 @@ test("Should run without failures") {
 
 _After:_
 
-```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="7" hl_lines="1 2 3 4 5 6 7 8 9 10 11 12"
+```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="7" hl_lines="1-12"
     test("Should call son's haplotype correctly") {
 
         setup {

--- a/docs/nf4_science/genomics/04_testing.md
+++ b/docs/nf4_science/genomics/04_testing.md
@@ -511,7 +511,7 @@ _After:_
 
 ### 2.3. Provide inputs using the setup method
 
-We insert a `setup` block before the `when` block, where we can trigger a run of the `SAMTOOLS_INDEX` process on one of our original input files.
+We insert a `setup` block before the `when` block, where we can trigger a run of the `SAMTOOLS_INDEX` process on one of our original input files. Also, remember as before to change the test name to something meaningful.
 
 _Before:_
 
@@ -706,7 +706,7 @@ SUCCESS: Executed 1 tests in 19.382s
 Add similar tests for the mother and father samples:
 
 ```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="43"
-    test("reads_mother [bam]") {
+    test("Should call mother's haplotype correctly") {
 
         setup {
             run("SAMTOOLS_INDEX") {
@@ -1072,6 +1072,21 @@ nextflow_pipeline {
 }
 ```
 
+Just correct the name to something meaningful (you'll see why this is useful shortly).
+
+_Before:_
+
+```groovy title="tests/nf-test.config" linenums="1" hl_lines="1"
+    test("Should run without failures") {
+```
+
+_After:_
+
+```groovy title="nf-test.config" linenums="1" hl_lines="1"
+    test("Should run the pipeline without failures") {
+```
+
+
 !!!note
 
     In this case the test file can stay where `nf-test` created it.
@@ -1197,7 +1212,7 @@ Test Process SAMTOOLS_INDEX
 
 Test Workflow genomics-4.nf
 
-  Test [c7dbcaca] 'Should run without failures' PASSED (47.92s)
+  Test [c7dbcaca] 'Should run the pipeline without failures' PASSED (47.92s)
 
 
 SUCCESS: Executed 8 tests in 167.772s

--- a/docs/nf4_science/genomics/04_testing.md
+++ b/docs/nf4_science/genomics/04_testing.md
@@ -654,7 +654,7 @@ In practice, we replace the second assertion in the `then` block as follows:
 
 _Before:_
 
-```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="35" hl_lines="2"
+```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="35" hl_lines="3"
 then {
     assert process.success
     assert snapshot(process.out).match()
@@ -663,7 +663,7 @@ then {
 
 _After:_
 
-```console title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="35" hl_lines="2 3"
+```console title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="35" hl_lines="3 4"
         then {
             assert process.success
             assert path(process.out[0][0]).readLines().contains('#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	reads_son')

--- a/docs/nf4_science/genomics/04_testing.md
+++ b/docs/nf4_science/genomics/04_testing.md
@@ -170,7 +170,7 @@ Now we can simplify the `script` section of the test file to a relative path:
 
 _Before:_
 
-```groovy title="modules/samtools/index/tests/main.nf.test" linenums="3"
+```groovy title="modules/samtools/index/tests/main.nf.test" linenums="3" hl_lines="2"
 name "Test Process SAMTOOLS_INDEX"
 script "modules/samtools/index/main.nf"
 process "SAMTOOLS_INDEX"
@@ -178,7 +178,7 @@ process "SAMTOOLS_INDEX"
 
 _After:_
 
-```groovy title="modules/samtools/index/tests/main.nf.test" linenums="3"
+```groovy title="modules/samtools/index/tests/main.nf.test" linenums="3" hl_lines="2"
 name "Test Process SAMTOOLS_INDEX"
 script "../main.nf"
 process "SAMTOOLS_INDEX"
@@ -495,7 +495,7 @@ Finally, don't forget to update the script path:
 
 _Before:_
 
-```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="3"
+```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="3" hl_lines="2"
     name "Test Process GATK_HAPLOTYPECALLER"
     script "modules/gatk/haplotypecaller/main.nf"
     process "GATK_HAPLOTYPECALLER"
@@ -503,7 +503,7 @@ _Before:_
 
 _After:_
 
-```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="3"
+```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="3" hl_lines="2"
     name "Test Process GATK_HAPLOTYPECALLER"
     script "../main.nf"
     process "GATK_HAPLOTYPECALLER"
@@ -515,7 +515,7 @@ We insert a `setup` block before the `when` block, where we can trigger a run of
 
 _Before:_
 
-```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="7"
+```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="7"  hl_lines="1"
 test("Should run without failures") {
 
     when {
@@ -523,7 +523,7 @@ test("Should run without failures") {
 
 _After:_
 
-```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="7"
+```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="7" hl_lines="1 2 3 4 5 6 7 8 9 10 11 12"
     test("Should call son's haplotype correctly") {
 
         setup {
@@ -654,7 +654,7 @@ In practice, we replace the second assertion in the `then` block as follows:
 
 _Before:_
 
-```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="35"
+```groovy title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="35" hl_lines="2"
 then {
     assert process.success
     assert snapshot(process.out).match()
@@ -663,7 +663,7 @@ then {
 
 _After:_
 
-```console title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="35"
+```console title="modules/gatk/haplotypecaller/tests/main.nf.test" linenums="35" hl_lines="2 3"
         then {
             assert process.success
             assert path(process.out[0][0]).readLines().contains('#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	reads_son')
@@ -919,7 +919,7 @@ And don't forget to update the script path:
 
 _Before:_
 
-```groovy title="modules/gatk/jointgenotyping/tests/main.nf.test" linenums="3"
+```groovy title="modules/gatk/jointgenotyping/tests/main.nf.test" linenums="3" hl_lines="2"
 name "Test Process GATK_JOINTGENOTYPING"
 script "modules/gatk/jointgenotyping/main.nf"
 process "GATK_JOINTGENOTYPING"
@@ -927,7 +927,7 @@ process "GATK_JOINTGENOTYPING"
 
 _After:_
 
-```groovy title="modules/gatk/jointgenotyping/tests/main.nf.test" linenums="3"
+```groovy title="modules/gatk/jointgenotyping/tests/main.nf.test" linenums="3" hl_lines="2"
 name "Test Process GATK_JOINTGENOTYPING"
 script "../main.nf"
 process "GATK_JOINTGENOTYPING"
@@ -1140,7 +1140,7 @@ nf-test has one more trick up it's sleeve. We can run all the tests at once! Mod
 
 _Before:_
 
-```groovy title="tests/nf-test.config" linenums="1"
+```groovy title="tests/nf-test.config" linenums="1" hl_lines="3"
 config {
 
     testsDir "tests"
@@ -1153,7 +1153,7 @@ config {
 
 _After:_
 
-```groovy title="nf-test.config" linenums="1"
+```groovy title="nf-test.config" linenums="1" hl_lines="3"
 config {
 
     testsDir "."

--- a/docs/nf4_science/genomics/04_testing.md
+++ b/docs/nf4_science/genomics/04_testing.md
@@ -1086,7 +1086,6 @@ _After:_
     test("Should run the pipeline without failures") {
 ```
 
-
 !!!note
 
     In this case the test file can stay where `nf-test` created it.


### PR DESCRIPTION
Tiny tweaks in response to training delivery today:

1. Add some highlights where code blocks illustrate changes
2. Reinforce renames of tests and add a name to the workflow test to distinguish it in the final collected tests
3. Correct nf-test config path in a block