### PR TITLE
Blindly auto-fix all headings

### DIFF
--- a/docs/hello_nextflow/01_hello_world.pt.md
+++ b/docs/hello_nextflow/01_hello_world.pt.md
@@ -103,7 +103,7 @@ Como você pode ver, um script Nextflow envolve dois tipos de componentes princi
 Cada **processo** descreve a(s) operação(ões) que a etapa correspondente no pipeline deve realizar, enquanto o **fluxo de trabalho** descreve a lógica do fluxo de dados que conecta as várias etapas.
 Vamos dar uma olhada mais de perto no bloco **process** primeiro e, depois, no bloco **workflow**.
 
-#### 1.1.1 A definição `process`
+#### 1.1.1. A definição `process`
 
 O primeiro bloco de código descreve um **processo**. A definição do processo começa com a palavra-chave `process`, seguida do nome do processo e, finalmente, do corpo do processo delimitado por chaves.
 O corpo do processo deve conter um bloco de script que especifica o comando a ser executado, que pode ser qualquer coisa que você executaria em um terminal de linha de comando.
@@ -132,7 +132,7 @@ A definição de saída não _determina_ qual saída será criada.
 Ela simplesmente _declara_ qual é a saída esperada, de modo que o Nextflow possa procurá-la quando a execução estiver concluída.
 Isso é necessário para verificar se o comando foi executado com êxito e para passar a saída para processos posteriores, se necessário.
 
-#### 1.1.2 A definição `workflow`
+#### 1.1.2. A definição `workflow`
 
 O segundo bloco de código descreve o **fluxo de trabalho** em si.
 A definição do fluxo de trabalho começa com a palavra-chave `workflow`, seguida de um nome opcional e, em seguida, o corpo do fluxo de trabalho delimitado por chaves.
@@ -240,7 +240,7 @@ Saiba como fazer com que o script produza um arquivo nomeado.
 
 ---
 
-## 3. Enviando a saída para um arquivo
+## 2. Enviando a saída para um arquivo
 
 Em vez de imprimir "Hello World!" na saída padrão, seria melhor salvar essa saída em um arquivo específico, exatamente como fizemos ao executar no terminal anteriormente.
 É assim que a maioria das ferramentas que você executará como parte dos pipelines do mundo real normalmente se comporta; veremos exemplos disso mais tarde.
@@ -390,7 +390,7 @@ Saiba como fazer com que o Nextflow retome a execução de um pipeline usando re
 
 ---
 
-## 4. Usando o recurso `resume` do Nextflow
+## 3. Usando o recurso `resume` do Nextflow
 
 O Nextflow tem uma opção chamada `resume`, que permite que você execute novamente um pipeline que já tenha sido iniciado anteriormente.
 Quando iniciado com `-resume`, qualquer processo que já tenha sido executado exatamente com o mesmo código, configurações e entradas será ignorado.
@@ -433,7 +433,7 @@ Saiba como adicionar entradas variáveis.
 
 ---
 
-## 5. Adicionando entradas variáveis usando um canal
+## 4. Adicionando entradas variáveis usando um canal
 
 Até agora, estamos emitindo uma saudação codificada no comando `process`.
 Agora, vamos adicionar alguma flexibilidade usando uma variável de entrada, para que possamos alterar facilmente a saudação.
@@ -575,7 +575,7 @@ Saiba como passar entradas da linha de comando.
 
 ---
 
-## 6. Usando parâmetros da CLI para entradas
+## 5. Usando parâmetros da CLI para entradas
 
 Queremos poder especificar a entrada da linha de comando, pois essa é a parte que quase sempre será diferente nas execuções subsequentes do fluxo de trabalho.
 
@@ -692,7 +692,7 @@ Saiba como adicionar um segundo processo e encadeá-los.
 
 ---
 
