### PR TITLE
De-emphasize metadata basics and fix errors in splitting_and_grouping

### DIFF
--- a/docs/side_quests/splitting_and_grouping.md
+++ b/docs/side_quests/splitting_and_grouping.md
@@ -100,7 +100,7 @@ Apply these changes to `main.nf`:
 
 === "After"
 
-    ```groovy title="main.nf" linenums="2" hl_lines="3-5"
+    ```groovy title="main.nf" linenums="2" hl_lines="2-6"
         ch_samples = Channel.fromPath("./data/samplesheet.csv")
             .splitCsv(header: true)
             .map{ row ->


### PR DESCRIPTION
This commit addresses redundancy with the metadata module and fixes several issues in the splitting_and_grouping side quest:

De-duplication changes:
- Strengthen prerequisite to recommend completing metadata module first
- Simplify Section 1.1 to assume familiarity with splitCsv and meta maps
- Show complete meta map structure from the start rather than building up
- Remove redundant explanation of basic concepts already in metadata module
- Remove "Reading data sheets" from Key Concepts (covered in metadata)
- Update Summary to reference metadata module and focus on unique content

Bug fixes:
- Fix malformed subMap syntax (missing closing parenthesis) on lines 604, 607
- Fix variable naming inconsistency: ch_sample -> ch_samples on lines 395, 479
- Standardize spelling: "Tumour" -> "Tumor" for consistency

The module now builds on metadata module foundations while focusing on its unique content: filtering, joining, combining, and grouping operations.