### PR TITLE
Update nextflow to 25.04.06

### DIFF
--- a/.devcontainer/codespaces-dev/devcontainer.json
+++ b/.devcontainer/codespaces-dev/devcontainer.json
@@ -29,7 +29,7 @@
         // Nextflow installation version
         "NXF_HOME": "/workspaces/.nextflow",
         "NXF_EDGE": "0",
-        "NXF_VER": "25.04.3",
+        "NXF_VER": "25.04.06",
         // Other env vars
         "HOST_PROJECT_PATH": "/workspaces/training",
         "SHELL": "/bin/bash" // Ush bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
         // Nextflow installation version
         "NXF_HOME": "/workspaces/.nextflow",
         "NXF_EDGE": "0",
-        "NXF_VER": "25.04.3",
+        "NXF_VER": "25.04.06",
         // Other env vars
         "HOST_PROJECT_PATH": "/workspaces/training",
         "SHELL": "/bin/bash" // Ush bash

--- a/.devcontainer/local-dev/devcontainer.json
+++ b/.devcontainer/local-dev/devcontainer.json
@@ -30,7 +30,7 @@
         // Nextflow installation version
         "NXF_HOME": "/workspaces/training/.nextflow",
         "NXF_EDGE": "0",
-        "NXF_VER": "25.04.3",
+        "NXF_VER": "25.04.06",
         // Other env vars
         "HOST_PROJECT_PATH": "/workspaces/training",
         "SHELL": "/bin/bash" // Ush bash


### PR DESCRIPTION
Update Nextflow version to 25.04.06 in devcontainer configurations as requested.

---
[Slack Thread](https://seqera.slack.com/archives/C07V30EQ4FM/p1754477123279469?thread_ts=1754477123.279469&cid=C07V30EQ4FM)

<a href="https://cursor.com/background-agent?bcId=bc-95ec3899-9311-49fe-bb07-2e70901f948a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95ec3899-9311-49fe-bb07-2e70901f948a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