-## 7. Adicionando uma segunda etapa ao fluxo de trabalho
+## 6. Adicionando uma segunda etapa ao fluxo de trabalho
 
 A maioria dos fluxos de trabalho do mundo real envolve mais de uma etapa. Aqui apresentamos um segundo processo que converte o texto em maiúsculas (all-caps), usando o clássico UNIX one-liner:
 
@@ -827,7 +827,7 @@ Saiba como fazer com que o fluxo de trabalho seja executado em um lote de valore
 
 ---
 
-## 8. Modificando o fluxo de trabalho para ser executado em um lote de valores de entrada
+## 7. Modificando o fluxo de trabalho para ser executado em um lote de valores de entrada
 
 Os fluxos de trabalho normalmente são executados em lotes de entradas que devem ser processados em massa, portanto, queremos atualizar o fluxo de trabalho para aceitar vários valores de entrada.
 
@@ -1012,7 +1012,7 @@ Saiba como fazer com que o fluxo de trabalho use um arquivo como sua fonte de va
 
 ---
 
-## 9. Modificando o fluxo de trabalho para usar um arquivo como fonte de valores de entrada
+## 8. Modificando o fluxo de trabalho para usar um arquivo como fonte de valores de entrada
 
 Muitas vezes, quando queremos executar um lote de vários elementos de entrada, os valores de entrada podem estar contidos em um arquivo.
 

--- a/docs/hello_nextflow/03_hello_workflow.it.md
+++ b/docs/hello_nextflow/03_hello_workflow.it.md
@@ -74,7 +74,7 @@ A tal fine, dobbiamo fare tre cose:
 - Scrivere un nuovo processo che racchiuda il comando per la conversione in maiuscolo.
 - Chiamare il nuovo processo nel blocco del workflow e configurarlo per prendere l'output del processo `sayHello()` come input.
 
-## 1.1 Definire il comando per la conversione in maiuscolo e testarlo nel terminale
+### 1.1. Definire il comando per la conversione in maiuscolo e testarlo nel terminale
 
 Per eseguire la conversione dei saluti in maiuscolo, useremo uno strumento UNIX classico chiamato `tr` per 'text replacement' (sostituzione del testo), con la seguente sintassi:
 
@@ -98,7 +98,7 @@ HELLO WORLD
 
 Questo è ciò che proveremo a fare con il nostro workflow.
 
-### 1.1 Scrivere il passaggio di conversione in maiuscolo come un processo Nextflow
+### 1.2. Scrivere il passaggio di conversione in maiuscolo come un processo Nextflow
 
 Possiamo modellare il nostro nuovo processo sul primo, poiché vogliamo usare gli stessi componenti.
 
@@ -131,7 +131,7 @@ Qui, componiamo il secondo nome del file di output in base al nome del file di i
 
     Nextflow determinerà l'ordine delle operazioni in base alla concatenazione degli input e degli output, quindi l'ordine delle definizioni dei processi nello script del flusso di lavoro non è importante. Tuttavia, ti consigliamo di essere gentile con i tuoi collaboratori e con il futuro te stesso, e cercare di scriverle in un ordine logico per motivi di leggibilità."
 
-### 1.2 Aggiungi una chiamata al nuovo processo nel blocco del workflow
+### 1.3. Aggiungi una chiamata al nuovo processo nel blocco del workflow
 
 Ora dobbiamo dire a Nextflow di chiamare effettivamente il processo che abbiamo appena definito.
 
@@ -158,7 +158,7 @@ Nel blocco del workflow, apporta la seguente modifica al codice:
 
 Questo non è ancora funzionante perché non abbiamo specificato cosa deve essere l'input per il processo `convertToUpper()`.
 
-### 1.3 Passare l'output del primo processo al secondo processo
+### 1.4. Passare l'output del primo processo al secondo processo
 
 Ora dobbiamo fare in modo che l'output del processo `sayHello()` fluisca nel processo `convertToUpper()`.
 
