### PR TITLE
Move check-headings docs to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Table of contents:
   - [Figures \& diagrams](#figures--diagrams)
   - [Content style and formatting](#content-style-and-formatting)
     - [Formatting / linting](#formatting--linting)
+    - [Headings CI tests](#headings-ci-tests)
     - [Admonitions](#admonitions)
   - [Known limitations](#known-limitations)
     - [Code annotations](#code-annotations)
@@ -135,6 +136,33 @@ For paragraphs containing multiple sentences, please start each sentence on a ne
 Doing that produces cleaner diffs for future code reviews.
 The sentences will still be rendered as a continuous paragraph.
 For an example, have a look at the code for this paragraph.
+
+### Headings CI tests
+
+This repository includes a Python tool to validate markdown heading numbering consistency across training materials.
+
+The `check_headings.py` script ensures:
+
+- Sequential numbering at each level (1., 1.1., 1.2., etc.)
+- Trailing periods after heading numbers
+- Heading levels match numbering depth (## for 1., ### for 1.1.)
+
+The easiest way to run it is [with `uv`](https://docs.astral.sh/uv/), which handles dependencies for you automatically:
+
+```bash
+# Check files for issues
+uv run .github/check_headings.py docs/**/*.md
+```
+
+```bash
+# Auto-fix detected issues
+uv run .github/check_headings.py --fix docs/**/*.md
+```
+
+Otherwise, run `pip install typer rich` then `python .github/check_headings.py`.
+
+The script runs automatically in CI on markdown file changes via GitHub Actions,
+and will cause a CI failure if any incorrect headings are found.
 
 ### Admonitions
 

--- a/README.md
+++ b/README.md
@@ -28,34 +28,8 @@ We are excited to have you on the path to writing reproducible and scalable scie
 
 We welcome fixes and improvements from the community. Please fork the repository and create pull-requests with any improvements you'd like to suggest to the docs.
 
-You can find instructions about how to develop the training material code in [`CONTRIBUTING.md`](CONTRIBUTING.md). If you want to contribute with a translation instead, check [`TRANSLATING.md`](TRANSLATING.md).
-
-### Headings CI tests
-
-This repository includes a Python tool to validate markdown heading numbering consistency across training materials.
-
-The `check_headings.py` script ensures:
-
-- Sequential numbering at each level (1., 1.1., 1.2., etc.)
-- Trailing periods after heading numbers
-- Heading levels match numbering depth (## for 1., ### for 1.1.)
-
-The easiest way to run it is [with `uv`](https://docs.astral.sh/uv/), which handles dependencies for you automatically:
-
-```bash
-# Check files for issues
-uv run .github/check_headings.py docs/**/*.md
-```
-
-```bash
-# Auto-fix detected issues
-uv run .github/check_headings.py --fix docs/**/*.md
-```
-
-Otherwise, run `pip install typer rich` then `python .github/check_headings.py`.
-
-The script runs automatically in CI on markdown file changes via GitHub Actions,
-and will cause a CI failure if any incorrect headings are found.
+> [!NOTE]
+> You can find instructions about how to develop the training material code in [`CONTRIBUTING.md`](CONTRIBUTING.md). If you want to contribute with a translation instead, check [`TRANSLATING.md`](TRANSLATING.md).
 
 ## Credits & Copyright
 


### PR DESCRIPTION
Realised that I shouldn't really have put these in the main readme. Moved to contributing and added a more obvious note admonition on the readme to point to this file.