### PR TITLE
Update install.sh

### DIFF
--- a/.devcontainer/local-features/apptainer/install.sh
+++ b/.devcontainer/local-features/apptainer/install.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
 # Install Apptainer (Singularity)
-add-apt-repository -y ppa:apptainer/ppa
+
 apt-get update --quiet
+
+# installs add-apt-repository
+apt install --reinstall -y software-properties-common
+
+add-apt-repository -y ppa:apptainer/ppa
 
 apt install -y apptainer
 


### PR DESCRIPTION
The apptainer `install.sh` script is apparently failing silently. This fix should make Apptainer work again inside the container image.