@@ -185,7 +185,7 @@ Nel blocco del workflow, apporta la seguente modifica al codice:
 
 Per un caso semplice come questo (un output a un input), è tutto ciò che dobbiamo fare per connettere due processi!
 
-### 1.4 Esegui di nuovo il flusso di lavoro con `-resume`
+### 1.5. Esegui di nuovo il flusso di lavoro con `-resume`
 
 Eseguiamo di nuovo il flusso di lavoro utilizzando il flag `-resume`, poiché abbiamo già eseguito con successo il primo passaggio del workflow.
 
@@ -772,7 +772,7 @@ Nel blocco del processo `collectGreetings`, apporta la seguente modifica al codi
 
 La variabile `count_greetings` verrà calcolata durante l'esecuzione.
 
-### 4.1.2. Emissione del conteggio come output con nome
+#### 4.1.2. Emissione del conteggio come output con nome
 
 In linea di principio, tutto ciò che dobbiamo fare è aggiungere la variabile `count_greetings` al blocco `output:`.
 

--- a/docs/hello_nextflow/03_hello_workflow.md
+++ b/docs/hello_nextflow/03_hello_workflow.md
@@ -98,7 +98,7 @@ HELLO WORLD
 
 That's basically what we're going to try to do with our workflow.
 
-### 1.1. Write the uppercasing step as a Nextflow process
+### 1.2. Write the uppercasing step as a Nextflow process
 
 We can model our new process on the first one, since we want to use all the same components.
 
@@ -132,7 +132,7 @@ Here, we compose the second output filename based on the input filename, similar
     Nextflow will determine the order of operations based on the chaining of inputs and outputs, so the order of the process definitions in the workflow script does not matter.
     However, we do recommend you be kind to your collaborators and to your future self, and try to write them in a logical order for the sake of readability.
 
-### 1.2. Add a call to the new process in the workflow block
+### 1.3. Add a call to the new process in the workflow block
 
 Now we need to tell Nextflow to actually call the process that we just defined.
 
@@ -159,7 +159,7 @@ In the workflow block, make the following code change:
 
 This is not yet functional because we have not specified what should be input to the `convertToUpper()` process.
 
-### 1.3. Pass the output of the first process to the second process
+### 1.4. Pass the output of the first process to the second process
 
 Now we need to make the output of the `sayHello()` process flow into the `convertToUpper()` process.
 
@@ -186,7 +186,7 @@ In the workflow block, make the following code change:
 
 For a simple case like this (one output to one input), that's all we need to do to connect two processes!
 
-### 1.4. Run the workflow again with `-resume`
+### 1.5. Run the workflow again with `-resume`
 
 Let's run this using the `-resume` flag, since we've already run the first step of the workflow successfully.
 
@@ -773,7 +773,7 @@ In the `collectGreetings` process block, make the following code change:
 
 The `count_greetings` variable will be computed at runtime.
 
-### 4.1.2. Emit the count as a named output
+#### 4.1.2. Emit the count as a named output
 
 In principle all we need to do is to add the `count_greetings` variable to the `output:` block.
 

--- a/docs/hello_nextflow/04_hello_modules.it.md
+++ b/docs/hello_nextflow/04_hello_modules.it.md
@@ -93,7 +93,7 @@ Creeremo un file stub per il modulo, copieremo il codice pertinente e lo cancell
 
 A questo punto, basterà aggiungere una dichiarazione di importazione, in modo che Nextflow sappia che deve inserire il codice in questione in fase di esecuzione.
 
-### 2.1.1. Creare un file stub per il nuovo modulo
+#### 2.1.1. Creare un file stub per il nuovo modulo
 
 Creiamo un file vuoto per il modulo, chiamato `sayHello.nf`.
 
@@ -103,7 +103,7 @@ touch modules/sayHello.nf
 
 Questo ci dà un posto dove mettere il codice del processo.
 
-### 2.2. Spostare il codice del processo `sayHello' nel file del modulo
+### 2.1. Spostare il codice del processo `sayHello' nel file del modulo
 
 Copiare l'intera definizione del processo dal file del workflow al file del modulo, assicurandosi di copiare anche lo shebang `#!/usr/bin/env nextflow`.
 
@@ -132,7 +132,7 @@ process sayHello {
 
 Una volta fatto ciò, eliminate la definizione del processo dal file del workflow, ma assicuratevi di lasciare lo shebang al suo posto.
 
-### 2.3. Aggiungere una dichiarazione di importazione prima del blocco del workflow
+### 2.2. Aggiungere una dichiarazione di importazione prima del blocco del workflow
 
 La sintassi per importare un modulo locale è abbastanza semplice:
 
@@ -157,7 +157,7 @@ Inseriamo questo blocco sopra il blocco del workflow e compiliamolo in modo appr
     workflow {
     ```
 
-### 2.4. Eseguite il workflow per verificare che faccia la stessa cosa di prima
+### 2.3. Eseguite il workflow per verificare che faccia la stessa cosa di prima
 
 Stiamo eseguendo il workflow essenzialmente con lo stesso codice e gli stessi input di prima, quindi eseguiamolo con il flag `resume` e vediamo cosa succede.
 

--- a/docs/hello_nextflow/04_hello_modules.md
+++ b/docs/hello_nextflow/04_hello_modules.md
@@ -93,7 +93,7 @@ We're going to create a file stub for the module, copy the relevant code over th
 
 Then all we'll need to do is add an import statement so that Nextflow will know to pull in the relevant code at runtime.
 
-### 2.1.1. Create a file stub for the new module
+#### 2.1.1. Create a file stub for the new module
 
 Let's create an empty file for the module called `sayHello.nf`.
 
@@ -103,7 +103,7 @@ touch modules/sayHello.nf
 
 This gives us a place to put the process code.
 
-### 2.2. Move the `sayHello` process code to the module file
+### 2.1. Move the `sayHello` process code to the module file
 
 Copy the whole process definition over from the workflow file to the module file, making sure to copy over the `#!/usr/bin/env nextflow` shebang too.
 
@@ -132,7 +132,7 @@ process sayHello {
 
 Once that is done, delete the process definition from the workflow file, but make sure to leave the shebang in place.
 
-### 2.3. Add an import declaration before the workflow block
+### 2.2. Add an import declaration before the workflow block
 
 The syntax for importing a local module is fairly straightforward:
 
@@ -157,7 +157,7 @@ Let's insert that above the workflow block and fill it out appropriately.
     workflow {
     ```
 
-### 2.4. Run the workflow to verify that it does the same thing as before
+### 2.3. Run the workflow to verify that it does the same thing as before
 
 We're running the workflow with essentially the same code and inputs as before, so let's run with the `-resume` flag and see what happens.
 

--- a/docs/hello_nextflow/05_hello_containers.it.md
+++ b/docs/hello_nextflow/05_hello_containers.it.md
@@ -396,7 +396,7 @@ process cowpy {
 
 L'output sarà un nuovo file di testo contenente l'ASCII art generata dallo strumento `cowpy`.
 
-### 2.2. Aggiungi cowpy al flusso di lavoro
+### 2.1. Aggiungi cowpy al flusso di lavoro
 
 Ora dobbiamo importare il modulo e chiamare il processo.
 
@@ -537,7 +537,7 @@ Naturalmente, dato che stiamo chiamando lo strumento `cowpy` ma non abbiamo anco
 
 Dobbiamo specificare un container e dire a Nextflow di usarlo per il processo `cowpy()`.
 
-#### 2.3.1. Specificare un container per il processo `cowpy` da utilizzare
+#### 2.3.5. Specificare un container per il processo `cowpy` da utilizzare
 
 Modificare il modulo `cowpy.nf` per aggiungere la direttiva `container` alla definizione del processo come segue:
 
@@ -560,7 +560,7 @@ Modificare il modulo `cowpy.nf` per aggiungere la direttiva `container` alla def
 
 indica a Nextflow che, se l'uso di Docker è abilitato, deve usare l'immagine del container specificata qui per eseguire il processo.
 
-#### 2.3.2. Abilitare l'uso di Docker tramite il file `nextflow.config
+#### 2.3.6. Abilitare l'uso di Docker tramite il file `nextflow.config
 
 Qui anticipiamo leggermente l'argomento della prossima e ultima parte di questo corso (Parte 6), che riguarda la configurazione.
 
@@ -587,7 +587,7 @@ Ora, passiamo a `true` per abilitare Docker:
     However, that only allows us to specify one container for the entire workflow, whereas the approach we just showed you allows us to specify a different container per process.
     This is better for modularity, code maintenance and reproducibility.
 
-#### 2.3.3. Eseguire il workflow con Docker abilitato
+#### 2.3.7. Eseguire il workflow con Docker abilitato
 
 Eseguire il workflow con il flag `resume`:
 
@@ -645,7 +645,7 @@ Si vede che il personaggio sta pronunciando tutti i saluti, proprio come ha fatt
 
 <!-- considering a side quest where we show how to use a conditional to skip the collect step if we want to emit the cowpy'ed greetings individually, and how to use metadata management to assign a specific character to each greeting, maybe do some cross products etc -->
 
-#### 2.3.4. Controllare come Nextflow ha lanciato il task containerizzato
+#### 2.3.8. Controllare come Nextflow ha lanciato il task containerizzato
 
 Diamo un'occhiata alla sottodirectory di lavoro di una delle chiamate al processo cowpy per capire meglio come Nextflow lavora con i container.
 

--- a/docs/hello_nextflow/next_steps.md
+++ b/docs/hello_nextflow/next_steps.md
@@ -12,13 +12,13 @@ Congrats again on completing the Hello Nextflow training course and thank you fo
 
 **Here are our top 3 recommendations for what you can do next to take your Nextflow skills to the next level.**
 
-### 1. See how what you just learned applies to a scientific analysis use case
+## 1. See how what you just learned applies to a scientific analysis use case
 
 **Check out the [Nextflow for Science](../nf4_science/index.md) page** for a list of short standalone courses that demonstrate how to apply the basic concepts and mechanisms presented in Hello Nextflow to common scientific analysis use cases.
 
 If you don't see your domain represented by a relatable use case, let us know in the [Community forum](https://community.seqera.io/) so we can add it to our development list.
 
-### 2. Delve into the details
+## 2. Delve into the details
 
 In the Hello Nextflow course, we keep the level of technical complexity low on purpose to avoid overloading you with information you don't need in order to get started with Nextflow.
 As you move forward with your work, you're going to want to learn how to use the full feature set and power of Nextflow.
@@ -27,7 +27,7 @@ To that end, we are currently working on a collection of Side Quests, which are 
 
 In the meantime, feel free to **browse the [Fundamentals Training](../basic_training/index.md) and [Advanced Training](../advanced/index.md)** to find training exercises about the topics that interest you.
 
-### 3. Learn how to use nf-core resources and the Seqera Platform
+## 3. Learn how to use nf-core resources and the Seqera Platform
 
 **The [nf-core project](https://nf-co.re/) is a worldwide collaborative effort to develop standardized open-source pipelines for a wide range of scientific research applications.**
 It includes [over 100 pipelines](https://nf-co.re/pipelines/) that are available for use out of the box and [well over 1400 process modules](https://nf-co.re/modules/) that can be integrated into your own projects, as well as a rich set of developer tools.


### PR DESCRIPTION
There seem to be some dodgy headings that are now causing CI to fail after https://github.com/nextflow-io/training/pull/596 is merged, if those files are touched.

Ran the auto-fix script to clean them up here, but might need some oversight - especially if some of these are affected by drift between English / translated versions.