### PR TITLE
Add 'Workflows in the AI era' side quest

### DIFF
--- a/docs/en/docs/side_quests/index.md
+++ b/docs/en/docs/side_quests/index.md
@@ -16,6 +16,7 @@ additional_information:
     - Work efficiently with files using Nextflow file operations
     - Debug common workflow issues systematically
     - Use and build Nextflow plugins
+    - Articulate when a workflow tool is the right answer in an AI-driven analysis world
   audience_prerequisites:
     - "**Audience:** This collection is designed for learners who have completed the Hello Nextflow beginner course and want to go deeper into specific topics."
     - "**Skills:** Experience with the command line and familiarity with basic Nextflow concepts and tooling is assumed."
@@ -45,6 +46,7 @@ If this is your first time exploring the Side Quests, start with the [Orientatio
 | [Splitting and Grouping](./splitting_and_grouping/index.md)             | Techniques for splitting and regrouping data channels                    | 45 mins       |
 | [Testing with nf-test](./nf_test/index.md)                              | Writing and running tests for Nextflow workflows                         | 1 hour        |
 | [Troubleshooting Workflows](./debugging/index.md)                       | Identifying and fixing common workflow errors                            | 1 hour        |
+| [Workflows in the AI era](./workflows_in_the_ai_era/index.md)           | Why a workflow tool when an agent can run your analysis or write the pipeline for you | 90 mins       |
 | [Workflows of Workflows](./workflows_of_workflows/index.md)             | Composing complex pipelines from reusable named workflow modules         | 30 mins       |
 | [Plugin Development](./plugin_development/index.md)                     | Using and building Nextflow plugins                                      | 3 hours       |
 

--- a/docs/en/docs/side_quests/index.md
+++ b/docs/en/docs/side_quests/index.md
@@ -46,7 +46,7 @@ If this is your first time exploring the Side Quests, start with the [Orientatio
 | [Splitting and Grouping](./splitting_and_grouping/index.md)             | Techniques for splitting and regrouping data channels                    | 45 mins       |
 | [Testing with nf-test](./nf_test/index.md)                              | Writing and running tests for Nextflow workflows                         | 1 hour        |
 | [Troubleshooting Workflows](./debugging/index.md)                       | Identifying and fixing common workflow errors                            | 1 hour        |
-| [Workflows in the AI era](./workflows_in_the_ai_era/index.md)           | Why a workflow tool when an agent can run your analysis or write the pipeline for you | 90 mins       |
+| [Workflows in the AI era](./workflows_in_the_ai_era/index.md)           | When to use a workflow tool in an AI-driven world                        | 90 mins       |
 | [Workflows of Workflows](./workflows_of_workflows/index.md)             | Composing complex pipelines from reusable named workflow modules         | 30 mins       |
 | [Plugin Development](./plugin_development/index.md)                     | Using and building Nextflow plugins                                      | 3 hours       |
 

--- a/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
+++ b/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
@@ -1,0 +1,1141 @@
+# Workflow Management Fundamentals
+
+If you're coming from a background of writing scripts for data processing - whether in bash, Python, or any other language - workflow management tools might seem like unnecessary complexity.
+Why learn a whole new framework when your script does the job?
+
+This side quest answers that question through direct experience.
+You'll build a real analysis pipeline using scripts, try to achieve production-quality standards, then rebuild it in Nextflow to see what workflow management actually provides.
+
+!!! note "Why bash?"
+
+    We use bash in Part 1 because it's common for bioinformatics pipelines, but the limitations we'll encounter apply equally to Python scripts, R pipelines, or any approach where you're manually orchestrating tools. The issue isn't the language - it's the scripting approach itself.
+
+---
+
+## What Makes a Good Analysis Pipeline?
+
+Before writing any code, here are the qualities of a production-quality analysis pipeline:
+
+- **Reproducibility** - Same inputs produce identical outputs, every time. Results can be verified and published with confidence.
+- **Software management** - Each task gets its own isolated environment. No dependency conflicts between tools, and a standardized approach across your whole pipeline.
+- **Scalability** - Handles 3 samples or 3,000 without code changes.
+- **Efficient parallelization** - Independent tasks run simultaneously, so analysis completes in hours, not days.
+- **Resource awareness** - Respects memory and CPU limits. No crashed jobs or killed processes.
+- **Failure recovery** - Can resume from where it stopped. A single failure doesn't waste hours of completed work.
+- **Portability** - Runs on laptop, cluster, or cloud with the same code.
+
+These aren't nice-to-haves - they're requirements for serious computational research.
+
+The question is how can we achieve this in one pipeline?
+
+---
+
+## What You'll Build
+
+An RNA-seq analysis pipeline that runs:
+
+1. Quality control (FastQC)
+2. Adapter trimming (fastp)
+3. Transcript quantification (Salmon)
+
+**How this tutorial works:**
+
+| Part | Software | What You'll Do                                       | What You'll Learn                                    |
+| ---- | -------- | ---------------------------------------------------- | ---------------------------------------------------- |
+| 1    | Bash     | Build a pipeline, try to hit those quality standards | How much infrastructure code it takes                |
+| 2    | Nextflow | Rebuild with a workflow manager                      | How the same standards are achieved with less effort |
+
+By the end, you'll understand _why_ workflow managers exist - not from explanation, but from hitting the limitations yourself.
+
+---
+
+## 1. Building a Bash Pipeline
+
+In this part, you'll build an RNA-seq analysis pipeline using bash, aiming for the production-quality standards we defined above.
+We'll see how far we can get - and where things get difficult.
+
+---
+
+### 1.1. Setup
+
+#### The Scenario
+
+You're a bioinformatician analyzing RNA-seq data from a yeast gene expression study.
+You have 3 samples today. Your PI mentions that 50 more samples are coming next week.
+
+#### Navigate to the Working Directory
+
+```bash
+cd side-quests/workflow_management_fundamentals
+```
+
+#### Explore the Starter Files
+
+```bash
+ls -la bash/
+```
+
+```console title="Output"
+bash/
+├── process_sample.sh      # Single sample script (has TODOs)
+├── pipeline_sequential.sh # Multi-sample loop (has TODOs)
+└── pipeline_parallel.sh   # Parallel version (has TODOs)
+```
+
+You'll fill in these starter files as you progress through the tutorial.
+
+#### Examine the Sample Data
+
+```bash
+cat data/samples.csv
+```
+
+```console title="Output"
+sample,fastq_1,fastq_2
+WT_REP1,https://raw.githubusercontent.com/.../SRR6357070_1.fastq.gz,https://...
+WT_REP2,https://raw.githubusercontent.com/.../SRR6357072_1.fastq.gz,https://...
+RAP1_IAA_30M_REP1,https://raw.githubusercontent.com/.../SRR6357076_1.fastq.gz,https://...
+```
+
+Each row is a sample with URLs to paired-end FASTQ files.
+
+---
+
+### 1.2. Installing Your Tools
+
+Before you can run any analysis, you need to install the bioinformatics tools.
+
+#### Create a Conda Environment
+
+=== "Mamba (Recommended)"
+
+    ```bash
+    mamba create -n rnaseq-bash fastqc fastp salmon -c bioconda -c conda-forge -y
+    ```
+
+=== "Conda"
+
+    ```bash
+    conda create -n rnaseq-bash fastqc fastp salmon -c bioconda -c conda-forge -y
+    ```
+
+Watch the output. Notice:
+
+- Dependencies being resolved (sometimes this takes minutes)
+- Packages being downloaded
+- Hope that there are no conflicts...
+
+#### Activate the Environment
+
+```bash
+mamba activate rnaseq-bash
+```
+
+!!! warning "Remember this step"
+
+    Every time you open a new terminal, you must activate this environment again.
+    Forget, and your script fails with "command not found".
+
+#### Verify Installation
+
+```bash
+fastqc --version
+fastp --version
+salmon --version
+```
+
+#### Reflection: The Installation Tax
+
+You just spent time on:
+
+- Choosing a package manager (conda vs mamba vs pip?)
+- Finding the right channel (bioconda)
+- Waiting for dependency resolution
+- Hoping nothing conflicts
+
+This is before writing a single line of analysis code. And this is a simple pipeline - real analyses often need tools with conflicting dependencies that can't coexist in the same environment.
+
+You could improve this with versioned `environment.yml` files, but that's another system you'd need to set up and maintain. Every colleague who runs your pipeline needs to replicate your environment setup.
+
+---
+
+### 1.3. Building Your First Script
+
+Open the starter file `bash/process_sample.sh`. It has the structure ready - you just need to add the tool commands.
+
+```bash
+cat bash/process_sample.sh
+```
+
+```bash title="bash/process_sample.sh"
+#!/bin/bash
+# Process a single RNA-seq sample
+set -e
+
+SAMPLE_ID=$1
+FASTQ_R1_URL=$2
+FASTQ_R2_URL=$3
+
+echo "Processing sample: $SAMPLE_ID"
+
+# Create output directories
+mkdir -p data/fastq results/fastqc results/fastp results/salmon data/salmon_index
+
+# Step 1: Download FASTQ files
+# TODO: Add curl commands to download R1 and R2 files
+
+# Step 2: Run FastQC
+# TODO: Add fastqc command
+
+# Step 3: Run fastp
+# TODO: Add fastp command
+
+# Step 4: Download salmon index (if needed)
+# TODO: Add conditional download of salmon index
+
+# Step 5: Run Salmon quantification
+# TODO: Add salmon quant command
+
+echo "Completed: $SAMPLE_ID"
+```
+
+#### Understanding the Starter Script
+
+The script accepts three arguments: a sample ID and two URLs for paired-end FASTQ files. The `set -e` line means the script will stop immediately if any command fails.
+
+The TODO comments mark where you'll add each analysis step:
+
+1. **Download** - Get the raw sequencing data
+2. **FastQC** - Check the quality of the raw reads
+3. **fastp** - Trim adapters and filter low-quality reads
+4. **Salmon** - Quantify transcript expression levels
+
+This is a typical RNA-seq preprocessing workflow. Fill in each step below.
+
+#### 1.3.1. Add the Download Step
+
+First, we need to download the FASTQ files from their URLs. We'll use `curl` with `-sL` (silent mode, follow redirects) to fetch each file and save it with a consistent naming pattern.
+
+=== "After"
+
+    ```bash title="bash/process_sample.sh" linenums="17" hl_lines="2-4"
+    # Step 1: Download FASTQ files
+    echo "  Downloading FASTQ files..."
+    curl -sL "$FASTQ_R1_URL" -o "data/fastq/${SAMPLE_ID}_R1.fastq.gz"
+    curl -sL "$FASTQ_R2_URL" -o "data/fastq/${SAMPLE_ID}_R2.fastq.gz"
+    ```
+
+=== "Before"
+
+    ```bash title="bash/process_sample.sh" linenums="17"
+    # Step 1: Download FASTQ files
+    # TODO: Add curl commands to download R1 and R2 files
+    ```
+
+#### 1.3.2. Add FastQC
+
+FastQC analyzes sequencing data and generates quality reports. We run it on both read files (`R1` and `R2`) and save the output to our results directory. The `-q` flag suppresses progress output.
+
+=== "After"
+
+    ```bash title="bash/process_sample.sh" linenums="22" hl_lines="3-5"
+    # Step 2: Run FastQC
+    echo "  Running FastQC..."
+    fastqc -q -o results/fastqc \
+        "data/fastq/${SAMPLE_ID}_R1.fastq.gz" \
+        "data/fastq/${SAMPLE_ID}_R2.fastq.gz"
+    ```
+
+=== "Before"
+
+    ```bash title="bash/process_sample.sh" linenums="22"
+    # Step 2: Run FastQC
+    # TODO: Add fastqc command
+    ```
+
+#### 1.3.3. Add fastp
+
+fastp trims adapter sequences and filters out low-quality reads. It takes paired input files (`-i`, `-I`) and produces trimmed output files (`-o`, `-O`), plus JSON and HTML reports for quality metrics.
+
+=== "After"
+
+    ```bash title="bash/process_sample.sh" linenums="28" hl_lines="3-10"
+    # Step 3: Run fastp
+    echo "  Running fastp..."
+    fastp \
+        -i "data/fastq/${SAMPLE_ID}_R1.fastq.gz" \
+        -I "data/fastq/${SAMPLE_ID}_R2.fastq.gz" \
+        -o "results/fastp/${SAMPLE_ID}_trimmed_R1.fastq.gz" \
+        -O "results/fastp/${SAMPLE_ID}_trimmed_R2.fastq.gz" \
+        -j "results/fastp/${SAMPLE_ID}.fastp.json" \
+        -h "results/fastp/${SAMPLE_ID}.fastp.html" \
+        2>/dev/null
+    ```
+
+=== "Before"
+
+    ```bash title="bash/process_sample.sh" linenums="28"
+    # Step 3: Run fastp
+    # TODO: Add fastp command
+    ```
+
+#### 1.3.4. Add Salmon Index Download
+
+Salmon needs a pre-built index of the reference transcriptome. We'll download a pre-built index (to save time) only if it doesn't already exist. This avoids re-downloading for every sample.
+
+=== "After"
+
+    ```bash title="bash/process_sample.sh" linenums="39" hl_lines="2-8"
+    # Step 4: Download salmon index (if needed)
+    if [ ! -d "data/salmon_index/salmon" ]; then
+        echo "  Downloading salmon index..."
+        curl -sL https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz \
+            -o data/salmon_index/salmon.tar.gz
+        tar -xzf data/salmon_index/salmon.tar.gz -C data/salmon_index/
+        rm data/salmon_index/salmon.tar.gz
+    fi
+    ```
+
+=== "Before"
+
+    ```bash title="bash/process_sample.sh" linenums="39"
+    # Step 4: Download salmon index (if needed)
+    # TODO: Add conditional download of salmon index
+    ```
+
+!!! note "Conditional logic in scripts vs workflow managers"
+
+    This `if [ ! -d ... ]` check is a common pattern in scripts - "only do this if it hasn't been done already." While conceptually simple, it's fragile: it checks if a directory exists, not whether the download actually succeeded or the files are valid. Workflow managers handle this more robustly by tracking actual task outputs rather than checking for file/directory existence.
+
+#### 1.3.5. Add Salmon Quantification
+
+Salmon quantifies transcript expression by pseudo-aligning reads to the index. It takes the **trimmed** reads from fastp (not the raw reads) and outputs expression counts per transcript.
+
+=== "After"
+
+    ```bash title="bash/process_sample.sh" linenums="48" hl_lines="2-10"
+    # Step 5: Run Salmon quantification
+    echo "  Running Salmon..."
+    salmon quant \
+        --index data/salmon_index/salmon \
+        --libType A \
+        --mates1 "results/fastp/${SAMPLE_ID}_trimmed_R1.fastq.gz" \
+        --mates2 "results/fastp/${SAMPLE_ID}_trimmed_R2.fastq.gz" \
+        --output "results/salmon/${SAMPLE_ID}" \
+        --threads 2 \
+        --quiet
+    ```
+
+=== "Before"
+
+    ```bash title="bash/process_sample.sh" linenums="48"
+    # Step 5: Run Salmon quantification
+    # TODO: Add salmon quant command
+    ```
+
+#### Test Your Script
+
+Make it executable and run on one sample:
+
+```bash
+chmod +x bash/process_sample.sh
+./bash/process_sample.sh WT_REP1 \
+    "https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357070_1.fastq.gz" \
+    "https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357070_2.fastq.gz"
+```
+
+Check the results:
+
+```bash
+ls results/
+```
+
+This works for one sample, but you have 3 samples (and 50 more coming).
+Running this command manually for each one isn't practical.
+
+---
+
+### 1.4. Processing Multiple Samples
+
+Now that we can process one sample, we need to handle all samples from our CSV file. Open `bash/pipeline_sequential.sh` - it already has the loop structure that reads the CSV and iterates over each sample.
+
+The starter script handles:
+
+- Reading the CSV file and skipping the header row
+- Parsing each line into sample ID and FASTQ URLs
+- Creating output directories and downloading the shared Salmon index
+
+Your task is to add the actual processing commands inside the loop - the same steps you just wrote, but using the loop variables (`$sample_id`, `$fastq_r1`, `$fastq_r2`) instead of the script arguments.
+
+#### Add Processing Logic to the Loop
+
+=== "After"
+
+    ```bash title="bash/pipeline_sequential.sh" linenums="26" hl_lines="5-24"
+    tail -n +2 "$SAMPLES_FILE" | while IFS=',' read -r sample_id fastq_r1 fastq_r2; do
+        echo ""
+        echo "Processing: $sample_id"
+
+        # Download
+        curl -sL "$fastq_r1" -o "data/fastq/${sample_id}_R1.fastq.gz"
+        curl -sL "$fastq_r2" -o "data/fastq/${sample_id}_R2.fastq.gz"
+
+        # FastQC
+        echo "  Running FastQC..."
+        fastqc -q -o results/fastqc "data/fastq/${sample_id}_R1.fastq.gz" "data/fastq/${sample_id}_R2.fastq.gz"
+
+        # fastp
+        echo "  Running fastp..."
+        fastp -i "data/fastq/${sample_id}_R1.fastq.gz" -I "data/fastq/${sample_id}_R2.fastq.gz" \
+            -o "results/fastp/${sample_id}_trimmed_R1.fastq.gz" -O "results/fastp/${sample_id}_trimmed_R2.fastq.gz" \
+            -j "results/fastp/${sample_id}.fastp.json" -h "results/fastp/${sample_id}.fastp.html" 2>/dev/null
+
+        # Salmon
+        echo "  Running Salmon..."
+        salmon quant --index data/salmon_index/salmon --libType A \
+            --mates1 "results/fastp/${sample_id}_trimmed_R1.fastq.gz" \
+            --mates2 "results/fastp/${sample_id}_trimmed_R2.fastq.gz" \
+            --output "results/salmon/${sample_id}" --threads 2 --quiet
+
+        echo "  Done: $sample_id"
+    done
+    ```
+
+=== "Before"
+
+    ```bash title="bash/pipeline_sequential.sh" linenums="26"
+    tail -n +2 "$SAMPLES_FILE" | while IFS=',' read -r sample_id fastq_r1 fastq_r2; do
+        echo ""
+        echo "Processing: $sample_id"
+
+        # TODO: Add the processing steps for each sample
+        # - Download FASTQ files
+        # - Run FastQC
+        # - Run fastp
+        # - Run Salmon
+
+        echo "  Done: $sample_id"
+    done
+    ```
+
+#### Run and Time It
+
+```bash
+chmod +x bash/pipeline_sequential.sh
+time ./bash/pipeline_sequential.sh
+```
+
+Watch the output. Each sample waits for the previous one to finish:
+
+```
+Processing: WT_REP1
+  Running FastQC...
+  Running fastp...
+  Running Salmon...
+  Done: WT_REP1
+
+Processing: WT_REP2      <- Starts only after WT_REP1 is completely done
+```
+
+#### The Problem: Sequential Execution
+
+```
+Timeline (sequential):
+WT_REP1:          [====FastQC====][====fastp====][======Salmon======]
+WT_REP2:                                                              [====FastQC====]...
+```
+
+These samples are **completely independent** - WT_REP2's analysis doesn't depend on WT_REP1's results at all. Yet WT_REP2 sits idle while WT_REP1 runs through all its steps.
+
+With 50 samples, you're looking at **50× the runtime** for no good reason. Your computer has multiple cores sitting unused.
+
+---
+
+### 1.5. Adding Parallelization
+
+The sequential script works, but it's slow - each sample waits for the previous one to finish completely. Since samples are independent, they could run simultaneously.
+
+Open `bash/pipeline_parallel.sh`. This version wraps the processing logic in a function called `process_sample()`. The starter script has everything except the parallelization itself.
+
+Your task is to make the loop run samples in parallel by:
+
+1. Adding `&` after each function call to run it in the background
+2. Adding `wait` after the loop to pause until all background jobs complete
+
+#### Add Background Execution
+
+=== "After"
+
+    ```bash title="bash/pipeline_parallel.sh" linenums="58" hl_lines="4 7"
+    # Process each sample in parallel
+    echo "Launching all samples in parallel..."
+    while IFS=',' read -r sample_id fastq_r1 fastq_r2; do
+        process_sample "$sample_id" "$fastq_r1" "$fastq_r2" &
+    done < <(tail -n +2 "$SAMPLES_FILE")
+
+    wait
+    ```
+
+=== "Before"
+
+    ```bash title="bash/pipeline_parallel.sh" linenums="58"
+    # Process each sample
+    # TODO: Modify this loop to run samples in PARALLEL
+    # Hint: Add & after the function call to run in background
+    while IFS=',' read -r sample_id fastq_r1 fastq_r2; do
+        process_sample "$sample_id" "$fastq_r1" "$fastq_r2"
+    done < <(tail -n +2 "$SAMPLES_FILE")
+
+    # TODO: Add wait command to wait for all background jobs
+    ```
+
+The key changes:
+
+- **`&`** at the end of the function call runs it in the background
+- **`wait`** pauses until all background jobs complete
+
+#### Run and Compare
+
+```bash
+chmod +x bash/pipeline_parallel.sh
+time ./bash/pipeline_parallel.sh
+```
+
+Notice the interleaved output - all samples running at once:
+
+```
+[WT_REP1] Starting...
+[WT_REP2] Starting...
+[RAP1_IAA_30M_REP1] Starting...
+[WT_REP1] Complete!
+[RAP1_IAA_30M_REP1] Complete!
+[WT_REP2] Complete!
+```
+
+Faster, because all samples run concurrently.
+
+#### The Hidden Problem
+
+What happens with 50 samples? Or 500?
+
+```bash
+# This would launch 500 Salmon jobs simultaneously!
+# Each Salmon uses ~4GB RAM
+# That's 500 × 4GB = 2TB RAM required!
+```
+
+Your machine would crash from memory exhaustion. Bash's `&` has no concept of resource limits - it just launches everything at once.
+
+!!! question "How would you limit concurrent jobs?"
+
+    You'd need to track running jobs, wait when at the limit, and start new jobs as others complete. That's 20-30 lines of infrastructure code that has nothing to do with your science. And you'd have to maintain it, debug it, and hope it works correctly under all conditions.
+
+---
+
+### 1.6. Adding Aggregation
+
+Real pipelines need a final aggregation step - collecting QC metrics from all samples into a summary report. MultiQC does this, but integrating it with parallel bash processing is tricky.
+
+#### The Problem
+
+Your parallel script launches all samples with `&` and waits for completion with `wait`. But `wait` only tells you when jobs finish - not which ones succeeded. To run MultiQC, you need to:
+
+1. Track which samples completed successfully
+2. Collect the right output files from each tool
+3. Handle partial failures gracefully
+
+#### A Simple (Fragile) Approach
+
+Add MultiQC after the `wait`:
+
+```bash title="bash/pipeline_parallel.sh" linenums="64"
+wait
+echo "All samples complete. Running MultiQC..."
+
+# Collect outputs - assumes everything succeeded
+multiqc results/fastqc results/fastp results/salmon -o results/multiqc
+```
+
+This works if everything succeeds, but breaks silently on partial failures - MultiQC runs on whatever files exist, potentially giving you an incomplete report without warning.
+
+#### A Robust Approach (More Code)
+
+Proper aggregation requires tracking job status:
+
+```bash
+declare -A job_status
+for sample_id in "${samples[@]}"; do
+    process_sample "$sample_id" &
+    pids[$sample_id]=$!
+done
+
+# Wait and track success/failure
+for sample_id in "${!pids[@]}"; do
+    if wait ${pids[$sample_id]}; then
+        job_status[$sample_id]="success"
+    else
+        job_status[$sample_id]="failed"
+        echo "WARNING: $sample_id failed"
+    fi
+done
+
+# Only aggregate successful samples
+successful_dirs=""
+for sample_id in "${!job_status[@]}"; do
+    if [[ ${job_status[$sample_id]} == "success" ]]; then
+        successful_dirs+=" results/salmon/$sample_id"
+    fi
+done
+
+multiqc results/fastqc results/fastp $successful_dirs -o results/multiqc
+```
+
+That's another 20+ lines of infrastructure code for something that should be simple: "run this after everything else finishes."
+
+---
+
+### 1.7. The Pain Points
+
+We won't implement these, but consider what you'd need for a production-ready pipeline:
+
+#### Failure Recovery
+
+If Salmon fails on sample 47 of 50, what happens?
+
+- With `set -e`, everything stops immediately
+- You have no record of which 46 samples completed successfully
+- To resume, you'd need to manually figure out what finished and what didn't
+- Implementing proper checkpoint logic would add 40+ lines of file-based state tracking
+
+#### Reproducibility
+
+When your colleague tries to run your script:
+
+```
+salmon: command not found
+```
+
+They need to replicate your exact conda environment - same tool versions, same dependencies.
+
+Or worse - they have salmon 1.4.0 but you used 1.10.3. The script runs fine, but results differ silently. Months later, you can't reproduce your own analysis because conda updated something.
+
+#### Scaling to Cluster
+
+Your laptop worked fine for 3 samples. For 500 samples, you need the SLURM cluster:
+
+```bash
+#SBATCH --job-name=salmon
+#SBATCH --cpus-per-task=4
+```
+
+Now you're rewriting the entire script with job arrays, dependency tracking, and cluster-specific syntax. Your collaborator's PBS cluster needs yet another rewrite. Each environment requires maintaining a separate codebase.
+
+---
+
+### 1.8. Part 1 Summary
+
+Checking progress against the production-quality standards:
+
+- ⚠️ **Reproducibility** - Partial. Conda environment helps, but requires discipline to maintain.
+- ⚠️ **Software management** - Partial. All tools share one environment - conflicts possible. Setup is manual and must be replicated by every user.
+- ❌ **Scalability** - Limited. Works on one machine until you hit resource limits. Scaling to cluster/cloud requires a complete rewrite.
+- ⚠️ **Efficient parallelization** - Partial. Works, but no resource limits.
+- ❌ **Resource awareness** - Missing. Would need 20-30 lines of job limiting code.
+- ❌ **Failure recovery** - Missing. Would need 40+ lines of checkpoint logic.
+- ❌ **Portability** - Missing. Complete rewrite for each cluster type.
+
+We achieved the basics, but the production-quality features require significant infrastructure code that has nothing to do with our science.
+
+**The fundamental problem:** Scripts mix _what_ to compute with _how_ to compute it. Every quality requirement adds more infrastructure code - and this would be true whether we wrote it in bash, Python, or any other language.
+
+This is where workflow managers come in.
+
+---
+
+## 2. Building a Nextflow Pipeline
+
+Now you'll rebuild the same pipeline using Nextflow.
+At each step, we'll contrast with the scripting approach from Part 1.
+
+!!! note "This isn't a Nextflow tutorial"
+
+    We're skipping over a lot of Nextflow detail here to focus on illustrating how workflow managers solve the problems from Part 1. If you're sold on the idea and want to learn Nextflow properly, head to [Hello Nextflow](../hello_nextflow/index.md) for a thorough introduction.
+
+---
+
+### 2.1. What is Nextflow?
+
+Nextflow is a workflow manager. Instead of writing imperative scripts that say "do this, then do that," you **declare** what processes exist and how data flows between them. Nextflow handles everything else - the parallelization, scheduling, error handling, and resource management you'd otherwise write yourself.
+
+#### Key Concepts
+
+| Concept      | What It Is                                         | Bash Equivalent                      |
+| ------------ | -------------------------------------------------- | ------------------------------------ |
+| **Process**  | A unit of work (like running FastQC on one sample) | A function or script                 |
+| **Channel**  | A queue of data flowing between processes          | Variables passed between commands    |
+| **Workflow** | How processes connect together                     | The order of commands in your script |
+
+The key difference: in bash, you explicitly manage data flow with variables and file paths. In Nextflow, you declare what each process needs, and Nextflow figures out the execution order automatically.
+
+#### Software Management
+
+In Part 1, you installed FastQC, fastp, and Salmon with conda - hoping dependencies wouldn't conflict, documenting versions manually.
+
+With Nextflow, each process declares its own software requirements. The tools are configured automatically at runtime with support for whichever software packaging tool you prefer. Your colleague runs the same pipeline and gets the exact same software environment based on the process definition, not their system.
+
+---
+
+### 2.2. Your First Process: FastQC
+
+In bash, you wrote FastQC commands inside loops, managed file paths with variables, and handled parallelization with `&`. In Nextflow, each tool runs inside a **process** - a self-contained unit that declares its inputs, outputs, and command. You don't write loops; Nextflow runs the process once per input item automatically.
+
+Copy this complete process into `nextflow/modules/fastqc.nf`:
+
+```groovy title="nextflow/modules/fastqc.nf"
+process FASTQC {
+    tag "$id"
+    container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'
+    publishDir "${params.outdir}/fastqc", mode: 'copy'
+
+    input:
+    tuple val(id), path(reads)
+
+    output:
+    tuple val(id), path("*.html"), emit: html
+    tuple val(id), path("*.zip"), emit: zip
+
+    script:
+    """
+    fastqc --quiet --threads 2 ${reads}
+    """
+}
+```
+
+#### Understanding the Process
+
+Each part has a purpose:
+
+- **`tag`** - Labels each job with the sample ID (visible in logs)
+- **`container`** - The Docker image containing FastQC (replaces your conda setup)
+- **`publishDir`** - Where to copy final outputs
+- **`input`** - Declares expected data: a tuple with sample ID (`val(id)`) and file paths (`path(reads)`)
+- **`output`** - Declares produced files with named channels (`emit: html`) for downstream processes
+- **`script`** - The actual command, nearly identical to your bash version
+
+You're not writing any loop logic, file existence checks, or error handling.
+
+!!! tip "Contrast with scripts"
+
+    The **one line** `container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'` handles all software dependencies. The version is locked forever. Your colleague, your cluster, and your cloud all get the exact same FastQC.
+
+#### Call FASTQC in main.nf
+
+Open `nextflow/main.nf` and add the FASTQC call:
+
+=== "After"
+
+    ```groovy title="nextflow/main.nf" linenums="34" hl_lines="1"
+    FASTQC(ch_samples)
+    ```
+
+=== "Before"
+
+    ```groovy title="nextflow/main.nf" linenums="34"
+    // TODO: Call FASTQC process with ch_samples
+    ```
+
+#### Test It
+
+```bash
+cd nextflow
+nextflow run main.nf
+```
+
+```console title="Output"
+N E X T F L O W  ~  version 24.10.0
+
+executor >  local (3)
+[a1/b2c3d4] FASTQC (WT_REP1)           [100%] 3 of 3 ✔
+```
+
+**All 3 samples ran in parallel automatically.** In Part 1, you wrote `&` and `wait` and worried about resource limits. Nextflow figures out optimal parallelization from your process definition alone.
+
+---
+
+### 2.3. Adding fastp
+
+Now add fastp following the same pattern. The key difference: fastp's output (trimmed reads) needs to flow to Salmon. In bash, you managed this with file paths like `results/fastp/${sample_id}_trimmed_R1.fastq.gz`. In Nextflow, you declare the output and let channels handle the data flow.
+
+Open `nextflow/modules/fastp.nf` and fill in the input, output, and script blocks.
+
+#### Complete fastp.nf
+
+Pay attention to the `emit: reads` on the trimmed reads output - this names the output channel so Salmon can consume it.
+
+=== "After"
+
+    ```groovy title="nextflow/modules/fastp.nf" hl_lines="7 10-12 15-23"
+    process FASTP {
+        tag "$id"
+        container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
+        publishDir "${params.outdir}/fastp", mode: 'copy'
+
+        input:
+        tuple val(id), path(reads)
+
+        output:
+        tuple val(id), path("*_trimmed*.fastq.gz"), emit: reads
+        tuple val(id), path("*.json"), emit: json
+        tuple val(id), path("*.html"), emit: html
+
+        script:
+        """
+        fastp \\
+            --in1 ${reads[0]} \\
+            --in2 ${reads[1]} \\
+            --out1 ${id}_trimmed_R1.fastq.gz \\
+            --out2 ${id}_trimmed_R2.fastq.gz \\
+            --json ${id}.fastp.json \\
+            --html ${id}.fastp.html \\
+            --thread 4
+        """
+    }
+    ```
+
+=== "Before"
+
+    ```groovy title="nextflow/modules/fastp.nf"
+    process FASTP {
+        tag "$id"
+        container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
+        publishDir "${params.outdir}/fastp", mode: 'copy'
+
+        input:
+        ???
+
+        output:
+        ???
+
+        script:
+        """
+        ???
+        """
+    }
+    ```
+
+The key line is `emit: reads` on the trimmed read files output. This creates a named output channel that Salmon will consume. When you later write `FASTP.out.reads`, you're accessing this specific output.
+
+#### Call FASTP in main.nf
+
+Now connect FASTP to the sample channel in the workflow:
+
+=== "After"
+
+    ```groovy title="nextflow/main.nf" linenums="36" hl_lines="1"
+    FASTP(ch_samples)
+    ```
+
+=== "Before"
+
+    ```groovy title="nextflow/main.nf" linenums="36"
+    // TODO: Call FASTP process with ch_samples
+    ```
+
+!!! tip "Contrast with scripts"
+
+    In Part 1, all tools shared one conda environment - conflicts were a constant risk. Here, fastp uses a completely different container than FastQC. They could require incompatible Python versions or conflicting libraries - doesn't matter. Each process gets its own isolated environment.
+
+---
+
+### 2.4. Connecting to Salmon
+
+This is where Nextflow's data flow model pays off. In bash, you manually coordinated file paths - Salmon needed to know where fastp wrote its output. In Nextflow, you declare that Salmon needs fastp's output, and the framework handles the rest.
+
+Salmon needs **two** inputs:
+
+1. **Trimmed reads** - Different for each sample (from FASTP)
+2. **Reference index** - Same for all samples (from UNTAR)
+
+This is a common pattern: per-sample data combined with a shared reference. In bash, you'd check if the index exists with `if [ ! -d ... ]`. In Nextflow, the channel system handles this automatically.
+
+#### Complete salmon.nf
+
+The UNTAR process (which extracts the pre-built Salmon index) is already complete. Your task is to fill in SALMON_QUANT, which has **two input declarations**:
+
+=== "After"
+
+    ```groovy title="nextflow/modules/salmon.nf" linenums="17" hl_lines="10-11 14 18-24"
+    process SALMON_QUANT {
+        tag "$id"
+        container 'quay.io/biocontainers/salmon:1.10.3--h6dccd9a_2'
+        publishDir "${params.outdir}/salmon", mode: 'copy'
+
+        cpus 4
+        memory '8.GB'
+
+        input:
+        tuple val(id), path(reads)
+        path index
+
+        output:
+        tuple val(id), path("$id"), emit: results
+
+        script:
+        """
+        salmon quant \\
+            --index $index \\
+            --libType A \\
+            --mates1 ${reads[0]} \\
+            --mates2 ${reads[1]} \\
+            --output $id \\
+            --threads $task.cpus
+        """
+    }
+    ```
+
+=== "Before"
+
+    ```groovy title="nextflow/modules/salmon.nf" linenums="17"
+    process SALMON_QUANT {
+        tag "$id"
+        container 'quay.io/biocontainers/salmon:1.10.3--h6dccd9a_2'
+        publishDir "${params.outdir}/salmon", mode: 'copy'
+
+        cpus 4
+        memory '8.GB'
+
+        input:
+        ???
+
+        output:
+        ???
+
+        script:
+        """
+        ???
+        """
+    }
+    ```
+
+Notice two things in the script:
+
+- **`$task.cpus`** - Nextflow makes declared resources available as variables. In bash, you hardcoded `--threads 2`. Here, you declare resources once (`cpus 4`) and reference them in the script. Change the declaration, and the script adapts automatically.
+- **Two inputs** - The process receives the trimmed reads tuple and the index path separately. In bash, you coordinated these with file paths. Here, the data flow is explicit.
+
+#### Wire It Up in main.nf
+
+Now connect the processes. SALMON_QUANT needs two arguments:
+
+=== "After"
+
+    ```groovy title="nextflow/main.nf" linenums="38" hl_lines="1"
+    SALMON_QUANT(FASTP.out.reads, UNTAR.out.index.first())
+    ```
+
+=== "Before"
+
+    ```groovy title="nextflow/main.nf" linenums="38"
+    // TODO: Call SALMON_QUANT with FASTP output and the index
+    // Hint: Use FASTP.out.reads for the trimmed reads
+    // Hint: Use UNTAR.out.index.first() for the index
+    ```
+
+Understanding this line:
+
+- **`FASTP.out.reads`** - The trimmed reads channel (one item per sample)
+- **`UNTAR.out.index.first()`** - The `.first()` operator converts the channel to a single value that gets reused for every sample
+
+Without `.first()`, Nextflow would try to pair each sample with a separate index item. Since there's only one index, we tell Nextflow to reuse it.
+
+#### Run and Watch
+
+Run the complete pipeline:
+
+```bash
+nextflow run main.nf
+```
+
+Watch what happens - Nextflow automatically determines the execution order from the data flow you defined:
+
+- **FastQC and FASTP can run in parallel** - Both only need the raw reads, no dependency between them
+- **SALMON_QUANT must wait for FASTP** - It needs the trimmed reads output
+- **Each sample runs independently** - Sample 2's Salmon can start as soon as Sample 2's fastp finishes, even if Sample 1 is still running
+
+!!! tip "Contrast with scripts"
+
+    In Part 1, you implemented `&` and `wait`, then worried about memory limits with 500 samples. Nextflow infers parallelization from the data flow and respects resource declarations.
+
+---
+
+### 2.5. Aggregation with MultiQC
+
+Real pipelines don't just run processes per sample - they often need to aggregate results across all samples. MultiQC collects QC metrics from FastQC, fastp, Salmon, and other tools into a single summary report.
+
+In bash, aggregation is awkward. You'd need to:
+
+1. Wait for all parallel jobs to complete
+2. Track which output files exist
+3. Handle the case where some samples failed
+4. Construct file lists for the aggregation tool
+
+With channels, this is straightforward. Add a MULTIQC process:
+
+```groovy title="nextflow/modules/multiqc.nf"
+process MULTIQC {
+    container 'quay.io/biocontainers/multiqc:1.19--pyhdfd78af_0'
+    publishDir "${params.outdir}/multiqc", mode: 'copy'
+
+    input:
+    path('*')
+
+    output:
+    path "multiqc_report.html", emit: report
+    path "multiqc_data"       , emit: data
+
+    script:
+    """
+    multiqc . --filename multiqc_report
+    """
+}
+```
+
+Then wire it up to collect outputs from all processes:
+
+```groovy title="nextflow/main.nf"
+// Collect all QC outputs for MultiQC
+ch_multiqc = FASTQC.out.zip
+    .map { id, files -> files }
+    .mix(FASTP.out.json.map { id, files -> files })
+    .mix(SALMON_QUANT.out.results.map { id, files -> files })
+    .collect()
+
+MULTIQC(ch_multiqc)
+```
+
+The `.collect()` operator waits for all upstream processes to complete, then passes everything to MultiQC as a single batch. Nextflow tracks which files to collect automatically.
+
+!!! tip "Contrast with scripts"
+
+    In Part 1, you'd need to track job completion status, build file lists manually, and handle partial failures. Here, the channel operators handle all of that. The `.collect()` naturally waits for all inputs, and `.mix()` combines outputs from different processes.
+
+---
+
+### 2.6. Resume and Caching
+
+In Part 1, failure recovery was a pain point - if sample 47 failed, you had no record of what completed, and implementing checkpoint logic would take 40+ lines of state tracking.
+
+Run the Nextflow pipeline, then modify something and run with `-resume`:
+
+```bash
+nextflow run main.nf -resume
+```
+
+```console title="Output"
+[a1/b2c3d4] UNTAR              [100%] 1 of 1, cached: 1 ✔
+[e5/f6g7h8] FASTQC (WT_REP1)   [100%] 3 of 3, cached: 3 ✔
+[i9/j0k1l2] FASTP (WT_REP1)    [100%] 3 of 3, cached: 3 ✔
+[m3/n4o5p6] SALMON_QUANT       [100%] 3 of 3 ✔  <- Only this re-ran
+```
+
+Nextflow automatically tracks what completed successfully. Failed tasks can be fixed and re-run without repeating successful work. **One flag** (`-resume`) replaces 40+ lines of bash checkpoint logic you'd have to write and debug.
+
+---
+
+### 2.7. Configuration Profiles
+
+In Part 1, scaling to clusters required rewriting the entire script with SLURM job arrays and cluster-specific syntax. Your collaborator on PBS would need yet another version.
+
+With Nextflow, the `nextflow.config` file lets you run the **same workflow** anywhere:
+
+```bash
+# On your laptop
+nextflow run main.nf -profile standard
+
+# On SLURM cluster
+nextflow run main.nf -profile slurm
+
+# On AWS
+nextflow run main.nf -profile aws
+```
+
+Same workflow code. Same scientific results. Different infrastructure. You write your analysis once, and configuration profiles adapt it to any environment.
+
+---
+
+### 2.8. Part 2 Summary
+
+Checking progress against the same standards:
+
+- ✅ **Reproducibility** - Containers lock exact tool versions. Same results everywhere.
+- ✅ **Software management** - Each process gets its own isolated container. No conflicts, no manual setup.
+- ✅ **Scalability** - Same code for 3 or 3,000 samples. Manages resources on one machine, or distributes to cluster/cloud with a config change.
+- ✅ **Efficient parallelization** - Automatic from data flow declarations.
+- ✅ **Resource awareness** - Declarative `cpus` and `memory` per process.
+- ✅ **Failure recovery** - `-resume` flag. One word.
+- ✅ **Portability** - Same code, different `-profile`.
+
+Every quality we struggled with in Part 1 is built into Nextflow. You didn't write any infrastructure code - you just declared what each process needs and produces.
+
+**The fundamental difference:** Scripts mix _what_ to compute with _how_ to compute it. Workflow managers separate these concerns - you declare the science, the framework handles the infrastructure.
+
+---
+
+## Quick Reference
+
+### Nextflow Commands
+
+```bash
+# Run workflow
+nextflow run main.nf
+
+# Resume from cached results
+nextflow run main.nf -resume
+
+# Use specific profile
+nextflow run main.nf -profile slurm
+```
+
+### Process Template
+
+```groovy
+process TOOL_NAME {
+    tag "$id"
+    container 'quay.io/biocontainers/tool:version'
+    publishDir "${params.outdir}/tool", mode: 'copy'
+
+    input:
+    tuple val(id), path(reads)
+
+    output:
+    tuple val(id), path("*.out"), emit: results
+
+    script:
+    """
+    tool command ${reads}
+    """
+}
+```
+
+---
+
+## Summary
+
+We started with a question: _Why learn a whole new framework when your script does the job?_
+
+Building production-quality pipelines with scripts means writing significant infrastructure code - job scheduling, resource management, failure recovery, environment setup - that has nothing to do with your science. And you'd face the same challenges whether you wrote it in bash, Python, or any other language.
+
+Workflow managers like Nextflow handle that infrastructure for you. You declare what each process needs and produces; the framework figures out the rest. The result is code that's almost entirely focused on your science, with production-quality features built in.
+
+There's also **standardization**. Workflow managers are established tools with communities, documentation, and shared best practices. When you join a new team or project using one, you're working with familiar concepts rather than deciphering someone's homegrown scripting solution. Skills transfer. You're not maintaining custom infrastructure - you're using battle-tested tools that thousands of others rely on.
+
+### What's Next?
+
+If you're convinced and want to learn Nextflow properly:
+
+- **[Hello Nextflow](../hello_nextflow/index.md)** - A thorough introduction to Nextflow concepts and syntax
+- **[Nextflow Documentation](https://www.nextflow.io/docs/latest/)** - Official reference documentation
+
+If you want to explore more advanced topics:
+
+- **[nf-core](https://nf-co.re/)** - Community-curated, production-ready pipelines you can use or learn from
+- **[Seqera Platform](https://seqera.io/platform/)** - Enterprise features for monitoring, launching, and managing workflows

--- a/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
+++ b/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
@@ -1,17 +1,18 @@
 # Workflows in the AI era
 
-If an AI agent can run your analysis on demand, or generate a complete pipeline for you in seconds, why do you still need to learn a workflow tool?
+If an AI agent can run your analysis on demand, or write the code for you in seconds, why do you still need to learn a workflow tool?
 
-Because the pipeline is the durable artefact.
-Without one, the analysis the agent just ran cannot be re-run, audited, ported, scaled, or trusted.
-With one, those properties come from the workflow boundary, no matter who or what wrote the code inside it.
+The agent will happily produce either a bash script or a Nextflow pipeline; the question is which artefact is worth keeping.
+A script is only as good as the engineering work the agent (or you) remembered to bake into it: software pinning, parallelism limits, resume logic, scale handling, provenance.
+A workflow is different.
+The same agent producing Nextflow gets reproducibility, software tracking, parallelisation, resume, and portability for free, because the workflow boundary makes them part of the artefact's structure rather than something extra to write.
 
 This side quest answers the question by experience.
-You will build a real RNA-seq analysis the way an agent might run it for you, find the limits of what that gets you, then rebuild it as a Nextflow workflow and watch each limit disappear.
+You'll see the same RNA-seq analysis as a bash script (the kind an agent might hand you), find the engineering limits of that form, then see it as a Nextflow workflow (which the same agent could just as easily produce) and watch each limit disappear.
 
 !!! note "Why bash?"
 
-    Part 1 uses bash to stand in for the kind of ad-hoc invocation an agent would produce on demand. The limitations are the same whether the script is bash, Python, R, or output from a chat session. The issue is not the language; it is running tools without a workflow boundary.
+    Part 1 uses bash to stand in for any ad-hoc form: a chat-generated script, a quick Python equivalent, an R one-liner, a sequence of commands an agent ran for you. The limitations apply to all of them. The issue is not the language; it is running tools without a workflow boundary, regardless of who or what authored the code.
 
 ### Learning goals
 
@@ -35,7 +36,7 @@ You'll need:
 
 ## 1. What a production-grade analysis needs
 
-These are the properties an AI assistant does not give you for free, and that a workflow manager does:
+These are the properties any agent producing bash has to remember to write, every time, and the properties a workflow tool supplies structurally:
 
 - **Reproducibility**: Same inputs produce identical outputs, every time. Results can be verified and published with confidence.
 - **Software management**: Each task gets its own isolated environment. No dependency conflicts between tools, and a standardised approach across your whole pipeline.
@@ -362,7 +363,7 @@ This works for one sample, but you have 3 samples and 50 more coming. Running th
 
 #### 3.3.9. Takeaway
 
-You now have a runnable script. There is no record of which conda environment solved for which tool versions, no resume on failure, no way to scale up without rewriting the loop, no provenance trace beyond your shell history. The script is what an agent hands you when you ask it to run an analysis; the rest is on you.
+You now have a runnable script. There is no record of which conda environment solved for which tool versions, no resume on failure, no way to scale up without rewriting the loop, no provenance trace beyond your shell history. A bash script is what an agent might hand you for a quick analysis; everything past "it ran once on my laptop" is something the agent has to remember to write separately, and probably won't get right. Asking the same agent for a workflow instead is what fixes that, as Part 2 will show.
 
 ---
 
@@ -533,7 +534,7 @@ What happens with 50 samples, or 500?
 # That's 500 x 4GB = 2TB RAM required
 ```
 
-Your machine would crash from memory exhaustion. Bash's `&` has no concept of resource limits; it just launches everything at once. The agent didn't write a job-throttling layer; you'd need to track running jobs, wait when at the limit, and start new jobs as others complete. That's 20-30 lines of infrastructure code that has nothing to do with your science.
+Your machine would crash from memory exhaustion. Bash's `&` has no concept of resource limits; it just launches everything at once. An agent producing bash here would need to add a job-throttling layer: 20-30 lines tracking running jobs, waiting at the limit, and starting new jobs as others complete. The same agent producing Nextflow doesn't have to write any of it; the executor handles throttling from the resource declarations on each process.
 
 ---
 
@@ -985,7 +986,7 @@ Watch what happens. Nextflow automatically determines the execution order from t
 
 !!! tip "Contrast with the agent's script"
 
-    In Part 1, you implemented `&` and `wait`, then worried about memory limits with 500 samples. Nextflow infers parallelisation from the data flow and respects resource declarations. The agent on its own would have hit the same wall.
+    In Part 1, the bash version needed `&` and `wait` and worried about memory limits at 500 samples. The same agent producing this Nextflow process gets parallelisation and resource-aware throttling for free; producing the bash version, it has to remember to write the throttling itself, and probably won't.
 
 ---
 
@@ -1103,13 +1104,15 @@ The fundamental difference: scripts mix _what_ to compute with _how_ to compute 
 
 ---
 
-## 5. But what if the AI writes the Nextflow?
+## 5. Why this matters more, not less, when AI is writing the code
 
-The other half of the question still stands. If an AI can write Nextflow for you, why do you still need to learn it?
+The bash and Nextflow versions you just compared could both have been generated by the same agent from the same paragraph of intent. The difference between them is not who wrote them, it is what abstraction the agent had to write into.
 
-AI-assisted authoring of Nextflow is genuinely useful. Tools like [Seqera AI](https://seqera.io/ask-ai/) and the [`nf-core` Claude Code skills](https://nf-co.re/docs/tutorials/llm/claude_code) can scaffold processes, draft modules, and produce whole pipelines from a paragraph of intent. The case for using a workflow tool does not weaken when AI authors the code; it strengthens. Every line the AI writes lands inside a system that supplies the seven properties you saw in Part 2.
+When the agent writes bash, it has to remember to add: container pins, parallelism with throttling, resume logic, structured outputs, a SLURM-friendly fallback, a way to reproduce the conda solve six months from now. It might do some of that. It will not do all of it. Each property it forgets is a silent failure that surfaces on file four, on a different laptop, six months later.
 
-What that means in practice: you still operate, debug, audit, scale, and lock with tests what the AI produced. Reading Nextflow, verifying container pins, validating cache behaviour, running tests; these are the durable skills. AI accelerates authoring; the workflow tool makes the operate-debug-maintain loop tractable. The [`nf-test` side quest](../nf_test/index.md) is the right next step for locking that contract.
+When the agent writes Nextflow, those properties come from the workflow boundary regardless of how careful the agent was. The case for the workflow tool gets stronger, not weaker, the more code the agent writes, because the agent's mistakes have somewhere safe to land.
+
+You still read what the agent produced. You still verify container pins, validate cache behaviour, lock the contract with tests; these are the durable skills. AI accelerates the authoring. The workflow tool makes the operate-debug-maintain loop tractable. Tools like [Seqera AI](https://seqera.io/ask-ai/) and the [`nf-core` Claude Code skills](https://nf-co.re/docs/tutorials/llm/claude_code) help with the authoring; the [`nf-test` side quest](../nf_test/index.md) is the right next step for locking what got authored.
 
 The answer to "why workflows when I have Claude" is "because Claude needs them too."
 
@@ -1119,9 +1122,9 @@ The answer to "why workflows when I have Claude" is "because Claude needs them t
 
 You started with a question: _why learn a whole new framework when an AI agent can do my analysis or build my pipeline for me?_
 
-You then built the same RNA-seq analysis twice. Once as a script of the kind an agent produces on demand, where every production-quality property you tried to add cost more infrastructure code than science. Once as a Nextflow workflow, where reproducibility, software tracking, scalability, parallelisation, resource awareness, failure recovery, and portability came from the workflow boundary itself.
+You then built the same RNA-seq analysis twice. Once as a bash script of the kind an agent might produce on demand, where every production-quality property cost extra infrastructure code that the agent had to remember to write. Once as a Nextflow workflow (which the same agent could just as easily produce), where reproducibility, software tracking, scalability, parallelisation, resource awareness, failure recovery, and portability came from the workflow boundary itself.
 
-The pipeline is the durable artefact. It captures the analysis in a way that survives the agent that ran it.
+The pipeline is the durable artefact. The agent will write either form for you on demand. The form that makes the agent's output trustworthy is the one with a workflow boundary baked in.
 
 ### Key patterns
 

--- a/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
+++ b/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
@@ -2,13 +2,11 @@
 
 If an AI agent can run your analysis on demand, or write the code for you in seconds, why do you still need to learn a workflow tool?
 
-Bioinformatics has been through three eras of how analyses get expressed: commands typed into a terminal, scripts that captured those commands, and workflows that captured the scripts plus the engineering work needed to make them reproducible, portable, and maintainable. Each step was a better artefact for a team to live with, and each step happened because the previous form's limits started costing real time.
+Bioinformatics has been through three eras of how analyses get expressed: commands typed into a terminal, scripts that captured those commands, and workflows that captured the scripts plus the engineering work needed to make them reproducible, portable, and maintainable. Each step happened because the previous form's limits started costing real time.
 
-We are in a fourth era now, where an agent will produce any of those forms in seconds. The agent will write bash, Python, Nextflow, all of it. So the question is not "should I bother learning Nextflow when the agent could write it for me?" The question is what artefact you want to live with after the agent is done; what gets vetted at code review, tested, updated when a tool releases a new version, extended when the lab adds a new sample type, read by the colleague who inherits it next quarter.
+We're in a fourth era now, where an agent will produce any of those forms in seconds. So the question is no longer "should I bother learning Nextflow when an agent could write it for me?" The question is what artefact you want to live with after the agent is done.
 
-A bash script can be that artefact, but it is the wrong shape for the job: every engineering property is buried inline, every change requires re-deriving correctness, and a maintainer six months from now has to reconstruct what the original author (human or otherwise) was thinking. A Nextflow workflow encodes the same logic in a form built for that maintenance role, with declarative containers and resources, explicit data flow, and the engineering properties supplied by the workflow boundary rather than by individual lines an author had to remember to write.
-
-This side quest answers the question by experience. You will see the same RNA-seq analysis as a bash script (the kind an agent might hand you), find the engineering limits of that form, then see it as a Nextflow workflow (which the same agent could just as easily produce) and watch each limit disappear. By the end you should have an artefact you would be willing to put your name on and maintain.
+This side quest answers the question by experience. You'll see the same RNA-seq analysis as a bash script (the kind an agent might hand you), find the engineering limits of that form, then see it as a Nextflow workflow (which the same agent could just as easily produce) and watch each limit disappear.
 
 !!! note "Why bash?"
 

--- a/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
+++ b/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
@@ -187,7 +187,7 @@ FastQC analyzes sequencing data and generates quality reports. We run it on both
 
 === "After"
 
-    ```bash title="bash/process_sample.sh" linenums="22" hl_lines="3-5"
+    ```bash title="bash/process_sample.sh" linenums="22" hl_lines="2-5"
     # Step 2: Run FastQC
     echo "  Running FastQC..."
     fastqc -q -o results/fastqc \
@@ -208,7 +208,7 @@ fastp trims adapter sequences and filters out low-quality reads. It takes paired
 
 === "After"
 
-    ```bash title="bash/process_sample.sh" linenums="28" hl_lines="3-10"
+    ```bash title="bash/process_sample.sh" linenums="28" hl_lines="2-10"
     # Step 3: Run fastp
     echo "  Running fastp..."
     fastp \
@@ -887,7 +887,7 @@ Now connect the processes. SALMON_QUANT needs two arguments. Then add `publish:`
 
 === "After"
 
-    ```groovy title="nextflow/main.nf" linenums="30" hl_lines="1 3-9 12-18"
+    ```groovy title="nextflow/main.nf" linenums="30" hl_lines="1 4-9 13-18"
     SALMON_QUANT(FASTP.out.reads, UNTAR.out.index.first())
 
     publish:
@@ -931,6 +931,10 @@ Two things to notice:
 
 The `publish:` block names the channels you want kept; the top-level `output {}` block tells Nextflow what subdirectory to put each one in. The actual root directory comes from `-output-dir` on the command line.
 
+!!! note "Why `main:`?"
+
+    The `main:` label is required when a `publish:` block follows in the same workflow; it separates the workflow logic from the output declarations. Workflows without a `publish:` block can drop the `main:` label.
+
 #### 2.4.3. Run and watch
 
 Run the complete pipeline:
@@ -962,7 +966,7 @@ In bash, aggregation is awkward. You'd need to:
 3. Handle the case where some samples failed
 4. Construct file lists for the aggregation tool
 
-With channels, this is straightforward. Add a MULTIQC process:
+With channels, this is straightforward. Below is a MULTIQC process and the wiring that drives it; the focus here is the channel pattern, not the process itself, so this section walks through code that's already been written for you.
 
 ```groovy title="nextflow/modules/multiqc.nf"
 process MULTIQC {
@@ -982,10 +986,11 @@ process MULTIQC {
 }
 ```
 
-Then wire it up to collect outputs from all processes:
+The wiring in `main.nf`:
 
 ```groovy title="nextflow/main.nf"
-// Collect all QC outputs for MultiQC
+// Collect all QC outputs for MultiQC. _id discards the per-sample id;
+// MultiQC only needs the files themselves.
 ch_multiqc = FASTQC.out.zip
     .map { _id, files -> files }
     .mix(FASTP.out.json.map { _id, files -> files })
@@ -997,7 +1002,7 @@ MULTIQC(ch_multiqc)
 
 Add `multiqc_report = MULTIQC.out.report` to the workflow's `publish:` block and `multiqc_report { path 'multiqc' }` to the `output {}` block.
 
-The `.collect()` operator waits for all upstream processes to complete, then passes everything to MultiQC as a single batch. Nextflow tracks which files to collect automatically.
+The `.collect()` operator waits for all upstream processes to complete, then passes everything to MultiQC as a single batch. The `_id` underscore prefix is the Groovy/Nextflow convention for "this destructured value is intentionally discarded"; MultiQC takes file paths only, so we drop the sample ID. Nextflow tracks which files to collect automatically.
 
 !!! tip "Contrast with the script form"
 
@@ -1019,7 +1024,8 @@ nextflow run main.nf -output-dir results -resume
 [a1/b2c3d4] UNTAR              [100%] 1 of 1, cached: 1 ✔
 [e5/f6g7h8] FASTQC (WT_REP1)   [100%] 3 of 3, cached: 3 ✔
 [i9/j0k1l2] FASTP (WT_REP1)    [100%] 3 of 3, cached: 3 ✔
-[m3/n4o5p6] SALMON_QUANT       [100%] 3 of 3 ✔  <- Only this re-ran
+[m3/n4o5p6] SALMON_QUANT       [100%] 3 of 3 ✔  <- This re-ran
+[q7/r8s9t0] MULTIQC            [100%] 1 of 1 ✔  <- And anything downstream
 ```
 
 Nextflow automatically tracks what completed successfully. Failed tasks can be fixed and re-run without repeating successful work. One flag (`-resume`) replaces 40+ lines of bash checkpoint logic you'd have to write and debug, whether you wrote it or asked an agent to.
@@ -1061,11 +1067,11 @@ Checking progress against the same properties:
 
 Every property we struggled with in Part 1 is supplied by the workflow boundary itself, not by the author. The artefact you produced is the same one an agent would produce from the same paragraph of intent, and a maintainer reading it can see at a glance which container ran each step, where outputs land, what gets parallelised, where the cache lives. Each engineering decision is one line, in a known place, easy to vet and easy to change.
 
-The form did the work that Part 1 left to the author.
+The form did the work that Part 1 left to the author. That 50-sample run next week your PI mentioned in section 1.1.1? Same `nextflow run` command, no changes to `main.nf`, swap `-profile docker` for `-profile slurm` if you want it on the cluster.
 
 ---
 
-## 3. Why workflows still matter when AI does the writing
+## 3. Workflows when AI writes the code
 
 An agent producing bash and the same agent producing Nextflow take roughly the same number of seconds. The bottleneck has moved. It is no longer how long it takes to write the code; it is how long it takes a team to verify, ship, and maintain what was written. The artefact's role has not changed.
 

--- a/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
+++ b/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
@@ -93,15 +93,18 @@ cd side-quests/workflows_in_the_ai_era
 #### 3.1.3. Explore the starter files
 
 ```bash
-ls -la bash/
+ls bash/
 ```
 
 ```console title="Output"
-bash/
-├── process_sample.sh      # Single sample script (has TODOs)
-├── pipeline_sequential.sh # Multi-sample loop (has TODOs)
-└── pipeline_parallel.sh   # Parallel version (has TODOs)
+pipeline_parallel.sh    pipeline_sequential.sh  process_sample.sh
 ```
+
+Three scripts, each with TODOs you'll fill in as you progress:
+
+- `process_sample.sh`: single sample script
+- `pipeline_sequential.sh`: multi-sample loop
+- `pipeline_parallel.sh`: parallel version
 
 You'll fill in these starter files as you progress through the tutorial.
 
@@ -122,13 +125,11 @@ Each row is a sample with URLs to paired-end FASTQ files.
 
 ---
 
-### 3.2. Installing your tools
+### 3.2. Kick off the tool install
 
-Before you can run any analysis, you need to install the bioinformatics tools.
+Part 1 needs FastQC, fastp, and Salmon installed locally so the bash scripts can call them from `PATH`. Conda solves environments slowly, so kick off the install now and let it run in the background while you keep reading. We'll check on it before you actually need to run anything.
 
-#### 3.2.1. Create a conda environment
-
-=== "Mamba (Recommended)"
+=== "Mamba (recommended)"
 
     ```bash
     mamba create -n rnaseq-bash fastqc fastp salmon -c bioconda -c conda-forge -y
@@ -140,34 +141,7 @@ Before you can run any analysis, you need to install the bioinformatics tools.
     conda create -n rnaseq-bash fastqc fastp salmon -c bioconda -c conda-forge -y
     ```
 
-Watch the output. Notice:
-
-- Dependencies being resolved (sometimes this takes minutes)
-- Packages being downloaded
-- Hope that there are no conflicts...
-
-#### 3.2.2. Activate the environment
-
-```bash
-mamba activate rnaseq-bash
-```
-
-!!! warning "Remember this step"
-
-    Every time you open a new terminal, you must activate this environment again.
-    Forget, and your script fails with `command not found`.
-
-#### 3.2.3. Verify installation
-
-```bash
-fastqc --version
-fastp --version
-salmon --version
-```
-
-#### 3.2.4. Takeaway
-
-The agent that ran this for you didn't record which versions of FastQC, fastp, or Salmon ended up in the environment, didn't pin a channel, and didn't write down what to do when conda's solver picks up a different combination next month. That documentation is your problem.
+This typically takes about 3 minutes. While it runs, work through the next section. The activation and version check come later, once you actually have a script to test.
 
 ---
 
@@ -345,7 +319,29 @@ Salmon quantifies transcript expression by pseudo-aligning reads to the index. I
     # TODO: Add salmon quant command
     ```
 
-#### 3.3.7. Test your script
+#### 3.3.7. Activate the env and verify it's ready
+
+The conda install you started in section 3.2 should be done by now. Switch back to that terminal (or the same one if you ran the install in this shell) and activate the environment:
+
+```bash
+mamba activate rnaseq-bash
+```
+
+!!! warning "Remember this step"
+
+    Every time you open a new terminal, you must activate this environment again. Forget, and your script fails with `command not found`.
+
+Verify the three tools are on your `PATH`:
+
+```bash
+fastqc --version
+fastp --version
+salmon --version
+```
+
+If any of those errors out, give the install another minute and try again. Once all three respond with versions, you are ready to run the script.
+
+#### 3.3.8. Test your script
 
 Make it executable and run on one sample:
 
@@ -364,9 +360,9 @@ ls results/
 
 This works for one sample, but you have 3 samples and 50 more coming. Running this command manually for each one isn't practical.
 
-#### 3.3.8. Takeaway
+#### 3.3.9. Takeaway
 
-You now have a runnable script. There is no record of which container or environment ran it, no resume on failure, no way to scale up without rewriting the loop. The script is what an agent hands you when you ask it to run an analysis; the rest is on you.
+You now have a runnable script. There is no record of which conda environment solved for which tool versions, no resume on failure, no way to scale up without rewriting the loop, no provenance trace beyond your shell history. The script is what an agent hands you when you ask it to run an analysis; the rest is on you.
 
 ---
 

--- a/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
+++ b/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
@@ -4,9 +4,11 @@ If an AI agent can run your analysis on demand, or write the code for you in sec
 
 Bioinformatics has been through three eras of how analyses get expressed: commands typed into a terminal, scripts that captured those commands, and workflows that captured the scripts plus the engineering work needed to make them reproducible, portable, and maintainable. Each step happened because the previous form's limits started costing real time.
 
-We're in a fourth era now, where an agent will produce any of those forms in seconds. So the question is no longer "should I bother learning Nextflow when an agent could write it for me?" The question is what artefact you want to live with after the agent is done.
+We're in a fourth era now, where an agent will produce any of those forms in seconds. So the question is what artefact you want to live with after the agent is done: the thing that goes into version control, gets reviewed, tested, and maintained as tools change.
 
-This side quest answers the question by experience. You'll see the same RNA-seq analysis as a bash script (the kind an agent might hand you), find the engineering limits of that form, then see it as a Nextflow workflow (which the same agent could just as easily produce) and watch each limit disappear.
+Whether human-written or agent-generated, a serious pipeline needs reproducibility, isolated software environments, scalability, efficient parallelisation, resource awareness, failure recovery, and portability. Two artefacts can supply those properties very differently: by the author writing each one as inline infrastructure code, or by the artefact's structure providing them automatically. The first is what an ad-hoc script ends up as; the second is what a workflow tool gives you.
+
+This side quest answers the question by experience. You'll build the same RNA-seq analysis (FastQC, fastp, Salmon) twice: once as a bash script, finding the engineering limits of that form, then once as a Nextflow workflow, watching each limit disappear.
 
 !!! note "Why bash?"
 
@@ -32,72 +34,26 @@ You'll need:
 
 ---
 
-## 1. What a production-grade analysis needs
+## 1. Building a bash pipeline
 
-These are the properties any agent producing bash has to remember to write, every time, and the properties a workflow tool supplies structurally:
-
-- **Reproducibility**: Same inputs produce identical outputs, every time. Results can be verified and published with confidence.
-- **Software management**: Each task gets its own isolated environment. No dependency conflicts between tools, and a standardised approach across your whole pipeline.
-- **Scalability**: Handles 3 samples or 3,000 without code changes.
-- **Efficient parallelisation**: Independent tasks run simultaneously, so analysis completes in hours, not days.
-- **Resource awareness**: Respects memory and CPU limits. No crashed jobs or killed processes.
-- **Failure recovery**: Can resume from where it stopped. A single failure doesn't waste hours of completed work.
-- **Portability**: Runs on laptop, cluster, or cloud with the same code.
-
-These aren't nice-to-haves; they're requirements for serious computational research.
+You'll build an RNA-seq analysis pipeline in bash (FastQC, fastp, Salmon). This is the kind of script an agent would produce from a paragraph of intent: it works on three samples on the laptop where it ran. Each property listed in the introduction (reproducibility, software pinning, parallelism, resume, scale, portability) is something the author, agent or human, has to remember to write into the script. We'll see how far that gets us, and what's left over for someone else to maintain.
 
 ---
 
-## 2. The artefact those properties live in
+### 1.1. Setup
 
-Whatever code achieves those properties, the code itself ends up somewhere: a script in your home directory, a Nextflow workflow in a repo, a chat session nobody saved. That somewhere is the artefact, and it has to outlive the conversation that produced it. It goes into version control. Someone reads it at code review. Someone tests it. When a tool ships a new version, when the lab adds a new sample type, when the pipeline starts producing slightly different numbers and you have to figure out why, you go back to the artefact.
-
-Two artefacts can do exactly the same analysis but be very different to live with. One can have its parallelism, software pinning, and resume logic written into individual lines that someone has to find and update by hand. Another can have those same properties supplied by the artefact's structure, visible at a glance to anyone who reads it. The second is what a workflow tool gives you. The first is what most ad-hoc analyses, whether human-written or agent-generated, end up as.
-
-The rest of this side quest builds the same RNA-seq analysis as both forms, so you can see the difference where it counts: in the artefact, not in the runtime.
-
----
-
-## 3. What you'll build
-
-An RNA-seq analysis pipeline that runs:
-
-1. Quality control (FastQC)
-2. Adapter trimming (fastp)
-3. Transcript quantification (Salmon)
-
-How this tutorial works:
-
-| Part | Software | What you'll do                                       | What you'll learn                                    |
-| ---- | -------- | ---------------------------------------------------- | ---------------------------------------------------- |
-| 1    | Bash     | Build a pipeline, try to hit those quality standards | How much infrastructure code it takes                |
-| 2    | Nextflow | Rebuild with a workflow manager                      | How the same standards are achieved with less effort |
-
-By the end, you'll understand _why_ workflow managers exist, not from explanation but from hitting the limitations yourself.
-
----
-
-## 4. Building a bash pipeline
-
-In this part, you'll build an RNA-seq analysis pipeline using bash, aiming for the production-quality properties listed above.
-We'll see how far we can get and where things get difficult.
-
----
-
-### 4.1. Setup
-
-#### 4.1.1. The scenario
+#### 1.1.1. The scenario
 
 You're a bioinformatician analysing RNA-seq data from a yeast gene expression study.
 You have 3 samples today. Your PI mentions that 50 more samples are coming next week.
 
-#### 4.1.2. Navigate to the working directory
+#### 1.1.2. Navigate to the working directory
 
 ```bash
 cd side-quests/workflows_in_the_ai_era
 ```
 
-#### 4.1.3. Explore the starter files
+#### 1.1.3. Explore the starter files
 
 ```bash
 ls bash/
@@ -115,7 +71,7 @@ Three scripts, each with TODOs you'll fill in as you progress:
 
 You'll fill in these starter files as you progress through the tutorial.
 
-#### 4.1.4. Examine the sample data
+#### 1.1.4. Examine the sample data
 
 ```bash
 cat data/samples.csv
@@ -132,7 +88,7 @@ Each row is a sample with URLs to paired-end FASTQ files.
 
 ---
 
-### 4.2. Kick off the tool install
+### 1.2. Kick off the tool install
 
 Part 1 needs FastQC, fastp, and Salmon installed locally so the bash scripts can call them from `PATH`. Conda solves environments slowly, so kick off the install now and let it run in the background while you keep reading. We'll check on it before you actually need to run anything.
 
@@ -152,7 +108,7 @@ This typically takes about 3 minutes. While it runs, work through the next secti
 
 ---
 
-### 4.3. Building your first script
+### 1.3. Building your first script
 
 Open the starter file `bash/process_sample.sh`. It has the structure ready; you just need to add the tool commands.
 
@@ -192,7 +148,7 @@ mkdir -p data/fastq results/fastqc results/fastp results/salmon data/salmon_inde
 echo "Completed: $SAMPLE_ID"
 ```
 
-#### 4.3.1. Understanding the starter script
+#### 1.3.1. Understanding the starter script
 
 The script accepts three arguments: a sample ID and two URLs for paired-end FASTQ files. The `set -e` line means the script will stop immediately if any command fails.
 
@@ -205,7 +161,7 @@ The TODO comments mark where you'll add each analysis step:
 
 This is a typical RNA-seq preprocessing workflow. Fill in each step below.
 
-#### 4.3.2. Add the download step
+#### 1.3.2. Add the download step
 
 First, we need to download the FASTQ files from their URLs. We'll use `curl` with `-sL` (silent mode, follow redirects) to fetch each file and save it with a consistent naming pattern.
 
@@ -225,7 +181,7 @@ First, we need to download the FASTQ files from their URLs. We'll use `curl` wit
     # TODO: Add curl commands to download R1 and R2 files
     ```
 
-#### 4.3.3. Add FastQC
+#### 1.3.3. Add FastQC
 
 FastQC analyzes sequencing data and generates quality reports. We run it on both read files (`R1` and `R2`) and save the output to our results directory. The `-q` flag suppresses progress output.
 
@@ -246,7 +202,7 @@ FastQC analyzes sequencing data and generates quality reports. We run it on both
     # TODO: Add fastqc command
     ```
 
-#### 4.3.4. Add fastp
+#### 1.3.4. Add fastp
 
 fastp trims adapter sequences and filters out low-quality reads. It takes paired input files (`-i`, `-I`) and produces trimmed output files (`-o`, `-O`), plus JSON and HTML reports for quality metrics.
 
@@ -272,7 +228,7 @@ fastp trims adapter sequences and filters out low-quality reads. It takes paired
     # TODO: Add fastp command
     ```
 
-#### 4.3.5. Add the Salmon index download
+#### 1.3.5. Add the Salmon index download
 
 Salmon needs a pre-built index of the reference transcriptome. We'll download a pre-built index (to save time) only if it doesn't already exist. This avoids re-downloading for every sample.
 
@@ -300,7 +256,7 @@ Salmon needs a pre-built index of the reference transcriptome. We'll download a 
 
     This `if [ ! -d ... ]` check is a common pattern in scripts: "only do this if it hasn't been done already." While conceptually simple, it's fragile, because it detects whether the directory exists rather than whether the download actually succeeded or the files are valid. Workflow managers handle this more robustly by tracking actual task outputs rather than checking for file or directory existence.
 
-#### 4.3.6. Add Salmon quantification
+#### 1.3.6. Add Salmon quantification
 
 Salmon quantifies transcript expression by pseudo-aligning reads to the index. It takes the **trimmed** reads from fastp (not the raw reads) and outputs expression counts per transcript.
 
@@ -326,9 +282,9 @@ Salmon quantifies transcript expression by pseudo-aligning reads to the index. I
     # TODO: Add salmon quant command
     ```
 
-#### 4.3.7. Activate the env and verify it's ready
+#### 1.3.7. Activate the env and verify it's ready
 
-The conda install you started in section 4.2 should be done by now. Switch back to that terminal (or the same one if you ran the install in this shell) and activate the environment:
+The conda install you started in section 1.2 should be done by now. Switch back to that terminal (or the same one if you ran the install in this shell) and activate the environment:
 
 ```bash
 mamba activate rnaseq-bash
@@ -348,7 +304,7 @@ salmon --version
 
 If any of those errors out, give the install another minute and try again. Once all three respond with versions, you are ready to run the script.
 
-#### 4.3.8. Test your script
+#### 1.3.8. Test your script
 
 Make it executable and run on one sample:
 
@@ -367,13 +323,13 @@ ls results/
 
 This works for one sample, but you have 3 samples and 50 more coming. Running this command manually for each one isn't practical.
 
-#### 4.3.9. Takeaway
+#### 1.3.9. Takeaway
 
 You now have a runnable script. There is no record of which conda environment solved for which tool versions, no resume on failure, no way to scale up without rewriting the loop, no provenance trace beyond your shell history. A bash script is what an agent might hand you for a quick analysis; everything past "it ran once on my laptop" is something the agent has to remember to write separately, and probably won't get right. Asking the same agent for a workflow instead is what fixes that, as Part 2 will show.
 
 ---
 
-### 4.4. Processing multiple samples
+### 1.4. Processing multiple samples
 
 Now that we can process one sample, we need to handle all samples from our CSV file. Open `bash/pipeline_sequential.sh`; it already has the loop structure that reads the CSV and iterates over each sample.
 
@@ -385,7 +341,7 @@ The starter script handles:
 
 Your task is to add the actual processing commands inside the loop, the same steps you just wrote, but using the loop variables (`$sample_id`, `$fastq_r1`, `$fastq_r2`) instead of the script arguments.
 
-#### 4.4.1. Add processing logic to the loop
+#### 1.4.1. Add processing logic to the loop
 
 === "After"
 
@@ -436,7 +392,7 @@ Your task is to add the actual processing commands inside the loop, the same ste
     done
     ```
 
-#### 4.4.2. Run and time it
+#### 1.4.2. Run and time it
 
 ```bash
 chmod +x bash/pipeline_sequential.sh
@@ -455,7 +411,7 @@ Processing: WT_REP1
 Processing: WT_REP2      <- Starts only after WT_REP1 is completely done
 ```
 
-#### 4.4.3. The problem: sequential execution
+#### 1.4.3. The problem: sequential execution
 
 ```
 Timeline (sequential):
@@ -467,7 +423,7 @@ These samples are completely independent. WT_REP2's analysis doesn't depend on W
 
 ---
 
-### 4.5. Adding parallelisation
+### 1.5. Adding parallelisation
 
 The sequential script works, but it's slow; each sample waits for the previous one to finish completely. Since samples are independent, they could run simultaneously.
 
@@ -478,7 +434,7 @@ Your task is to make the loop run samples in parallel by:
 1. Adding `&` after each function call to run it in the background
 2. Adding `wait` after the loop to pause until all background jobs complete
 
-#### 4.5.1. Add background execution
+#### 1.5.1. Add background execution
 
 === "After"
 
@@ -510,7 +466,7 @@ The key changes:
 - `&` at the end of the function call runs it in the background.
 - `wait` pauses until all background jobs complete.
 
-#### 4.5.2. Run and compare
+#### 1.5.2. Run and compare
 
 ```bash
 chmod +x bash/pipeline_parallel.sh
@@ -530,7 +486,7 @@ Notice the interleaved output, all samples running at once:
 
 Faster, because all samples run concurrently.
 
-#### 4.5.3. The hidden problem
+#### 1.5.3. The hidden problem
 
 What happens with 50 samples, or 500?
 
@@ -544,11 +500,11 @@ Your machine would crash from memory exhaustion. Bash's `&` has no concept of re
 
 ---
 
-### 4.6. Adding aggregation
+### 1.6. Adding aggregation
 
 Real pipelines need a final aggregation step that collects QC metrics from all samples into a summary report. MultiQC does this, but integrating it with parallel bash processing is tricky.
 
-#### 4.6.1. The problem
+#### 1.6.1. The problem
 
 Your parallel script launches all samples with `&` and waits for completion with `wait`. But `wait` only tells you when jobs finish, not which ones succeeded. To run MultiQC, you need to:
 
@@ -556,7 +512,7 @@ Your parallel script launches all samples with `&` and waits for completion with
 2. Collect the right output files from each tool
 3. Handle partial failures gracefully
 
-#### 4.6.2. A simple (fragile) approach
+#### 1.6.2. A simple (fragile) approach
 
 Add MultiQC after the `wait`:
 
@@ -570,7 +526,7 @@ multiqc results/fastqc results/fastp results/salmon -o results/multiqc
 
 This works if everything succeeds, but breaks silently on partial failures: MultiQC runs on whatever files exist, potentially giving you an incomplete report without warning.
 
-#### 4.6.3. A robust approach (more code)
+#### 1.6.3. A robust approach (more code)
 
 Proper aggregation requires tracking job status:
 
@@ -606,11 +562,11 @@ That's another 20+ lines of infrastructure code for something that should be sim
 
 ---
 
-### 4.7. The pain points
+### 1.7. The pain points
 
 We won't implement these, but consider what you'd need for a production-ready pipeline:
 
-#### 4.7.1. Failure recovery
+#### 1.7.1. Failure recovery
 
 If Salmon fails on sample 47 of 50, what happens?
 
@@ -619,7 +575,7 @@ If Salmon fails on sample 47 of 50, what happens?
 - To resume, you'd need to manually figure out what finished and what didn't.
 - Implementing proper checkpoint logic would add 40+ lines of file-based state tracking.
 
-#### 4.7.2. Reproducibility
+#### 1.7.2. Reproducibility
 
 When your colleague tries to run your script:
 
@@ -631,7 +587,7 @@ They need to replicate your exact conda environment, same tool versions, same de
 
 Or worse, they have salmon 1.4.0 but you used 1.10.3. The script runs fine, but results differ silently. Months later, you can't reproduce your own analysis because conda updated something.
 
-#### 4.7.3. Scaling to cluster
+#### 1.7.3. Scaling to cluster
 
 Your laptop worked fine for 3 samples. For 500 samples, you need the SLURM cluster:
 
@@ -644,7 +600,7 @@ Now you're rewriting the entire script with job arrays, dependency tracking, and
 
 ---
 
-### 4.8. Takeaway
+### 1.8. Takeaway
 
 Checking progress against the production-quality properties:
 
@@ -656,28 +612,27 @@ Checking progress against the production-quality properties:
 - :x: **Failure recovery**: Missing. Would need 40+ lines of checkpoint logic.
 - :x: **Portability**: Missing. Complete rewrite for each cluster type.
 
-We achieved the basics, but the production-quality properties require significant infrastructure code that has nothing to do with our science.
-
-The fundamental problem: scripts mix _what_ to compute with _how_ to compute it. Every quality requirement adds more infrastructure code, and this would be true whether the script came from bash, Python, or a chat session with an agent. This is where workflow managers come in.
+Every warning and :x: above is more bash someone has to write to fill the gap, and more bash a maintainer has to read to verify it was filled correctly. The author of this script (whether a person or an agent) could be asked to add each one. That's another 100+ lines of inline infrastructure code, increasingly tangled with the science, increasing the surface a reviewer has to vet and a test suite has to cover. The form itself is the problem, not who wrote it. This is where workflow managers come in.
 
 ---
 
-## 5. Building a Nextflow pipeline
+## 2. Building a Nextflow pipeline
 
-Now you'll rebuild the same pipeline using Nextflow.
-At each step, we'll contrast with the scripting approach from Part 1.
+Now you'll rebuild the same pipeline as a Nextflow workflow. The same paragraph of intent that produced Part 1's bash, given to the same agent, would produce something close to what you write here. The difference isn't authorship, and it isn't speed. The difference is the artefact's shape: every property Part 1 left to the author is now supplied by the workflow boundary.
+
+At each step, we'll contrast with the form of Part 1, not with its author.
 
 !!! note "This isn't a Nextflow tutorial"
 
-    We're skipping over a lot of Nextflow detail here to focus on illustrating how workflow managers solve the problems from Part 1. If you're sold on the idea and want to learn Nextflow properly, head to [Hello Nextflow](../../hello_nextflow/index.md) for a thorough introduction.
+    We're skipping over a lot of Nextflow detail here to focus on how the workflow form changes what the artefact has to encode. If you want to learn Nextflow properly, head to [Hello Nextflow](../../hello_nextflow/index.md) for a thorough introduction.
 
 ---
 
-### 5.1. What is Nextflow?
+### 2.1. What is Nextflow?
 
 Nextflow is a workflow manager. Instead of writing imperative scripts that say "do this, then do that," you _declare_ what processes exist and how data flows between them. Nextflow handles everything else: the parallelisation, scheduling, error handling, and resource management you'd otherwise write yourself.
 
-#### 5.1.1. Key concepts
+#### 2.1.1. Key concepts
 
 | Concept    | What it is                                         | Bash equivalent                      |
 | ---------- | -------------------------------------------------- | ------------------------------------ |
@@ -687,7 +642,7 @@ Nextflow is a workflow manager. Instead of writing imperative scripts that say "
 
 The key difference: in bash, you explicitly manage data flow with variables and file paths. In Nextflow, you declare what each process needs, and Nextflow figures out the execution order automatically.
 
-#### 5.1.2. Software management
+#### 2.1.2. Software management
 
 In Part 1, you installed FastQC, fastp, and Salmon with conda, hoping dependencies wouldn't conflict and documenting versions manually.
 
@@ -695,7 +650,7 @@ With Nextflow, each process declares its own software requirements. The tools ar
 
 ---
 
-### 5.2. Your first process: FastQC
+### 2.2. Your first process: FastQC
 
 In bash, you wrote FastQC commands inside loops, managed file paths with variables, and handled parallelisation with `&`. In Nextflow, each tool runs inside a `process`, a self-contained unit that declares its inputs, outputs, and command. You don't write loops; Nextflow runs the process once per input item automatically.
 
@@ -720,7 +675,7 @@ process FASTQC {
 }
 ```
 
-#### 5.2.1. Understanding the process
+#### 2.2.1. Understanding the process
 
 Each part has a purpose:
 
@@ -732,11 +687,11 @@ Each part has a purpose:
 
 You're not writing any loop logic, file existence checks, or error handling.
 
-!!! tip "Contrast with the agent's script"
+!!! tip "Contrast with the script form"
 
-    The one line `container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'` handles all software dependencies. The version is locked forever. Your colleague, your cluster, and your cloud all get the exact same FastQC, whether the agent generated this process for you or you wrote it by hand.
+    The one line `container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'` handles all software dependencies, and the version is locked forever. In Part 1 the same property required a conda environment that someone had to set up and replicate. Here it lives in the artefact, where a reviewer or a future maintainer can see exactly which version ran.
 
-#### 5.2.2. Call FASTQC in main.nf
+#### 2.2.2. Call FASTQC in main.nf
 
 Open `nextflow/main.nf` and add the FASTQC call:
 
@@ -752,7 +707,7 @@ Open `nextflow/main.nf` and add the FASTQC call:
     // TODO: Call FASTQC with ch_samples
     ```
 
-#### 5.2.3. Test it
+#### 2.2.3. Test it
 
 ```bash
 cd nextflow
@@ -770,13 +725,13 @@ All 3 samples ran in parallel automatically. In Part 1, you wrote `&` and `wait`
 
 ---
 
-### 5.3. Adding fastp
+### 2.3. Adding fastp
 
 Now add fastp following the same pattern. The key difference: fastp's output (trimmed reads) needs to flow to Salmon. In bash, you managed this with file paths like `results/fastp/${sample_id}_trimmed_R1.fastq.gz`. In Nextflow, you declare the output and let channels handle the data flow.
 
 Open `nextflow/modules/fastp.nf` and fill in the input, output, and script blocks.
 
-#### 5.3.1. Complete fastp.nf
+#### 2.3.1. Complete fastp.nf
 
 Pay attention to the `emit: reads` on the trimmed reads output. This names the output channel so Salmon can consume it.
 
@@ -831,7 +786,7 @@ Pay attention to the `emit: reads` on the trimmed reads output. This names the o
 
 The key line is `emit: reads` on the trimmed read files output. This creates a named output channel that Salmon will consume. When you later write `FASTP.out.reads`, you're accessing this specific output.
 
-#### 5.3.2. Call FASTP in main.nf
+#### 2.3.2. Call FASTP in main.nf
 
 Now connect FASTP to the sample channel in the workflow:
 
@@ -847,13 +802,13 @@ Now connect FASTP to the sample channel in the workflow:
     // TODO: Call FASTP with ch_samples
     ```
 
-!!! tip "Contrast with the agent's script"
+!!! tip "Contrast with the script form"
 
-    In Part 1, all tools shared one conda environment and conflicts were a constant risk. Here, fastp uses a completely different container than FastQC. They could require incompatible Python versions or conflicting libraries; doesn't matter. Each process gets its own isolated environment, regardless of what the agent picked when it set up your conda env.
+    In Part 1, all tools shared one conda environment and conflicts were a constant risk; the script's behaviour depended on whatever the solver picked. Here, fastp uses a completely different container than FastQC. They could require incompatible Python versions or conflicting libraries and it would not matter. Each process declares its own isolated environment in the artefact, where a reader can see it.
 
 ---
 
-### 5.4. Connecting to Salmon
+### 2.4. Connecting to Salmon
 
 This is where Nextflow's data flow model pays off. In bash, you manually coordinated file paths; Salmon needed to know where fastp wrote its output. In Nextflow, you declare that Salmon needs fastp's output, and the framework handles the rest.
 
@@ -864,7 +819,7 @@ Salmon needs two inputs:
 
 This is a common pattern: per-sample data combined with a shared reference. In bash, you'd check if the index exists with `if [ ! -d ... ]`. In Nextflow, the channel system handles this automatically.
 
-#### 5.4.1. Complete salmon.nf
+#### 2.4.1. Complete salmon.nf
 
 The UNTAR process (which extracts the pre-built Salmon index) is already complete. Your task is to fill in SALMON_QUANT, which has two input declarations:
 
@@ -926,7 +881,7 @@ Notice two things in the script:
 - `${task.cpus}`: Nextflow makes declared resources available as variables. In bash, you hardcoded `--threads 2`. Here, you declare resources once (`cpus 4`) and reference them in the script. Change the declaration, and the script adapts automatically.
 - Two inputs: the process receives the trimmed reads tuple and the index path separately. In bash, you coordinated these with file paths. Here, the data flow is explicit.
 
-#### 5.4.2. Wire it up in main.nf
+#### 2.4.2. Wire it up in main.nf
 
 Now connect the processes. SALMON_QUANT needs two arguments. Then add `publish:` and `output {}` blocks so each tool's results land in a predictable layout.
 
@@ -976,7 +931,7 @@ Two things to notice:
 
 The `publish:` block names the channels you want kept; the top-level `output {}` block tells Nextflow what subdirectory to put each one in. The actual root directory comes from `-output-dir` on the command line.
 
-#### 5.4.3. Run and watch
+#### 2.4.3. Run and watch
 
 Run the complete pipeline:
 
@@ -990,13 +945,13 @@ Watch what happens. Nextflow automatically determines the execution order from t
 - SALMON_QUANT must wait for FASTP; it needs the trimmed reads output.
 - Each sample runs independently; sample 2's Salmon can start as soon as sample 2's fastp finishes, even if sample 1 is still running.
 
-!!! tip "Contrast with the agent's script"
+!!! tip "Contrast with the script form"
 
-    In Part 1, the bash version needed `&` and `wait` and worried about memory limits at 500 samples. The same agent producing this Nextflow process gets parallelisation and resource-aware throttling for free; producing the bash version, it has to remember to write the throttling itself, and probably won't.
+    In Part 1, the script needed `&` and `wait` and worried about memory limits at 500 samples; resource-aware throttling was 20-30 lines that someone had to write and a reviewer had to check. Here parallelisation comes from the data flow declaration and throttling comes from the per-process `cpus` directive. Both are visible at a glance, neither has to be re-derived to verify, and changing one doesn't risk breaking the other.
 
 ---
 
-### 5.5. Aggregation with MultiQC
+### 2.5. Aggregation with MultiQC
 
 Real pipelines don't just run processes per sample; they often need to aggregate results across all samples. MultiQC collects QC metrics from FastQC, fastp, Salmon, and other tools into a single summary report.
 
@@ -1044,13 +999,13 @@ Add `multiqc_report = MULTIQC.out.report` to the workflow's `publish:` block and
 
 The `.collect()` operator waits for all upstream processes to complete, then passes everything to MultiQC as a single batch. Nextflow tracks which files to collect automatically.
 
-!!! tip "Contrast with the agent's script"
+!!! tip "Contrast with the script form"
 
-    In Part 1, you'd need to track job completion status, build file lists manually, and handle partial failures. Here, the channel operators handle all of that. The `.collect()` naturally waits for all inputs, and `.mix()` combines outputs from different processes; an agent generating bash from scratch would have to reinvent each of these every time.
+    In Part 1, this aggregation needed job-completion tracking, manual file-list assembly, and partial-failure handling: tens of lines of inline bookkeeping a reader has to follow. Here, `.collect()` naturally waits for all inputs and `.mix()` combines outputs from different processes. The reader sees the data flow, not the bookkeeping.
 
 ---
 
-### 5.6. Resume and caching
+### 2.6. Resume and caching
 
 In Part 1, failure recovery was a pain point. If sample 47 failed, you had no record of what completed, and implementing checkpoint logic would take 40+ lines of state tracking.
 
@@ -1071,7 +1026,7 @@ Nextflow automatically tracks what completed successfully. Failed tasks can be f
 
 ---
 
-### 5.7. Configuration profiles
+### 2.7. Configuration profiles
 
 In Part 1, scaling to clusters required rewriting the entire script with SLURM job arrays and cluster-specific syntax. Your collaborator on PBS would need yet another version.
 
@@ -1092,7 +1047,7 @@ Same workflow code. Same scientific results. Different infrastructure. You write
 
 ---
 
-### 5.8. Takeaway
+### 2.8. Takeaway
 
 Checking progress against the same properties:
 
@@ -1104,21 +1059,17 @@ Checking progress against the same properties:
 - :white_check_mark: **Failure recovery**: `-resume`. One flag.
 - :white_check_mark: **Portability**: Same code, different `-profile`.
 
-Every property we struggled with in Part 1 is built into Nextflow. You didn't write any infrastructure code; you just declared what each process needs and produces.
+Every property we struggled with in Part 1 is supplied by the workflow boundary itself, not by the author. The artefact you produced is the same one an agent would produce from the same paragraph of intent, and a maintainer reading it can see at a glance which container ran each step, where outputs land, what gets parallelised, where the cache lives. Each engineering decision is one line, in a known place, easy to vet and easy to change.
 
-The fundamental difference: scripts mix _what_ to compute with _how_ to compute it. Workflow managers separate these concerns. You (or your agent) declare the science, the framework handles the infrastructure.
+The form did the work that Part 1 left to the author.
 
 ---
 
-## 6. Why workflows still matter when AI does the writing
+## 3. Why workflows still matter when AI does the writing
 
-Look back at the four eras the introduction named. Commands gave way to scripts, and scripts gave way to workflows, because each step was a better artefact for a team to live with: easier to vet, easier to validate, easier to maintain when tools changed and labs grew. The workflow form did not appear because writing scripts was hard. It appeared because keeping scripts around was.
+An agent producing bash and the same agent producing Nextflow take roughly the same number of seconds. The bottleneck has moved. It is no longer how long it takes to write the code; it is how long it takes a team to verify, ship, and maintain what was written. The artefact's role has not changed.
 
-We are in the fourth era now. An agent producing bash and the same agent producing Nextflow take roughly the same number of seconds. The bottleneck has moved. It is no longer how long it takes to write code; it is how long it takes a team to verify, ship, and maintain what was written. The artefact's role has not changed.
-
-The case for the workflow tool gets stronger, not weaker, the more code AI is producing. Volumes of generated code that nobody can read or vet are a liability. A workflow puts the engineering structure where humans can see it: container pins as one-line declarations, parallelism as data flow, resume as a property of the cache rather than a property the author remembered to write. That is what makes review tractable, tests writable, and maintenance possible. AI accelerates the authoring; the workflow tool makes the operate-debug-maintain loop tractable.
-
-You still read what the AI produced. You still verify container pins, validate cache behaviour, lock the contract with tests; these are the durable skills. The [`nf-test` side quest](../nf_test/index.md) is the right next step for locking what got authored.
+The case for the workflow tool gets stronger, not weaker, the more code AI is producing. Volumes of generated code nobody can read or vet are a liability; the script form Part 1 produced is exactly that kind of liability at scale. The workflow form Part 2 produced puts the engineering structure where a reader can see it, where tests can lock it, and where maintenance does not require re-deriving correctness. AI accelerates the authoring; the workflow tool makes the operate-debug-maintain loop tractable. The [`nf-test` side quest](../nf_test/index.md) is the right next step for locking what got authored.
 
 The answer to "why workflows when AI can write the code for me" is that the artefact has to outlive the conversation that made it.
 

--- a/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
+++ b/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
@@ -1,36 +1,57 @@
-# Workflow Management Fundamentals
+# Workflows in the AI era
 
-If you're coming from a background of writing scripts for data processing - whether in bash, Python, or any other language - workflow management tools might seem like unnecessary complexity.
-Why learn a whole new framework when your script does the job?
+If an AI agent can run your analysis on demand, or generate a complete pipeline for you in seconds, why do you still need to learn a workflow tool?
 
-This side quest answers that question through direct experience.
-You'll build a real analysis pipeline using scripts, try to achieve production-quality standards, then rebuild it in Nextflow to see what workflow management actually provides.
+Because the pipeline is the durable artefact.
+Without one, the analysis the agent just ran cannot be re-run, audited, ported, scaled, or trusted.
+With one, those properties come from the workflow boundary, no matter who or what wrote the code inside it.
+
+This side quest answers the question by experience.
+You will build a real RNA-seq analysis the way an agent might run it for you, find the limits of what that gets you, then rebuild it as a Nextflow workflow and watch each limit disappear.
 
 !!! note "Why bash?"
 
-    We use bash in Part 1 because it's common for bioinformatics pipelines, but the limitations we'll encounter apply equally to Python scripts, R pipelines, or any approach where you're manually orchestrating tools. The issue isn't the language - it's the scripting approach itself.
+    Part 1 uses bash to stand in for the kind of ad-hoc invocation an agent would produce on demand. The limitations are the same whether the script is bash, Python, R, or output from a chat session. The issue is not the language; it is running tools without a workflow boundary.
+
+### Learning goals
+
+By the end of this side quest, you'll be able to:
+
+- Name the production-quality properties an ad-hoc analysis (yours, your colleague's, or an agent's) does not give you for free.
+- Wrap the same analysis logic in a Nextflow process so that reproducibility, software tracking, parallelisation, resume, and portability come from the workflow boundary.
+- Use the workflow output system (`publish:` + `output {}` + `-output-dir`) to produce a stable layout an operator or agent can consume.
+- Articulate why the case for a workflow tool gets stronger, not weaker, when AI is writing the Nextflow.
+
+### Prerequisites
+
+You don't need any prior Nextflow experience for this side quest; it is a motivational tour. If you want a thorough introduction afterwards, head to [Hello Nextflow](../../hello_nextflow/index.md).
+
+You'll need:
+
+- The Codespace (or a local environment with Docker, conda or mamba, and Nextflow >= 25.10).
+- About 90 minutes.
 
 ---
 
-## What Makes a Good Analysis Pipeline?
+## 1. What a production-grade analysis needs
 
-Before writing any code, here are the qualities of a production-quality analysis pipeline:
+These are the properties an AI assistant does not give you for free, and that a workflow manager does:
 
-- **Reproducibility** - Same inputs produce identical outputs, every time. Results can be verified and published with confidence.
-- **Software management** - Each task gets its own isolated environment. No dependency conflicts between tools, and a standardized approach across your whole pipeline.
-- **Scalability** - Handles 3 samples or 3,000 without code changes.
-- **Efficient parallelization** - Independent tasks run simultaneously, so analysis completes in hours, not days.
-- **Resource awareness** - Respects memory and CPU limits. No crashed jobs or killed processes.
-- **Failure recovery** - Can resume from where it stopped. A single failure doesn't waste hours of completed work.
-- **Portability** - Runs on laptop, cluster, or cloud with the same code.
+- **Reproducibility**: Same inputs produce identical outputs, every time. Results can be verified and published with confidence.
+- **Software management**: Each task gets its own isolated environment. No dependency conflicts between tools, and a standardised approach across your whole pipeline.
+- **Scalability**: Handles 3 samples or 3,000 without code changes.
+- **Efficient parallelisation**: Independent tasks run simultaneously, so analysis completes in hours, not days.
+- **Resource awareness**: Respects memory and CPU limits. No crashed jobs or killed processes.
+- **Failure recovery**: Can resume from where it stopped. A single failure doesn't waste hours of completed work.
+- **Portability**: Runs on laptop, cluster, or cloud with the same code.
 
-These aren't nice-to-haves - they're requirements for serious computational research.
+These aren't nice-to-haves; they're requirements for serious computational research.
 
-The question is how can we achieve this in one pipeline?
+The question is how to achieve this in one pipeline.
 
 ---
 
-## What You'll Build
+## 2. What you'll build
 
 An RNA-seq analysis pipeline that runs:
 
@@ -38,38 +59,38 @@ An RNA-seq analysis pipeline that runs:
 2. Adapter trimming (fastp)
 3. Transcript quantification (Salmon)
 
-**How this tutorial works:**
+How this tutorial works:
 
-| Part | Software | What You'll Do                                       | What You'll Learn                                    |
+| Part | Software | What you'll do                                       | What you'll learn                                    |
 | ---- | -------- | ---------------------------------------------------- | ---------------------------------------------------- |
 | 1    | Bash     | Build a pipeline, try to hit those quality standards | How much infrastructure code it takes                |
 | 2    | Nextflow | Rebuild with a workflow manager                      | How the same standards are achieved with less effort |
 
-By the end, you'll understand _why_ workflow managers exist - not from explanation, but from hitting the limitations yourself.
+By the end, you'll understand _why_ workflow managers exist, not from explanation but from hitting the limitations yourself.
 
 ---
 
-## 1. Building a Bash Pipeline
+## 3. Building a bash pipeline
 
-In this part, you'll build an RNA-seq analysis pipeline using bash, aiming for the production-quality standards we defined above.
-We'll see how far we can get - and where things get difficult.
+In this part, you'll build an RNA-seq analysis pipeline using bash, aiming for the production-quality properties listed above.
+We'll see how far we can get and where things get difficult.
 
 ---
 
-### 1.1. Setup
+### 3.1. Setup
 
-#### The Scenario
+#### 3.1.1. The scenario
 
-You're a bioinformatician analyzing RNA-seq data from a yeast gene expression study.
+You're a bioinformatician analysing RNA-seq data from a yeast gene expression study.
 You have 3 samples today. Your PI mentions that 50 more samples are coming next week.
 
-#### Navigate to the Working Directory
+#### 3.1.2. Navigate to the working directory
 
 ```bash
-cd side-quests/workflow_management_fundamentals
+cd side-quests/workflows_in_the_ai_era
 ```
 
-#### Explore the Starter Files
+#### 3.1.3. Explore the starter files
 
 ```bash
 ls -la bash/
@@ -84,7 +105,7 @@ bash/
 
 You'll fill in these starter files as you progress through the tutorial.
 
-#### Examine the Sample Data
+#### 3.1.4. Examine the sample data
 
 ```bash
 cat data/samples.csv
@@ -101,11 +122,11 @@ Each row is a sample with URLs to paired-end FASTQ files.
 
 ---
 
-### 1.2. Installing Your Tools
+### 3.2. Installing your tools
 
 Before you can run any analysis, you need to install the bioinformatics tools.
 
-#### Create a Conda Environment
+#### 3.2.1. Create a conda environment
 
 === "Mamba (Recommended)"
 
@@ -125,7 +146,7 @@ Watch the output. Notice:
 - Packages being downloaded
 - Hope that there are no conflicts...
 
-#### Activate the Environment
+#### 3.2.2. Activate the environment
 
 ```bash
 mamba activate rnaseq-bash
@@ -134,9 +155,9 @@ mamba activate rnaseq-bash
 !!! warning "Remember this step"
 
     Every time you open a new terminal, you must activate this environment again.
-    Forget, and your script fails with "command not found".
+    Forget, and your script fails with `command not found`.
 
-#### Verify Installation
+#### 3.2.3. Verify installation
 
 ```bash
 fastqc --version
@@ -144,24 +165,15 @@ fastp --version
 salmon --version
 ```
 
-#### Reflection: The Installation Tax
+#### 3.2.4. Takeaway
 
-You just spent time on:
-
-- Choosing a package manager (conda vs mamba vs pip?)
-- Finding the right channel (bioconda)
-- Waiting for dependency resolution
-- Hoping nothing conflicts
-
-This is before writing a single line of analysis code. And this is a simple pipeline - real analyses often need tools with conflicting dependencies that can't coexist in the same environment.
-
-You could improve this with versioned `environment.yml` files, but that's another system you'd need to set up and maintain. Every colleague who runs your pipeline needs to replicate your environment setup.
+The agent that ran this for you didn't record which versions of FastQC, fastp, or Salmon ended up in the environment, didn't pin a channel, and didn't write down what to do when conda's solver picks up a different combination next month. That documentation is your problem.
 
 ---
 
-### 1.3. Building Your First Script
+### 3.3. Building your first script
 
-Open the starter file `bash/process_sample.sh`. It has the structure ready - you just need to add the tool commands.
+Open the starter file `bash/process_sample.sh`. It has the structure ready; you just need to add the tool commands.
 
 ```bash
 cat bash/process_sample.sh
@@ -199,20 +211,20 @@ mkdir -p data/fastq results/fastqc results/fastp results/salmon data/salmon_inde
 echo "Completed: $SAMPLE_ID"
 ```
 
-#### Understanding the Starter Script
+#### 3.3.1. Understanding the starter script
 
 The script accepts three arguments: a sample ID and two URLs for paired-end FASTQ files. The `set -e` line means the script will stop immediately if any command fails.
 
 The TODO comments mark where you'll add each analysis step:
 
-1. **Download** - Get the raw sequencing data
-2. **FastQC** - Check the quality of the raw reads
-3. **fastp** - Trim adapters and filter low-quality reads
-4. **Salmon** - Quantify transcript expression levels
+1. **Download**: Get the raw sequencing data
+2. **FastQC**: Check the quality of the raw reads
+3. **fastp**: Trim adapters and filter low-quality reads
+4. **Salmon**: Quantify transcript expression levels
 
 This is a typical RNA-seq preprocessing workflow. Fill in each step below.
 
-#### 1.3.1. Add the Download Step
+#### 3.3.2. Add the download step
 
 First, we need to download the FASTQ files from their URLs. We'll use `curl` with `-sL` (silent mode, follow redirects) to fetch each file and save it with a consistent naming pattern.
 
@@ -232,7 +244,7 @@ First, we need to download the FASTQ files from their URLs. We'll use `curl` wit
     # TODO: Add curl commands to download R1 and R2 files
     ```
 
-#### 1.3.2. Add FastQC
+#### 3.3.3. Add FastQC
 
 FastQC analyzes sequencing data and generates quality reports. We run it on both read files (`R1` and `R2`) and save the output to our results directory. The `-q` flag suppresses progress output.
 
@@ -253,7 +265,7 @@ FastQC analyzes sequencing data and generates quality reports. We run it on both
     # TODO: Add fastqc command
     ```
 
-#### 1.3.3. Add fastp
+#### 3.3.4. Add fastp
 
 fastp trims adapter sequences and filters out low-quality reads. It takes paired input files (`-i`, `-I`) and produces trimmed output files (`-o`, `-O`), plus JSON and HTML reports for quality metrics.
 
@@ -279,7 +291,7 @@ fastp trims adapter sequences and filters out low-quality reads. It takes paired
     # TODO: Add fastp command
     ```
 
-#### 1.3.4. Add Salmon Index Download
+#### 3.3.5. Add the Salmon index download
 
 Salmon needs a pre-built index of the reference transcriptome. We'll download a pre-built index (to save time) only if it doesn't already exist. This avoids re-downloading for every sample.
 
@@ -305,9 +317,9 @@ Salmon needs a pre-built index of the reference transcriptome. We'll download a 
 
 !!! note "Conditional logic in scripts vs workflow managers"
 
-    This `if [ ! -d ... ]` check is a common pattern in scripts - "only do this if it hasn't been done already." While conceptually simple, it's fragile: it checks if a directory exists, not whether the download actually succeeded or the files are valid. Workflow managers handle this more robustly by tracking actual task outputs rather than checking for file/directory existence.
+    This `if [ ! -d ... ]` check is a common pattern in scripts: "only do this if it hasn't been done already." While conceptually simple, it's fragile, because it detects whether the directory exists rather than whether the download actually succeeded or the files are valid. Workflow managers handle this more robustly by tracking actual task outputs rather than checking for file or directory existence.
 
-#### 1.3.5. Add Salmon Quantification
+#### 3.3.6. Add Salmon quantification
 
 Salmon quantifies transcript expression by pseudo-aligning reads to the index. It takes the **trimmed** reads from fastp (not the raw reads) and outputs expression counts per transcript.
 
@@ -333,7 +345,7 @@ Salmon quantifies transcript expression by pseudo-aligning reads to the index. I
     # TODO: Add salmon quant command
     ```
 
-#### Test Your Script
+#### 3.3.7. Test your script
 
 Make it executable and run on one sample:
 
@@ -350,14 +362,17 @@ Check the results:
 ls results/
 ```
 
-This works for one sample, but you have 3 samples (and 50 more coming).
-Running this command manually for each one isn't practical.
+This works for one sample, but you have 3 samples and 50 more coming. Running this command manually for each one isn't practical.
+
+#### 3.3.8. Takeaway
+
+You now have a runnable script. There is no record of which container or environment ran it, no resume on failure, no way to scale up without rewriting the loop. The script is what an agent hands you when you ask it to run an analysis; the rest is on you.
 
 ---
 
-### 1.4. Processing Multiple Samples
+### 3.4. Processing multiple samples
 
-Now that we can process one sample, we need to handle all samples from our CSV file. Open `bash/pipeline_sequential.sh` - it already has the loop structure that reads the CSV and iterates over each sample.
+Now that we can process one sample, we need to handle all samples from our CSV file. Open `bash/pipeline_sequential.sh`; it already has the loop structure that reads the CSV and iterates over each sample.
 
 The starter script handles:
 
@@ -365,9 +380,9 @@ The starter script handles:
 - Parsing each line into sample ID and FASTQ URLs
 - Creating output directories and downloading the shared Salmon index
 
-Your task is to add the actual processing commands inside the loop - the same steps you just wrote, but using the loop variables (`$sample_id`, `$fastq_r1`, `$fastq_r2`) instead of the script arguments.
+Your task is to add the actual processing commands inside the loop, the same steps you just wrote, but using the loop variables (`$sample_id`, `$fastq_r1`, `$fastq_r2`) instead of the script arguments.
 
-#### Add Processing Logic to the Loop
+#### 3.4.1. Add processing logic to the loop
 
 === "After"
 
@@ -418,7 +433,7 @@ Your task is to add the actual processing commands inside the loop - the same st
     done
     ```
 
-#### Run and Time It
+#### 3.4.2. Run and time it
 
 ```bash
 chmod +x bash/pipeline_sequential.sh
@@ -437,7 +452,7 @@ Processing: WT_REP1
 Processing: WT_REP2      <- Starts only after WT_REP1 is completely done
 ```
 
-#### The Problem: Sequential Execution
+#### 3.4.3. Takeaway
 
 ```
 Timeline (sequential):
@@ -445,24 +460,22 @@ WT_REP1:          [====FastQC====][====fastp====][======Salmon======]
 WT_REP2:                                                              [====FastQC====]...
 ```
 
-These samples are **completely independent** - WT_REP2's analysis doesn't depend on WT_REP1's results at all. Yet WT_REP2 sits idle while WT_REP1 runs through all its steps.
-
-With 50 samples, you're looking at **50× the runtime** for no good reason. Your computer has multiple cores sitting unused.
+These samples are completely independent. WT_REP2's analysis doesn't depend on WT_REP1's results at all. Yet WT_REP2 sits idle while WT_REP1 runs through all its steps. With 50 samples that's 50x the runtime for no good reason; your computer has multiple cores sitting unused.
 
 ---
 
-### 1.5. Adding Parallelization
+### 3.5. Adding parallelisation
 
-The sequential script works, but it's slow - each sample waits for the previous one to finish completely. Since samples are independent, they could run simultaneously.
+The sequential script works, but it's slow; each sample waits for the previous one to finish completely. Since samples are independent, they could run simultaneously.
 
-Open `bash/pipeline_parallel.sh`. This version wraps the processing logic in a function called `process_sample()`. The starter script has everything except the parallelization itself.
+Open `bash/pipeline_parallel.sh`. This version wraps the processing logic in a function called `process_sample()`. The starter script has everything except the parallelisation itself.
 
 Your task is to make the loop run samples in parallel by:
 
 1. Adding `&` after each function call to run it in the background
 2. Adding `wait` after the loop to pause until all background jobs complete
 
-#### Add Background Execution
+#### 3.5.1. Add background execution
 
 === "After"
 
@@ -491,17 +504,17 @@ Your task is to make the loop run samples in parallel by:
 
 The key changes:
 
-- **`&`** at the end of the function call runs it in the background
-- **`wait`** pauses until all background jobs complete
+- `&` at the end of the function call runs it in the background.
+- `wait` pauses until all background jobs complete.
 
-#### Run and Compare
+#### 3.5.2. Run and compare
 
 ```bash
 chmod +x bash/pipeline_parallel.sh
 time ./bash/pipeline_parallel.sh
 ```
 
-Notice the interleaved output - all samples running at once:
+Notice the interleaved output, all samples running at once:
 
 ```
 [WT_REP1] Starting...
@@ -514,37 +527,33 @@ Notice the interleaved output - all samples running at once:
 
 Faster, because all samples run concurrently.
 
-#### The Hidden Problem
+#### 3.5.3. Takeaway
 
-What happens with 50 samples? Or 500?
+What happens with 50 samples, or 500?
 
 ```bash
-# This would launch 500 Salmon jobs simultaneously!
+# This would launch 500 Salmon jobs simultaneously
 # Each Salmon uses ~4GB RAM
-# That's 500 × 4GB = 2TB RAM required!
+# That's 500 x 4GB = 2TB RAM required
 ```
 
-Your machine would crash from memory exhaustion. Bash's `&` has no concept of resource limits - it just launches everything at once.
-
-!!! question "How would you limit concurrent jobs?"
-
-    You'd need to track running jobs, wait when at the limit, and start new jobs as others complete. That's 20-30 lines of infrastructure code that has nothing to do with your science. And you'd have to maintain it, debug it, and hope it works correctly under all conditions.
+Your machine would crash from memory exhaustion. Bash's `&` has no concept of resource limits; it just launches everything at once. The agent didn't write a job-throttling layer; you'd need to track running jobs, wait when at the limit, and start new jobs as others complete. That's 20-30 lines of infrastructure code that has nothing to do with your science.
 
 ---
 
-### 1.6. Adding Aggregation
+### 3.6. Adding aggregation
 
-Real pipelines need a final aggregation step - collecting QC metrics from all samples into a summary report. MultiQC does this, but integrating it with parallel bash processing is tricky.
+Real pipelines need a final aggregation step that collects QC metrics from all samples into a summary report. MultiQC does this, but integrating it with parallel bash processing is tricky.
 
-#### The Problem
+#### 3.6.1. The problem
 
-Your parallel script launches all samples with `&` and waits for completion with `wait`. But `wait` only tells you when jobs finish - not which ones succeeded. To run MultiQC, you need to:
+Your parallel script launches all samples with `&` and waits for completion with `wait`. But `wait` only tells you when jobs finish, not which ones succeeded. To run MultiQC, you need to:
 
 1. Track which samples completed successfully
 2. Collect the right output files from each tool
 3. Handle partial failures gracefully
 
-#### A Simple (Fragile) Approach
+#### 3.6.2. A simple (fragile) approach
 
 Add MultiQC after the `wait`:
 
@@ -556,9 +565,9 @@ echo "All samples complete. Running MultiQC..."
 multiqc results/fastqc results/fastp results/salmon -o results/multiqc
 ```
 
-This works if everything succeeds, but breaks silently on partial failures - MultiQC runs on whatever files exist, potentially giving you an incomplete report without warning.
+This works if everything succeeds, but breaks silently on partial failures: MultiQC runs on whatever files exist, potentially giving you an incomplete report without warning.
 
-#### A Robust Approach (More Code)
+#### 3.6.3. A robust approach (more code)
 
 Proper aggregation requires tracking job status:
 
@@ -594,20 +603,20 @@ That's another 20+ lines of infrastructure code for something that should be sim
 
 ---
 
-### 1.7. The Pain Points
+### 3.7. The pain points
 
 We won't implement these, but consider what you'd need for a production-ready pipeline:
 
-#### Failure Recovery
+#### 3.7.1. Failure recovery
 
 If Salmon fails on sample 47 of 50, what happens?
 
-- With `set -e`, everything stops immediately
-- You have no record of which 46 samples completed successfully
-- To resume, you'd need to manually figure out what finished and what didn't
-- Implementing proper checkpoint logic would add 40+ lines of file-based state tracking
+- With `set -e`, everything stops immediately.
+- You have no record of which 46 samples completed successfully.
+- To resume, you'd need to manually figure out what finished and what didn't.
+- Implementing proper checkpoint logic would add 40+ lines of file-based state tracking.
 
-#### Reproducibility
+#### 3.7.2. Reproducibility
 
 When your colleague tries to run your script:
 
@@ -615,11 +624,11 @@ When your colleague tries to run your script:
 salmon: command not found
 ```
 
-They need to replicate your exact conda environment - same tool versions, same dependencies.
+They need to replicate your exact conda environment, same tool versions, same dependencies.
 
-Or worse - they have salmon 1.4.0 but you used 1.10.3. The script runs fine, but results differ silently. Months later, you can't reproduce your own analysis because conda updated something.
+Or worse, they have salmon 1.4.0 but you used 1.10.3. The script runs fine, but results differ silently. Months later, you can't reproduce your own analysis because conda updated something.
 
-#### Scaling to Cluster
+#### 3.7.3. Scaling to cluster
 
 Your laptop worked fine for 3 samples. For 500 samples, you need the SLURM cluster:
 
@@ -632,62 +641,60 @@ Now you're rewriting the entire script with job arrays, dependency tracking, and
 
 ---
 
-### 1.8. Part 1 Summary
+### 3.8. Takeaway
 
-Checking progress against the production-quality standards:
+Checking progress against the production-quality properties:
 
-- ⚠️ **Reproducibility** - Partial. Conda environment helps, but requires discipline to maintain.
-- ⚠️ **Software management** - Partial. All tools share one environment - conflicts possible. Setup is manual and must be replicated by every user.
-- ❌ **Scalability** - Limited. Works on one machine until you hit resource limits. Scaling to cluster/cloud requires a complete rewrite.
-- ⚠️ **Efficient parallelization** - Partial. Works, but no resource limits.
-- ❌ **Resource awareness** - Missing. Would need 20-30 lines of job limiting code.
-- ❌ **Failure recovery** - Missing. Would need 40+ lines of checkpoint logic.
-- ❌ **Portability** - Missing. Complete rewrite for each cluster type.
+- :warning: **Reproducibility**: Partial. Conda environment helps, but requires discipline to maintain.
+- :warning: **Software management**: Partial. All tools share one environment, so conflicts are possible. Setup is manual and must be replicated by every user.
+- :x: **Scalability**: Limited. Works on one machine until you hit resource limits. Scaling to cluster or cloud requires a complete rewrite.
+- :warning: **Efficient parallelisation**: Partial. Works, but no resource limits.
+- :x: **Resource awareness**: Missing. Would need 20-30 lines of job-limiting code.
+- :x: **Failure recovery**: Missing. Would need 40+ lines of checkpoint logic.
+- :x: **Portability**: Missing. Complete rewrite for each cluster type.
 
-We achieved the basics, but the production-quality features require significant infrastructure code that has nothing to do with our science.
+We achieved the basics, but the production-quality properties require significant infrastructure code that has nothing to do with our science.
 
-**The fundamental problem:** Scripts mix _what_ to compute with _how_ to compute it. Every quality requirement adds more infrastructure code - and this would be true whether we wrote it in bash, Python, or any other language.
-
-This is where workflow managers come in.
+The fundamental problem: scripts mix _what_ to compute with _how_ to compute it. Every quality requirement adds more infrastructure code, and this would be true whether the script came from bash, Python, or a chat session with an agent. This is where workflow managers come in.
 
 ---
 
-## 2. Building a Nextflow Pipeline
+## 4. Building a Nextflow pipeline
 
 Now you'll rebuild the same pipeline using Nextflow.
 At each step, we'll contrast with the scripting approach from Part 1.
 
 !!! note "This isn't a Nextflow tutorial"
 
-    We're skipping over a lot of Nextflow detail here to focus on illustrating how workflow managers solve the problems from Part 1. If you're sold on the idea and want to learn Nextflow properly, head to [Hello Nextflow](../hello_nextflow/index.md) for a thorough introduction.
+    We're skipping over a lot of Nextflow detail here to focus on illustrating how workflow managers solve the problems from Part 1. If you're sold on the idea and want to learn Nextflow properly, head to [Hello Nextflow](../../hello_nextflow/index.md) for a thorough introduction.
 
 ---
 
-### 2.1. What is Nextflow?
+### 4.1. What is Nextflow?
 
-Nextflow is a workflow manager. Instead of writing imperative scripts that say "do this, then do that," you **declare** what processes exist and how data flows between them. Nextflow handles everything else - the parallelization, scheduling, error handling, and resource management you'd otherwise write yourself.
+Nextflow is a workflow manager. Instead of writing imperative scripts that say "do this, then do that," you _declare_ what processes exist and how data flows between them. Nextflow handles everything else: the parallelisation, scheduling, error handling, and resource management you'd otherwise write yourself.
 
-#### Key Concepts
+#### 4.1.1. Key concepts
 
-| Concept      | What It Is                                         | Bash Equivalent                      |
-| ------------ | -------------------------------------------------- | ------------------------------------ |
-| **Process**  | A unit of work (like running FastQC on one sample) | A function or script                 |
-| **Channel**  | A queue of data flowing between processes          | Variables passed between commands    |
-| **Workflow** | How processes connect together                     | The order of commands in your script |
+| Concept    | What it is                                         | Bash equivalent                      |
+| ---------- | -------------------------------------------------- | ------------------------------------ |
+| `process`  | A unit of work (like running FastQC on one sample) | A function or script                 |
+| `channel`  | A queue of data flowing between processes          | Variables passed between commands    |
+| `workflow` | How processes connect together                     | The order of commands in your script |
 
 The key difference: in bash, you explicitly manage data flow with variables and file paths. In Nextflow, you declare what each process needs, and Nextflow figures out the execution order automatically.
 
-#### Software Management
+#### 4.1.2. Software management
 
-In Part 1, you installed FastQC, fastp, and Salmon with conda - hoping dependencies wouldn't conflict, documenting versions manually.
+In Part 1, you installed FastQC, fastp, and Salmon with conda, hoping dependencies wouldn't conflict and documenting versions manually.
 
 With Nextflow, each process declares its own software requirements. The tools are configured automatically at runtime with support for whichever software packaging tool you prefer. Your colleague runs the same pipeline and gets the exact same software environment based on the process definition, not their system.
 
 ---
 
-### 2.2. Your First Process: FastQC
+### 4.2. Your first process: FastQC
 
-In bash, you wrote FastQC commands inside loops, managed file paths with variables, and handled parallelization with `&`. In Nextflow, each tool runs inside a **process** - a self-contained unit that declares its inputs, outputs, and command. You don't write loops; Nextflow runs the process once per input item automatically.
+In bash, you wrote FastQC commands inside loops, managed file paths with variables, and handled parallelisation with `&`. In Nextflow, each tool runs inside a `process`, a self-contained unit that declares its inputs, outputs, and command. You don't write loops; Nextflow runs the process once per input item automatically.
 
 Copy this complete process into `nextflow/modules/fastqc.nf`:
 
@@ -695,7 +702,6 @@ Copy this complete process into `nextflow/modules/fastqc.nf`:
 process FASTQC {
     tag "$id"
     container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'
-    publishDir "${params.outdir}/fastqc", mode: 'copy'
 
     input:
     tuple val(id), path(reads)
@@ -711,74 +717,72 @@ process FASTQC {
 }
 ```
 
-#### Understanding the Process
+#### 4.2.1. Understanding the process
 
 Each part has a purpose:
 
-- **`tag`** - Labels each job with the sample ID (visible in logs)
-- **`container`** - The Docker image containing FastQC (replaces your conda setup)
-- **`publishDir`** - Where to copy final outputs
-- **`input`** - Declares expected data: a tuple with sample ID (`val(id)`) and file paths (`path(reads)`)
-- **`output`** - Declares produced files with named channels (`emit: html`) for downstream processes
-- **`script`** - The actual command, nearly identical to your bash version
+- `tag`: Labels each job with the sample ID (visible in logs).
+- `container`: The Docker image containing FastQC (replaces your conda setup).
+- `input`: Declares expected data, here a tuple with sample ID (`val(id)`) and file paths (`path(reads)`).
+- `output`: Declares produced files with named channels (`emit: html`) for downstream processes.
+- `script`: The actual command, nearly identical to your bash version.
 
 You're not writing any loop logic, file existence checks, or error handling.
 
-!!! tip "Contrast with scripts"
+!!! tip "Contrast with the agent's script"
 
-    The **one line** `container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'` handles all software dependencies. The version is locked forever. Your colleague, your cluster, and your cloud all get the exact same FastQC.
+    The one line `container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'` handles all software dependencies. The version is locked forever. Your colleague, your cluster, and your cloud all get the exact same FastQC, whether the agent generated this process for you or you wrote it by hand.
 
-#### Call FASTQC in main.nf
+#### 4.2.2. Call FASTQC in main.nf
 
 Open `nextflow/main.nf` and add the FASTQC call:
 
 === "After"
 
-    ```groovy title="nextflow/main.nf" linenums="34" hl_lines="1"
+    ```groovy title="nextflow/main.nf" linenums="27" hl_lines="1"
     FASTQC(ch_samples)
     ```
 
 === "Before"
 
-    ```groovy title="nextflow/main.nf" linenums="34"
-    // TODO: Call FASTQC process with ch_samples
+    ```groovy title="nextflow/main.nf" linenums="27"
+    // TODO: Call FASTQC with ch_samples
     ```
 
-#### Test It
+#### 4.2.3. Test it
 
 ```bash
 cd nextflow
-nextflow run main.nf
+nextflow run main.nf -output-dir results
 ```
 
 ```console title="Output"
-N E X T F L O W  ~  version 24.10.0
+N E X T F L O W  ~  version 25.10.4
 
 executor >  local (3)
 [a1/b2c3d4] FASTQC (WT_REP1)           [100%] 3 of 3 ✔
 ```
 
-**All 3 samples ran in parallel automatically.** In Part 1, you wrote `&` and `wait` and worried about resource limits. Nextflow figures out optimal parallelization from your process definition alone.
+All 3 samples ran in parallel automatically. In Part 1, you wrote `&` and `wait` and worried about resource limits. Nextflow figures out optimal parallelisation from your process definition alone, with no extra code from you or the agent.
 
 ---
 
-### 2.3. Adding fastp
+### 4.3. Adding fastp
 
 Now add fastp following the same pattern. The key difference: fastp's output (trimmed reads) needs to flow to Salmon. In bash, you managed this with file paths like `results/fastp/${sample_id}_trimmed_R1.fastq.gz`. In Nextflow, you declare the output and let channels handle the data flow.
 
 Open `nextflow/modules/fastp.nf` and fill in the input, output, and script blocks.
 
-#### Complete fastp.nf
+#### 4.3.1. Complete fastp.nf
 
-Pay attention to the `emit: reads` on the trimmed reads output - this names the output channel so Salmon can consume it.
+Pay attention to the `emit: reads` on the trimmed reads output. This names the output channel so Salmon can consume it.
 
 === "After"
 
-    ```groovy title="nextflow/modules/fastp.nf" hl_lines="7 10-12 15-23"
+    ```groovy title="nextflow/modules/fastp.nf" hl_lines="5 8-10 13-21"
     process FASTP {
         tag "$id"
         container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
-        publishDir "${params.outdir}/fastp", mode: 'copy'
 
         input:
         tuple val(id), path(reads)
@@ -808,7 +812,6 @@ Pay attention to the `emit: reads` on the trimmed reads output - this names the 
     process FASTP {
         tag "$id"
         container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
-        publishDir "${params.outdir}/fastp", mode: 'copy'
 
         input:
         ???
@@ -825,50 +828,49 @@ Pay attention to the `emit: reads` on the trimmed reads output - this names the 
 
 The key line is `emit: reads` on the trimmed read files output. This creates a named output channel that Salmon will consume. When you later write `FASTP.out.reads`, you're accessing this specific output.
 
-#### Call FASTP in main.nf
+#### 4.3.2. Call FASTP in main.nf
 
 Now connect FASTP to the sample channel in the workflow:
 
 === "After"
 
-    ```groovy title="nextflow/main.nf" linenums="36" hl_lines="1"
+    ```groovy title="nextflow/main.nf" linenums="29" hl_lines="1"
     FASTP(ch_samples)
     ```
 
 === "Before"
 
-    ```groovy title="nextflow/main.nf" linenums="36"
-    // TODO: Call FASTP process with ch_samples
+    ```groovy title="nextflow/main.nf" linenums="29"
+    // TODO: Call FASTP with ch_samples
     ```
 
-!!! tip "Contrast with scripts"
+!!! tip "Contrast with the agent's script"
 
-    In Part 1, all tools shared one conda environment - conflicts were a constant risk. Here, fastp uses a completely different container than FastQC. They could require incompatible Python versions or conflicting libraries - doesn't matter. Each process gets its own isolated environment.
+    In Part 1, all tools shared one conda environment and conflicts were a constant risk. Here, fastp uses a completely different container than FastQC. They could require incompatible Python versions or conflicting libraries; doesn't matter. Each process gets its own isolated environment, regardless of what the agent picked when it set up your conda env.
 
 ---
 
-### 2.4. Connecting to Salmon
+### 4.4. Connecting to Salmon
 
-This is where Nextflow's data flow model pays off. In bash, you manually coordinated file paths - Salmon needed to know where fastp wrote its output. In Nextflow, you declare that Salmon needs fastp's output, and the framework handles the rest.
+This is where Nextflow's data flow model pays off. In bash, you manually coordinated file paths; Salmon needed to know where fastp wrote its output. In Nextflow, you declare that Salmon needs fastp's output, and the framework handles the rest.
 
-Salmon needs **two** inputs:
+Salmon needs two inputs:
 
-1. **Trimmed reads** - Different for each sample (from FASTP)
-2. **Reference index** - Same for all samples (from UNTAR)
+1. **Trimmed reads**: Different for each sample (from FASTP).
+2. **Reference index**: Same for all samples (from UNTAR).
 
 This is a common pattern: per-sample data combined with a shared reference. In bash, you'd check if the index exists with `if [ ! -d ... ]`. In Nextflow, the channel system handles this automatically.
 
-#### Complete salmon.nf
+#### 4.4.1. Complete salmon.nf
 
-The UNTAR process (which extracts the pre-built Salmon index) is already complete. Your task is to fill in SALMON_QUANT, which has **two input declarations**:
+The UNTAR process (which extracts the pre-built Salmon index) is already complete. Your task is to fill in SALMON_QUANT, which has two input declarations:
 
 === "After"
 
-    ```groovy title="nextflow/modules/salmon.nf" linenums="17" hl_lines="10-11 14 18-24"
+    ```groovy title="nextflow/modules/salmon.nf" linenums="17" hl_lines="8-9 12 16-22"
     process SALMON_QUANT {
         tag "$id"
         container 'quay.io/biocontainers/salmon:1.10.3--h6dccd9a_2'
-        publishDir "${params.outdir}/salmon", mode: 'copy'
 
         cpus 4
         memory '8.GB'
@@ -878,17 +880,17 @@ The UNTAR process (which extracts the pre-built Salmon index) is already complet
         path index
 
         output:
-        tuple val(id), path("$id"), emit: results
+        tuple val(id), path("${id}"), emit: results
 
         script:
         """
         salmon quant \\
-            --index $index \\
+            --index ${index} \\
             --libType A \\
             --mates1 ${reads[0]} \\
             --mates2 ${reads[1]} \\
-            --output $id \\
-            --threads $task.cpus
+            --output ${id} \\
+            --threads ${task.cpus}
         """
     }
     ```
@@ -899,7 +901,6 @@ The UNTAR process (which extracts the pre-built Salmon index) is already complet
     process SALMON_QUANT {
         tag "$id"
         container 'quay.io/biocontainers/salmon:1.10.3--h6dccd9a_2'
-        publishDir "${params.outdir}/salmon", mode: 'copy'
 
         cpus 4
         memory '8.GB'
@@ -919,57 +920,82 @@ The UNTAR process (which extracts the pre-built Salmon index) is already complet
 
 Notice two things in the script:
 
-- **`$task.cpus`** - Nextflow makes declared resources available as variables. In bash, you hardcoded `--threads 2`. Here, you declare resources once (`cpus 4`) and reference them in the script. Change the declaration, and the script adapts automatically.
-- **Two inputs** - The process receives the trimmed reads tuple and the index path separately. In bash, you coordinated these with file paths. Here, the data flow is explicit.
+- `${task.cpus}`: Nextflow makes declared resources available as variables. In bash, you hardcoded `--threads 2`. Here, you declare resources once (`cpus 4`) and reference them in the script. Change the declaration, and the script adapts automatically.
+- Two inputs: the process receives the trimmed reads tuple and the index path separately. In bash, you coordinated these with file paths. Here, the data flow is explicit.
 
-#### Wire It Up in main.nf
+#### 4.4.2. Wire it up in main.nf
 
-Now connect the processes. SALMON_QUANT needs two arguments:
+Now connect the processes. SALMON_QUANT needs two arguments. Then add `publish:` and `output {}` blocks so each tool's results land in a predictable layout.
 
 === "After"
 
-    ```groovy title="nextflow/main.nf" linenums="38" hl_lines="1"
+    ```groovy title="nextflow/main.nf" linenums="30" hl_lines="1 4-10 13-30"
     SALMON_QUANT(FASTP.out.reads, UNTAR.out.index.first())
+
+    publish:
+    fastqc_html = FASTQC.out.html
+    fastqc_zip = FASTQC.out.zip
+    fastp_reads = FASTP.out.reads
+    fastp_json = FASTP.out.json
+    fastp_html = FASTP.out.html
+    salmon_quant = SALMON_QUANT.out.results
+    }
+
+    output {
+        fastqc_html { path 'fastqc' }
+        fastqc_zip { path 'fastqc' }
+        fastp_reads { path 'fastp' }
+        fastp_json { path 'fastp' }
+        fastp_html { path 'fastp' }
+        salmon_quant { path 'salmon' }
+    }
     ```
 
 === "Before"
 
-    ```groovy title="nextflow/main.nf" linenums="38"
+    ```groovy title="nextflow/main.nf" linenums="30"
     // TODO: Call SALMON_QUANT with FASTP output and the index
-    // Hint: Use FASTP.out.reads for the trimmed reads
-    // Hint: Use UNTAR.out.index.first() for the index
+    // Hint: Use FASTP.out.reads and UNTAR.out.index.first()
+
+    publish:
+    // TODO: Publish the outputs you want kept after the run.
+    }
+
+    output {
+        // TODO: Configure output paths for each published channel.
+    }
     ```
 
-Understanding this line:
+Two things to notice:
 
-- **`FASTP.out.reads`** - The trimmed reads channel (one item per sample)
-- **`UNTAR.out.index.first()`** - The `.first()` operator converts the channel to a single value that gets reused for every sample
+- `FASTP.out.reads`: the trimmed reads channel (one item per sample).
+- `UNTAR.out.index.first()`: `.first()` converts the channel to a single value that gets reused for every sample. Without it, Nextflow would try to pair each sample with a separate index item.
 
-Without `.first()`, Nextflow would try to pair each sample with a separate index item. Since there's only one index, we tell Nextflow to reuse it.
+The `publish:` block names the channels you want kept; the top-level `output {}` block tells Nextflow what subdirectory to put each one in. The actual root directory comes from `-output-dir` on the command line.
 
-#### Run and Watch
+#### 4.4.3. Run and watch
 
 Run the complete pipeline:
 
 ```bash
-nextflow run main.nf
+nextflow run main.nf -output-dir results
 ```
 
-Watch what happens - Nextflow automatically determines the execution order from the data flow you defined:
+Watch what happens. Nextflow automatically determines the execution order from the data flow you defined:
 
-- **FastQC and FASTP can run in parallel** - Both only need the raw reads, no dependency between them
-- **SALMON_QUANT must wait for FASTP** - It needs the trimmed reads output
-- **Each sample runs independently** - Sample 2's Salmon can start as soon as Sample 2's fastp finishes, even if Sample 1 is still running
+- FastQC and FASTP can run in parallel; both only need the raw reads, no dependency between them.
+- SALMON_QUANT must wait for FASTP; it needs the trimmed reads output.
+- Each sample runs independently; sample 2's Salmon can start as soon as sample 2's fastp finishes, even if sample 1 is still running.
 
-!!! tip "Contrast with scripts"
+!!! tip "Contrast with the agent's script"
 
-    In Part 1, you implemented `&` and `wait`, then worried about memory limits with 500 samples. Nextflow infers parallelization from the data flow and respects resource declarations.
+    In Part 1, you implemented `&` and `wait`, then worried about memory limits with 500 samples. Nextflow infers parallelisation from the data flow and respects resource declarations. The agent on its own would have hit the same wall.
 
 ---
 
-### 2.5. Aggregation with MultiQC
+### 4.5. Aggregation with MultiQC
 
-Real pipelines don't just run processes per sample - they often need to aggregate results across all samples. MultiQC collects QC metrics from FastQC, fastp, Salmon, and other tools into a single summary report.
+Real pipelines don't just run processes per sample; they often need to aggregate results across all samples. MultiQC collects QC metrics from FastQC, fastp, Salmon, and other tools into a single summary report.
 
 In bash, aggregation is awkward. You'd need to:
 
@@ -983,7 +1009,6 @@ With channels, this is straightforward. Add a MULTIQC process:
 ```groovy title="nextflow/modules/multiqc.nf"
 process MULTIQC {
     container 'quay.io/biocontainers/multiqc:1.19--pyhdfd78af_0'
-    publishDir "${params.outdir}/multiqc", mode: 'copy'
 
     input:
     path('*')
@@ -1012,22 +1037,24 @@ ch_multiqc = FASTQC.out.zip
 MULTIQC(ch_multiqc)
 ```
 
+Add `multiqc_report = MULTIQC.out.report` to the workflow's `publish:` block and `multiqc_report { path 'multiqc' }` to the `output {}` block.
+
 The `.collect()` operator waits for all upstream processes to complete, then passes everything to MultiQC as a single batch. Nextflow tracks which files to collect automatically.
 
-!!! tip "Contrast with scripts"
+!!! tip "Contrast with the agent's script"
 
-    In Part 1, you'd need to track job completion status, build file lists manually, and handle partial failures. Here, the channel operators handle all of that. The `.collect()` naturally waits for all inputs, and `.mix()` combines outputs from different processes.
+    In Part 1, you'd need to track job completion status, build file lists manually, and handle partial failures. Here, the channel operators handle all of that. The `.collect()` naturally waits for all inputs, and `.mix()` combines outputs from different processes; an agent generating bash from scratch would have to reinvent each of these every time.
 
 ---
 
-### 2.6. Resume and Caching
+### 4.6. Resume and caching
 
-In Part 1, failure recovery was a pain point - if sample 47 failed, you had no record of what completed, and implementing checkpoint logic would take 40+ lines of state tracking.
+In Part 1, failure recovery was a pain point. If sample 47 failed, you had no record of what completed, and implementing checkpoint logic would take 40+ lines of state tracking.
 
 Run the Nextflow pipeline, then modify something and run with `-resume`:
 
 ```bash
-nextflow run main.nf -resume
+nextflow run main.nf -output-dir results -resume
 ```
 
 ```console title="Output"
@@ -1037,105 +1064,115 @@ nextflow run main.nf -resume
 [m3/n4o5p6] SALMON_QUANT       [100%] 3 of 3 ✔  <- Only this re-ran
 ```
 
-Nextflow automatically tracks what completed successfully. Failed tasks can be fixed and re-run without repeating successful work. **One flag** (`-resume`) replaces 40+ lines of bash checkpoint logic you'd have to write and debug.
+Nextflow automatically tracks what completed successfully. Failed tasks can be fixed and re-run without repeating successful work. One flag (`-resume`) replaces 40+ lines of bash checkpoint logic you'd have to write and debug, whether you wrote it or asked an agent to.
 
 ---
 
-### 2.7. Configuration Profiles
+### 4.7. Configuration profiles
 
 In Part 1, scaling to clusters required rewriting the entire script with SLURM job arrays and cluster-specific syntax. Your collaborator on PBS would need yet another version.
 
-With Nextflow, the `nextflow.config` file lets you run the **same workflow** anywhere:
+With Nextflow, the `nextflow.config` file lets you run the same workflow anywhere:
 
 ```bash
 # On your laptop
-nextflow run main.nf -profile standard
+nextflow run main.nf -output-dir results -profile docker
 
 # On SLURM cluster
-nextflow run main.nf -profile slurm
+nextflow run main.nf -output-dir results -profile slurm
 
-# On AWS
-nextflow run main.nf -profile aws
+# On AWS Batch
+nextflow run main.nf -output-dir results -profile awsbatch
 ```
 
 Same workflow code. Same scientific results. Different infrastructure. You write your analysis once, and configuration profiles adapt it to any environment.
 
 ---
 
-### 2.8. Part 2 Summary
+### 4.8. Takeaway
 
-Checking progress against the same standards:
+Checking progress against the same properties:
 
-- ✅ **Reproducibility** - Containers lock exact tool versions. Same results everywhere.
-- ✅ **Software management** - Each process gets its own isolated container. No conflicts, no manual setup.
-- ✅ **Scalability** - Same code for 3 or 3,000 samples. Manages resources on one machine, or distributes to cluster/cloud with a config change.
-- ✅ **Efficient parallelization** - Automatic from data flow declarations.
-- ✅ **Resource awareness** - Declarative `cpus` and `memory` per process.
-- ✅ **Failure recovery** - `-resume` flag. One word.
-- ✅ **Portability** - Same code, different `-profile`.
+- :white_check_mark: **Reproducibility**: Containers lock exact tool versions. Same results everywhere.
+- :white_check_mark: **Software management**: Each process gets its own isolated container. No conflicts, no manual setup.
+- :white_check_mark: **Scalability**: Same code for 3 or 3,000 samples. Manages resources on one machine, or distributes to cluster or cloud with a config change.
+- :white_check_mark: **Efficient parallelisation**: Automatic from data flow declarations.
+- :white_check_mark: **Resource awareness**: Declarative `cpus` and `memory` per process.
+- :white_check_mark: **Failure recovery**: `-resume`. One flag.
+- :white_check_mark: **Portability**: Same code, different `-profile`.
 
-Every quality we struggled with in Part 1 is built into Nextflow. You didn't write any infrastructure code - you just declared what each process needs and produces.
+Every property we struggled with in Part 1 is built into Nextflow. You didn't write any infrastructure code; you just declared what each process needs and produces.
 
-**The fundamental difference:** Scripts mix _what_ to compute with _how_ to compute it. Workflow managers separate these concerns - you declare the science, the framework handles the infrastructure.
+The fundamental difference: scripts mix _what_ to compute with _how_ to compute it. Workflow managers separate these concerns. You (or your agent) declare the science, the framework handles the infrastructure.
 
 ---
 
-## Quick Reference
+## 5. But what if the AI writes the Nextflow?
 
-### Nextflow Commands
+The other half of the question still stands. If an AI can write Nextflow for you, why do you still need to learn it?
 
-```bash
-# Run workflow
-nextflow run main.nf
+AI-assisted authoring of Nextflow is genuinely useful. Tools like [Seqera AI](https://seqera.io/ask-ai/) and the [`nf-core` Claude Code skills](https://nf-co.re/docs/tutorials/llm/claude_code) can scaffold processes, draft modules, and produce whole pipelines from a paragraph of intent. The case for using a workflow tool does not weaken when AI authors the code; it strengthens. Every line the AI writes lands inside a system that supplies the seven properties you saw in Part 2.
 
-# Resume from cached results
-nextflow run main.nf -resume
+What that means in practice: you still operate, debug, audit, scale, and lock with tests what the AI produced. Reading Nextflow, verifying container pins, validating cache behaviour, running tests; these are the durable skills. AI accelerates authoring; the workflow tool makes the operate-debug-maintain loop tractable. The [`nf-test` side quest](../nf_test/index.md) is the right next step for locking that contract.
 
-# Use specific profile
-nextflow run main.nf -profile slurm
-```
-
-### Process Template
-
-```groovy
-process TOOL_NAME {
-    tag "$id"
-    container 'quay.io/biocontainers/tool:version'
-    publishDir "${params.outdir}/tool", mode: 'copy'
-
-    input:
-    tuple val(id), path(reads)
-
-    output:
-    tuple val(id), path("*.out"), emit: results
-
-    script:
-    """
-    tool command ${reads}
-    """
-}
-```
+The answer to "why workflows when I have Claude" is "because Claude needs them too."
 
 ---
 
 ## Summary
 
-We started with a question: _Why learn a whole new framework when your script does the job?_
+You started with a question: _why learn a whole new framework when an AI agent can do my analysis or build my pipeline for me?_
 
-Building production-quality pipelines with scripts means writing significant infrastructure code - job scheduling, resource management, failure recovery, environment setup - that has nothing to do with your science. And you'd face the same challenges whether you wrote it in bash, Python, or any other language.
+You then built the same RNA-seq analysis twice. Once as a script of the kind an agent produces on demand, where every production-quality property you tried to add cost more infrastructure code than science. Once as a Nextflow workflow, where reproducibility, software tracking, scalability, parallelisation, resource awareness, failure recovery, and portability came from the workflow boundary itself.
 
-Workflow managers like Nextflow handle that infrastructure for you. You declare what each process needs and produces; the framework figures out the rest. The result is code that's almost entirely focused on your science, with production-quality features built in.
+The pipeline is the durable artefact. It captures the analysis in a way that survives the agent that ran it.
 
-There's also **standardization**. Workflow managers are established tools with communities, documentation, and shared best practices. When you join a new team or project using one, you're working with familiar concepts rather than deciphering someone's homegrown scripting solution. Skills transfer. You're not maintaining custom infrastructure - you're using battle-tested tools that thousands of others rely on.
+### Key patterns
 
-### What's Next?
+Pin every tool with a container, not a manual install:
 
-If you're convinced and want to learn Nextflow properly:
+```groovy
+container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'
+```
 
-- **[Hello Nextflow](../hello_nextflow/index.md)** - A thorough introduction to Nextflow concepts and syntax
-- **[Nextflow Documentation](https://www.nextflow.io/docs/latest/)** - Official reference documentation
+Capture outputs with the workflow output system, so the run produces a stable layout:
 
-If you want to explore more advanced topics:
+```groovy
+publish:
+fastqc_html = FASTQC.out.html
 
-- **[nf-core](https://nf-co.re/)** - Community-curated, production-ready pipelines you can use or learn from
-- **[Seqera Platform](https://seqera.io/platform/)** - Enterprise features for monitoring, launching, and managing workflows
+}
+
+output {
+    fastqc_html { path 'fastqc' }
+}
+```
+
+Pick the run's output root at the command line:
+
+```bash
+nextflow run main.nf -output-dir results
+```
+
+Resume after a failure with one flag:
+
+```bash
+nextflow run main.nf -output-dir results -resume
+```
+
+Move the same workflow between laptop, cluster, and cloud with a profile:
+
+```bash
+nextflow run main.nf -output-dir results -profile slurm
+```
+
+### Additional resources
+
+- [Hello Nextflow](../../hello_nextflow/index.md): the thorough introduction to Nextflow if you want to keep going.
+- [Testing with nf-test](../nf_test/index.md): lock the contract on what the AI generated.
+- [Nextflow documentation](https://www.nextflow.io/docs/latest/): reference for the workflow output system, profiles, and `nextflow log`.
+- [Seqera AI](https://seqera.io/ask-ai/) and the [`nf-core` Claude Code skills](https://nf-co.re/docs/tutorials/llm/claude_code): use AI to author Nextflow, then operate it with the skills you just built.
+
+### What's next?
+
+Return to the [menu of Side Quests](../index.md) or click the button in the bottom right of the page to move on to the next topic.

--- a/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
+++ b/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
@@ -2,13 +2,13 @@
 
 If an AI agent can run your analysis on demand, or write the code for you in seconds, why do you still need to learn a workflow tool?
 
-The agent will happily produce either a bash script or a Nextflow pipeline; the question is which artefact is worth keeping.
-A script is only as good as the engineering work the agent (or you) remembered to bake into it: software pinning, parallelism limits, resume logic, scale handling, provenance.
-A workflow is different.
-The same agent producing Nextflow gets reproducibility, software tracking, parallelisation, resume, and portability for free, because the workflow boundary makes them part of the artefact's structure rather than something extra to write.
+Bioinformatics has been through three eras of how analyses get expressed: commands typed into a terminal, scripts that captured those commands, and workflows that captured the scripts plus the engineering work needed to make them reproducible, portable, and maintainable. Each step was a better artefact for a team to live with, and each step happened because the previous form's limits started costing real time.
 
-This side quest answers the question by experience.
-You'll see the same RNA-seq analysis as a bash script (the kind an agent might hand you), find the engineering limits of that form, then see it as a Nextflow workflow (which the same agent could just as easily produce) and watch each limit disappear.
+We are in a fourth era now, where an agent will produce any of those forms in seconds. The agent will write bash, Python, Nextflow, all of it. So the question is not "should I bother learning Nextflow when the agent could write it for me?" The question is what artefact you want to live with after the agent is done; what gets vetted at code review, tested, updated when a tool releases a new version, extended when the lab adds a new sample type, read by the colleague who inherits it next quarter.
+
+A bash script can be that artefact, but it is the wrong shape for the job: every engineering property is buried inline, every change requires re-deriving correctness, and a maintainer six months from now has to reconstruct what the original author (human or otherwise) was thinking. A Nextflow workflow encodes the same logic in a form built for that maintenance role, with declarative containers and resources, explicit data flow, and the engineering properties supplied by the workflow boundary rather than by individual lines an author had to remember to write.
+
+This side quest answers the question by experience. You will see the same RNA-seq analysis as a bash script (the kind an agent might hand you), find the engineering limits of that form, then see it as a Nextflow workflow (which the same agent could just as easily produce) and watch each limit disappear. By the end you should have an artefact you would be willing to put your name on and maintain.
 
 !!! note "Why bash?"
 
@@ -48,11 +48,19 @@ These are the properties any agent producing bash has to remember to write, ever
 
 These aren't nice-to-haves; they're requirements for serious computational research.
 
-The question is how to achieve this in one pipeline.
+---
+
+## 2. The artefact those properties live in
+
+Whatever code achieves those properties, the code itself ends up somewhere: a script in your home directory, a Nextflow workflow in a repo, a chat session nobody saved. That somewhere is the artefact, and it has to outlive the conversation that produced it. It goes into version control. Someone reads it at code review. Someone tests it. When a tool ships a new version, when the lab adds a new sample type, when the pipeline starts producing slightly different numbers and you have to figure out why, you go back to the artefact.
+
+Two artefacts can do exactly the same analysis but be very different to live with. One can have its parallelism, software pinning, and resume logic written into individual lines that someone has to find and update by hand. Another can have those same properties supplied by the artefact's structure, visible at a glance to anyone who reads it. The second is what a workflow tool gives you. The first is what most ad-hoc analyses, whether human-written or agent-generated, end up as.
+
+The rest of this side quest builds the same RNA-seq analysis as both forms, so you can see the difference where it counts: in the artefact, not in the runtime.
 
 ---
 
-## 2. What you'll build
+## 3. What you'll build
 
 An RNA-seq analysis pipeline that runs:
 
@@ -71,27 +79,27 @@ By the end, you'll understand _why_ workflow managers exist, not from explanatio
 
 ---
 
-## 3. Building a bash pipeline
+## 4. Building a bash pipeline
 
 In this part, you'll build an RNA-seq analysis pipeline using bash, aiming for the production-quality properties listed above.
 We'll see how far we can get and where things get difficult.
 
 ---
 
-### 3.1. Setup
+### 4.1. Setup
 
-#### 3.1.1. The scenario
+#### 4.1.1. The scenario
 
 You're a bioinformatician analysing RNA-seq data from a yeast gene expression study.
 You have 3 samples today. Your PI mentions that 50 more samples are coming next week.
 
-#### 3.1.2. Navigate to the working directory
+#### 4.1.2. Navigate to the working directory
 
 ```bash
 cd side-quests/workflows_in_the_ai_era
 ```
 
-#### 3.1.3. Explore the starter files
+#### 4.1.3. Explore the starter files
 
 ```bash
 ls bash/
@@ -109,7 +117,7 @@ Three scripts, each with TODOs you'll fill in as you progress:
 
 You'll fill in these starter files as you progress through the tutorial.
 
-#### 3.1.4. Examine the sample data
+#### 4.1.4. Examine the sample data
 
 ```bash
 cat data/samples.csv
@@ -126,7 +134,7 @@ Each row is a sample with URLs to paired-end FASTQ files.
 
 ---
 
-### 3.2. Kick off the tool install
+### 4.2. Kick off the tool install
 
 Part 1 needs FastQC, fastp, and Salmon installed locally so the bash scripts can call them from `PATH`. Conda solves environments slowly, so kick off the install now and let it run in the background while you keep reading. We'll check on it before you actually need to run anything.
 
@@ -146,7 +154,7 @@ This typically takes about 3 minutes. While it runs, work through the next secti
 
 ---
 
-### 3.3. Building your first script
+### 4.3. Building your first script
 
 Open the starter file `bash/process_sample.sh`. It has the structure ready; you just need to add the tool commands.
 
@@ -186,7 +194,7 @@ mkdir -p data/fastq results/fastqc results/fastp results/salmon data/salmon_inde
 echo "Completed: $SAMPLE_ID"
 ```
 
-#### 3.3.1. Understanding the starter script
+#### 4.3.1. Understanding the starter script
 
 The script accepts three arguments: a sample ID and two URLs for paired-end FASTQ files. The `set -e` line means the script will stop immediately if any command fails.
 
@@ -199,7 +207,7 @@ The TODO comments mark where you'll add each analysis step:
 
 This is a typical RNA-seq preprocessing workflow. Fill in each step below.
 
-#### 3.3.2. Add the download step
+#### 4.3.2. Add the download step
 
 First, we need to download the FASTQ files from their URLs. We'll use `curl` with `-sL` (silent mode, follow redirects) to fetch each file and save it with a consistent naming pattern.
 
@@ -219,7 +227,7 @@ First, we need to download the FASTQ files from their URLs. We'll use `curl` wit
     # TODO: Add curl commands to download R1 and R2 files
     ```
 
-#### 3.3.3. Add FastQC
+#### 4.3.3. Add FastQC
 
 FastQC analyzes sequencing data and generates quality reports. We run it on both read files (`R1` and `R2`) and save the output to our results directory. The `-q` flag suppresses progress output.
 
@@ -240,7 +248,7 @@ FastQC analyzes sequencing data and generates quality reports. We run it on both
     # TODO: Add fastqc command
     ```
 
-#### 3.3.4. Add fastp
+#### 4.3.4. Add fastp
 
 fastp trims adapter sequences and filters out low-quality reads. It takes paired input files (`-i`, `-I`) and produces trimmed output files (`-o`, `-O`), plus JSON and HTML reports for quality metrics.
 
@@ -266,7 +274,7 @@ fastp trims adapter sequences and filters out low-quality reads. It takes paired
     # TODO: Add fastp command
     ```
 
-#### 3.3.5. Add the Salmon index download
+#### 4.3.5. Add the Salmon index download
 
 Salmon needs a pre-built index of the reference transcriptome. We'll download a pre-built index (to save time) only if it doesn't already exist. This avoids re-downloading for every sample.
 
@@ -294,7 +302,7 @@ Salmon needs a pre-built index of the reference transcriptome. We'll download a 
 
     This `if [ ! -d ... ]` check is a common pattern in scripts: "only do this if it hasn't been done already." While conceptually simple, it's fragile, because it detects whether the directory exists rather than whether the download actually succeeded or the files are valid. Workflow managers handle this more robustly by tracking actual task outputs rather than checking for file or directory existence.
 
-#### 3.3.6. Add Salmon quantification
+#### 4.3.6. Add Salmon quantification
 
 Salmon quantifies transcript expression by pseudo-aligning reads to the index. It takes the **trimmed** reads from fastp (not the raw reads) and outputs expression counts per transcript.
 
@@ -320,9 +328,9 @@ Salmon quantifies transcript expression by pseudo-aligning reads to the index. I
     # TODO: Add salmon quant command
     ```
 
-#### 3.3.7. Activate the env and verify it's ready
+#### 4.3.7. Activate the env and verify it's ready
 
-The conda install you started in section 3.2 should be done by now. Switch back to that terminal (or the same one if you ran the install in this shell) and activate the environment:
+The conda install you started in section 4.2 should be done by now. Switch back to that terminal (or the same one if you ran the install in this shell) and activate the environment:
 
 ```bash
 mamba activate rnaseq-bash
@@ -342,7 +350,7 @@ salmon --version
 
 If any of those errors out, give the install another minute and try again. Once all three respond with versions, you are ready to run the script.
 
-#### 3.3.8. Test your script
+#### 4.3.8. Test your script
 
 Make it executable and run on one sample:
 
@@ -361,13 +369,13 @@ ls results/
 
 This works for one sample, but you have 3 samples and 50 more coming. Running this command manually for each one isn't practical.
 
-#### 3.3.9. Takeaway
+#### 4.3.9. Takeaway
 
 You now have a runnable script. There is no record of which conda environment solved for which tool versions, no resume on failure, no way to scale up without rewriting the loop, no provenance trace beyond your shell history. A bash script is what an agent might hand you for a quick analysis; everything past "it ran once on my laptop" is something the agent has to remember to write separately, and probably won't get right. Asking the same agent for a workflow instead is what fixes that, as Part 2 will show.
 
 ---
 
-### 3.4. Processing multiple samples
+### 4.4. Processing multiple samples
 
 Now that we can process one sample, we need to handle all samples from our CSV file. Open `bash/pipeline_sequential.sh`; it already has the loop structure that reads the CSV and iterates over each sample.
 
@@ -379,7 +387,7 @@ The starter script handles:
 
 Your task is to add the actual processing commands inside the loop, the same steps you just wrote, but using the loop variables (`$sample_id`, `$fastq_r1`, `$fastq_r2`) instead of the script arguments.
 
-#### 3.4.1. Add processing logic to the loop
+#### 4.4.1. Add processing logic to the loop
 
 === "After"
 
@@ -430,7 +438,7 @@ Your task is to add the actual processing commands inside the loop, the same ste
     done
     ```
 
-#### 3.4.2. Run and time it
+#### 4.4.2. Run and time it
 
 ```bash
 chmod +x bash/pipeline_sequential.sh
@@ -449,7 +457,7 @@ Processing: WT_REP1
 Processing: WT_REP2      <- Starts only after WT_REP1 is completely done
 ```
 
-#### 3.4.3. The problem: sequential execution
+#### 4.4.3. The problem: sequential execution
 
 ```
 Timeline (sequential):
@@ -461,7 +469,7 @@ These samples are completely independent. WT_REP2's analysis doesn't depend on W
 
 ---
 
-### 3.5. Adding parallelisation
+### 4.5. Adding parallelisation
 
 The sequential script works, but it's slow; each sample waits for the previous one to finish completely. Since samples are independent, they could run simultaneously.
 
@@ -472,7 +480,7 @@ Your task is to make the loop run samples in parallel by:
 1. Adding `&` after each function call to run it in the background
 2. Adding `wait` after the loop to pause until all background jobs complete
 
-#### 3.5.1. Add background execution
+#### 4.5.1. Add background execution
 
 === "After"
 
@@ -504,7 +512,7 @@ The key changes:
 - `&` at the end of the function call runs it in the background.
 - `wait` pauses until all background jobs complete.
 
-#### 3.5.2. Run and compare
+#### 4.5.2. Run and compare
 
 ```bash
 chmod +x bash/pipeline_parallel.sh
@@ -524,7 +532,7 @@ Notice the interleaved output, all samples running at once:
 
 Faster, because all samples run concurrently.
 
-#### 3.5.3. The hidden problem
+#### 4.5.3. The hidden problem
 
 What happens with 50 samples, or 500?
 
@@ -538,11 +546,11 @@ Your machine would crash from memory exhaustion. Bash's `&` has no concept of re
 
 ---
 
-### 3.6. Adding aggregation
+### 4.6. Adding aggregation
 
 Real pipelines need a final aggregation step that collects QC metrics from all samples into a summary report. MultiQC does this, but integrating it with parallel bash processing is tricky.
 
-#### 3.6.1. The problem
+#### 4.6.1. The problem
 
 Your parallel script launches all samples with `&` and waits for completion with `wait`. But `wait` only tells you when jobs finish, not which ones succeeded. To run MultiQC, you need to:
 
@@ -550,7 +558,7 @@ Your parallel script launches all samples with `&` and waits for completion with
 2. Collect the right output files from each tool
 3. Handle partial failures gracefully
 
-#### 3.6.2. A simple (fragile) approach
+#### 4.6.2. A simple (fragile) approach
 
 Add MultiQC after the `wait`:
 
@@ -564,7 +572,7 @@ multiqc results/fastqc results/fastp results/salmon -o results/multiqc
 
 This works if everything succeeds, but breaks silently on partial failures: MultiQC runs on whatever files exist, potentially giving you an incomplete report without warning.
 
-#### 3.6.3. A robust approach (more code)
+#### 4.6.3. A robust approach (more code)
 
 Proper aggregation requires tracking job status:
 
@@ -600,11 +608,11 @@ That's another 20+ lines of infrastructure code for something that should be sim
 
 ---
 
-### 3.7. The pain points
+### 4.7. The pain points
 
 We won't implement these, but consider what you'd need for a production-ready pipeline:
 
-#### 3.7.1. Failure recovery
+#### 4.7.1. Failure recovery
 
 If Salmon fails on sample 47 of 50, what happens?
 
@@ -613,7 +621,7 @@ If Salmon fails on sample 47 of 50, what happens?
 - To resume, you'd need to manually figure out what finished and what didn't.
 - Implementing proper checkpoint logic would add 40+ lines of file-based state tracking.
 
-#### 3.7.2. Reproducibility
+#### 4.7.2. Reproducibility
 
 When your colleague tries to run your script:
 
@@ -625,7 +633,7 @@ They need to replicate your exact conda environment, same tool versions, same de
 
 Or worse, they have salmon 1.4.0 but you used 1.10.3. The script runs fine, but results differ silently. Months later, you can't reproduce your own analysis because conda updated something.
 
-#### 3.7.3. Scaling to cluster
+#### 4.7.3. Scaling to cluster
 
 Your laptop worked fine for 3 samples. For 500 samples, you need the SLURM cluster:
 
@@ -638,7 +646,7 @@ Now you're rewriting the entire script with job arrays, dependency tracking, and
 
 ---
 
-### 3.8. Takeaway
+### 4.8. Takeaway
 
 Checking progress against the production-quality properties:
 
@@ -656,7 +664,7 @@ The fundamental problem: scripts mix _what_ to compute with _how_ to compute it.
 
 ---
 
-## 4. Building a Nextflow pipeline
+## 5. Building a Nextflow pipeline
 
 Now you'll rebuild the same pipeline using Nextflow.
 At each step, we'll contrast with the scripting approach from Part 1.
@@ -667,11 +675,11 @@ At each step, we'll contrast with the scripting approach from Part 1.
 
 ---
 
-### 4.1. What is Nextflow?
+### 5.1. What is Nextflow?
 
 Nextflow is a workflow manager. Instead of writing imperative scripts that say "do this, then do that," you _declare_ what processes exist and how data flows between them. Nextflow handles everything else: the parallelisation, scheduling, error handling, and resource management you'd otherwise write yourself.
 
-#### 4.1.1. Key concepts
+#### 5.1.1. Key concepts
 
 | Concept    | What it is                                         | Bash equivalent                      |
 | ---------- | -------------------------------------------------- | ------------------------------------ |
@@ -681,7 +689,7 @@ Nextflow is a workflow manager. Instead of writing imperative scripts that say "
 
 The key difference: in bash, you explicitly manage data flow with variables and file paths. In Nextflow, you declare what each process needs, and Nextflow figures out the execution order automatically.
 
-#### 4.1.2. Software management
+#### 5.1.2. Software management
 
 In Part 1, you installed FastQC, fastp, and Salmon with conda, hoping dependencies wouldn't conflict and documenting versions manually.
 
@@ -689,7 +697,7 @@ With Nextflow, each process declares its own software requirements. The tools ar
 
 ---
 
-### 4.2. Your first process: FastQC
+### 5.2. Your first process: FastQC
 
 In bash, you wrote FastQC commands inside loops, managed file paths with variables, and handled parallelisation with `&`. In Nextflow, each tool runs inside a `process`, a self-contained unit that declares its inputs, outputs, and command. You don't write loops; Nextflow runs the process once per input item automatically.
 
@@ -714,7 +722,7 @@ process FASTQC {
 }
 ```
 
-#### 4.2.1. Understanding the process
+#### 5.2.1. Understanding the process
 
 Each part has a purpose:
 
@@ -730,7 +738,7 @@ You're not writing any loop logic, file existence checks, or error handling.
 
     The one line `container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'` handles all software dependencies. The version is locked forever. Your colleague, your cluster, and your cloud all get the exact same FastQC, whether the agent generated this process for you or you wrote it by hand.
 
-#### 4.2.2. Call FASTQC in main.nf
+#### 5.2.2. Call FASTQC in main.nf
 
 Open `nextflow/main.nf` and add the FASTQC call:
 
@@ -746,7 +754,7 @@ Open `nextflow/main.nf` and add the FASTQC call:
     // TODO: Call FASTQC with ch_samples
     ```
 
-#### 4.2.3. Test it
+#### 5.2.3. Test it
 
 ```bash
 cd nextflow
@@ -764,13 +772,13 @@ All 3 samples ran in parallel automatically. In Part 1, you wrote `&` and `wait`
 
 ---
 
-### 4.3. Adding fastp
+### 5.3. Adding fastp
 
 Now add fastp following the same pattern. The key difference: fastp's output (trimmed reads) needs to flow to Salmon. In bash, you managed this with file paths like `results/fastp/${sample_id}_trimmed_R1.fastq.gz`. In Nextflow, you declare the output and let channels handle the data flow.
 
 Open `nextflow/modules/fastp.nf` and fill in the input, output, and script blocks.
 
-#### 4.3.1. Complete fastp.nf
+#### 5.3.1. Complete fastp.nf
 
 Pay attention to the `emit: reads` on the trimmed reads output. This names the output channel so Salmon can consume it.
 
@@ -825,7 +833,7 @@ Pay attention to the `emit: reads` on the trimmed reads output. This names the o
 
 The key line is `emit: reads` on the trimmed read files output. This creates a named output channel that Salmon will consume. When you later write `FASTP.out.reads`, you're accessing this specific output.
 
-#### 4.3.2. Call FASTP in main.nf
+#### 5.3.2. Call FASTP in main.nf
 
 Now connect FASTP to the sample channel in the workflow:
 
@@ -847,7 +855,7 @@ Now connect FASTP to the sample channel in the workflow:
 
 ---
 
-### 4.4. Connecting to Salmon
+### 5.4. Connecting to Salmon
 
 This is where Nextflow's data flow model pays off. In bash, you manually coordinated file paths; Salmon needed to know where fastp wrote its output. In Nextflow, you declare that Salmon needs fastp's output, and the framework handles the rest.
 
@@ -858,7 +866,7 @@ Salmon needs two inputs:
 
 This is a common pattern: per-sample data combined with a shared reference. In bash, you'd check if the index exists with `if [ ! -d ... ]`. In Nextflow, the channel system handles this automatically.
 
-#### 4.4.1. Complete salmon.nf
+#### 5.4.1. Complete salmon.nf
 
 The UNTAR process (which extracts the pre-built Salmon index) is already complete. Your task is to fill in SALMON_QUANT, which has two input declarations:
 
@@ -920,7 +928,7 @@ Notice two things in the script:
 - `${task.cpus}`: Nextflow makes declared resources available as variables. In bash, you hardcoded `--threads 2`. Here, you declare resources once (`cpus 4`) and reference them in the script. Change the declaration, and the script adapts automatically.
 - Two inputs: the process receives the trimmed reads tuple and the index path separately. In bash, you coordinated these with file paths. Here, the data flow is explicit.
 
-#### 4.4.2. Wire it up in main.nf
+#### 5.4.2. Wire it up in main.nf
 
 Now connect the processes. SALMON_QUANT needs two arguments. Then add `publish:` and `output {}` blocks so each tool's results land in a predictable layout.
 
@@ -970,7 +978,7 @@ Two things to notice:
 
 The `publish:` block names the channels you want kept; the top-level `output {}` block tells Nextflow what subdirectory to put each one in. The actual root directory comes from `-output-dir` on the command line.
 
-#### 4.4.3. Run and watch
+#### 5.4.3. Run and watch
 
 Run the complete pipeline:
 
@@ -990,7 +998,7 @@ Watch what happens. Nextflow automatically determines the execution order from t
 
 ---
 
-### 4.5. Aggregation with MultiQC
+### 5.5. Aggregation with MultiQC
 
 Real pipelines don't just run processes per sample; they often need to aggregate results across all samples. MultiQC collects QC metrics from FastQC, fastp, Salmon, and other tools into a single summary report.
 
@@ -1044,7 +1052,7 @@ The `.collect()` operator waits for all upstream processes to complete, then pas
 
 ---
 
-### 4.6. Resume and caching
+### 5.6. Resume and caching
 
 In Part 1, failure recovery was a pain point. If sample 47 failed, you had no record of what completed, and implementing checkpoint logic would take 40+ lines of state tracking.
 
@@ -1065,7 +1073,7 @@ Nextflow automatically tracks what completed successfully. Failed tasks can be f
 
 ---
 
-### 4.7. Configuration profiles
+### 5.7. Configuration profiles
 
 In Part 1, scaling to clusters required rewriting the entire script with SLURM job arrays and cluster-specific syntax. Your collaborator on PBS would need yet another version.
 
@@ -1086,7 +1094,7 @@ Same workflow code. Same scientific results. Different infrastructure. You write
 
 ---
 
-### 4.8. Takeaway
+### 5.8. Takeaway
 
 Checking progress against the same properties:
 
@@ -1104,17 +1112,17 @@ The fundamental difference: scripts mix _what_ to compute with _how_ to compute 
 
 ---
 
-## 5. Why this matters more, not less, when AI is writing the code
+## 6. Why workflows still matter when AI does the writing
 
-The bash and Nextflow versions you just compared could both have been generated by the same agent from the same paragraph of intent. The difference between them is not who wrote them, it is what abstraction the agent had to write into.
+Look back at the four eras the introduction named. Commands gave way to scripts, and scripts gave way to workflows, because each step was a better artefact for a team to live with: easier to vet, easier to validate, easier to maintain when tools changed and labs grew. The workflow form did not appear because writing scripts was hard. It appeared because keeping scripts around was.
 
-When the agent writes bash, it has to remember to add: container pins, parallelism with throttling, resume logic, structured outputs, a SLURM-friendly fallback, a way to reproduce the conda solve six months from now. It might do some of that. It will not do all of it. Each property it forgets is a silent failure that surfaces on file four, on a different laptop, six months later.
+We are in the fourth era now. An agent producing bash and the same agent producing Nextflow take roughly the same number of seconds. The bottleneck has moved. It is no longer how long it takes to write code; it is how long it takes a team to verify, ship, and maintain what was written. The artefact's role has not changed.
 
-When the agent writes Nextflow, those properties come from the workflow boundary regardless of how careful the agent was. The case for the workflow tool gets stronger, not weaker, the more code the agent writes, because the agent's mistakes have somewhere safe to land.
+The case for the workflow tool gets stronger, not weaker, the more code AI is producing. Volumes of generated code that nobody can read or vet are a liability. A workflow puts the engineering structure where humans can see it: container pins as one-line declarations, parallelism as data flow, resume as a property of the cache rather than a property the author remembered to write. That is what makes review tractable, tests writable, and maintenance possible. AI accelerates the authoring; the workflow tool makes the operate-debug-maintain loop tractable.
 
-You still read what the agent produced. You still verify container pins, validate cache behaviour, lock the contract with tests; these are the durable skills. AI accelerates the authoring. The workflow tool makes the operate-debug-maintain loop tractable. Tools like [Seqera AI](https://seqera.io/ask-ai/) and the [`nf-core` Claude Code skills](https://nf-co.re/docs/tutorials/llm/claude_code) help with the authoring; the [`nf-test` side quest](../nf_test/index.md) is the right next step for locking what got authored.
+You still read what the AI produced. You still verify container pins, validate cache behaviour, lock the contract with tests; these are the durable skills. The [`nf-test` side quest](../nf_test/index.md) is the right next step for locking what got authored.
 
-The answer to "why workflows when I have Claude" is "because Claude needs them too."
+The answer to "why workflows when AI can write the code for me" is that the artefact has to outlive the conversation that made it.
 
 ---
 
@@ -1122,9 +1130,11 @@ The answer to "why workflows when I have Claude" is "because Claude needs them t
 
 You started with a question: _why learn a whole new framework when an AI agent can do my analysis or build my pipeline for me?_
 
-You then built the same RNA-seq analysis twice. Once as a bash script of the kind an agent might produce on demand, where every production-quality property cost extra infrastructure code that the agent had to remember to write. Once as a Nextflow workflow (which the same agent could just as easily produce), where reproducibility, software tracking, scalability, parallelisation, resource awareness, failure recovery, and portability came from the workflow boundary itself.
+You then built the same RNA-seq analysis twice. Once as a bash script of the kind an agent might produce on demand, where every production-quality property cost extra infrastructure code that someone, human or otherwise, had to remember to write. Once as a Nextflow workflow (which the same agent could just as easily produce), where reproducibility, software tracking, scalability, parallelisation, resource awareness, failure recovery, and portability came from the workflow boundary itself.
 
-The pipeline is the durable artefact. The agent will write either form for you on demand. The form that makes the agent's output trustworthy is the one with a workflow boundary baked in.
+The pipeline is the durable artefact. The agent will write either form for you on demand. The form that makes the result trustworthy across time and across team members is the one shaped for the maintenance role: vetted at code review, validated by tests, updated when tools change, read by the next person who has to live with it.
+
+The artefact has to outlive the conversation that made it.
 
 ### Key patterns
 
@@ -1168,9 +1178,10 @@ nextflow run main.nf -output-dir results -profile slurm
 ### Additional resources
 
 - [Hello Nextflow](../../hello_nextflow/index.md): the thorough introduction to Nextflow if you want to keep going.
-- [Testing with nf-test](../nf_test/index.md): lock the contract on what the AI generated.
+- [Testing with nf-test](../nf_test/index.md): lock the contract on the artefact, whoever or whatever wrote it.
 - [Nextflow documentation](https://www.nextflow.io/docs/latest/): reference for the workflow output system, profiles, and `nextflow log`.
-- [Seqera AI](https://seqera.io/ask-ai/) and the [`nf-core` Claude Code skills](https://nf-co.re/docs/tutorials/llm/claude_code): use AI to author Nextflow, then operate it with the skills you just built.
+- [nf-core](https://nf-co.re/): community-maintained, production-grade pipelines that already use the patterns you saw here.
+- [Seqera AI](https://seqera.io/ask-ai/): an AI assistant trained on Nextflow and nf-core resources for help drafting and debugging workflows.
 
 ### What's next?
 

--- a/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
+++ b/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
@@ -452,7 +452,7 @@ Processing: WT_REP1
 Processing: WT_REP2      <- Starts only after WT_REP1 is completely done
 ```
 
-#### 3.4.3. Takeaway
+#### 3.4.3. The problem: sequential execution
 
 ```
 Timeline (sequential):
@@ -527,7 +527,7 @@ Notice the interleaved output, all samples running at once:
 
 Faster, because all samples run concurrently.
 
-#### 3.5.3. Takeaway
+#### 3.5.3. The hidden problem
 
 What happens with 50 samples, or 500?
 
@@ -779,7 +779,7 @@ Pay attention to the `emit: reads` on the trimmed reads output. This names the o
 
 === "After"
 
-    ```groovy title="nextflow/modules/fastp.nf" hl_lines="5 8-10 13-21"
+    ```groovy title="nextflow/modules/fastp.nf" hl_lines="6 9-11 15-21"
     process FASTP {
         tag "$id"
         container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
@@ -867,7 +867,7 @@ The UNTAR process (which extracts the pre-built Salmon index) is already complet
 
 === "After"
 
-    ```groovy title="nextflow/modules/salmon.nf" linenums="17" hl_lines="8-9 12 16-22"
+    ```groovy title="nextflow/modules/salmon.nf" linenums="17" hl_lines="9-10 13 17-23"
     process SALMON_QUANT {
         tag "$id"
         container 'quay.io/biocontainers/salmon:1.10.3--h6dccd9a_2'
@@ -929,7 +929,7 @@ Now connect the processes. SALMON_QUANT needs two arguments. Then add `publish:`
 
 === "After"
 
-    ```groovy title="nextflow/main.nf" linenums="30" hl_lines="1 4-10 13-30"
+    ```groovy title="nextflow/main.nf" linenums="30" hl_lines="1 3-9 12-18"
     SALMON_QUANT(FASTP.out.reads, UNTAR.out.index.first())
 
     publish:

--- a/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
+++ b/docs/en/docs/side_quests/workflows_in_the_ai_era/index.md
@@ -737,7 +737,7 @@ Pay attention to the `emit: reads` on the trimmed reads output. This names the o
 
 === "After"
 
-    ```groovy title="nextflow/modules/fastp.nf" hl_lines="6 9-11 15-21"
+    ```groovy title="nextflow/modules/fastp.nf" hl_lines="6 9-11 15-22"
     process FASTP {
         tag "$id"
         container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
@@ -977,7 +977,7 @@ process MULTIQC {
 
     script:
     """
-    multiqc . --filename multiqc_report
+    multiqc .
     """
 }
 ```
@@ -987,9 +987,9 @@ Then wire it up to collect outputs from all processes:
 ```groovy title="nextflow/main.nf"
 // Collect all QC outputs for MultiQC
 ch_multiqc = FASTQC.out.zip
-    .map { id, files -> files }
-    .mix(FASTP.out.json.map { id, files -> files })
-    .mix(SALMON_QUANT.out.results.map { id, files -> files })
+    .map { _id, files -> files }
+    .mix(FASTP.out.json.map { _id, files -> files })
+    .mix(SALMON_QUANT.out.results.map { _id, files -> files })
     .collect()
 
 MULTIQC(ch_multiqc)
@@ -1082,8 +1082,6 @@ You started with a question: _why learn a whole new framework when an AI agent c
 You then built the same RNA-seq analysis twice. Once as a bash script of the kind an agent might produce on demand, where every production-quality property cost extra infrastructure code that someone, human or otherwise, had to remember to write. Once as a Nextflow workflow (which the same agent could just as easily produce), where reproducibility, software tracking, scalability, parallelisation, resource awareness, failure recovery, and portability came from the workflow boundary itself.
 
 The pipeline is the durable artefact. The agent will write either form for you on demand. The form that makes the result trustworthy across time and across team members is the one shaped for the maintenance role: vetted at code review, validated by tests, updated when tools change, read by the next person who has to live with it.
-
-The artefact has to outlive the conversation that made it.
 
 ### Key patterns
 

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - side_quests/index.md
       - side_quests/orientation.md
       - side_quests/dev_environment/index.md
+      - side_quests/workflows_in_the_ai_era/index.md
       - side_quests/essential_scripting_patterns/index.md
       - side_quests/working_with_files/index.md
       - side_quests/metadata/index.md

--- a/side-quests/solutions/workflows_in_the_ai_era/bash/pipeline_parallel.sh
+++ b/side-quests/solutions/workflows_in_the_ai_era/bash/pipeline_parallel.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# pipeline_parallel.sh - Process all RNA-seq samples in parallel
+#
+# This is the parallelized script that learners build in Section 1.4.
+# It uses & to background jobs and wait to synchronize.
+#
+# Usage: ./pipeline_parallel.sh <samples.csv>
+#
+# WARNING: This script launches ALL samples simultaneously!
+# With many samples, this could exhaust memory or overwhelm the system.
+# A production script would need job limiting - see the discussion in the tutorial.
+
+set -e
+
+SAMPLES_FILE=${1:-data/samples.csv}
+
+if [ ! -f "$SAMPLES_FILE" ]; then
+    echo "Error: Samples file not found: $SAMPLES_FILE"
+    exit 1
+fi
+
+echo "=========================================="
+echo "RNA-seq Pipeline (Parallel)"
+echo "=========================================="
+echo ""
+
+# Create output directories
+mkdir -p data/fastq results/fastqc results/fastp results/salmon data/salmon_index
+
+# Download salmon index once (shared by all samples)
+if [ ! -d "data/salmon_index/salmon" ]; then
+    echo "Downloading salmon index..."
+    curl -sL https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz \
+        -o data/salmon_index/salmon.tar.gz
+    tar -xzf data/salmon_index/salmon.tar.gz -C data/salmon_index/
+    rm data/salmon_index/salmon.tar.gz
+    echo ""
+fi
+
+# Function to process a single sample
+process_sample() {
+    local sample_id=$1
+    local fastq_r1=$2
+    local fastq_r2=$3
+
+    echo "[${sample_id}] Starting..."
+
+    # Download FASTQ files
+    if [ ! -f "data/fastq/${sample_id}_R1.fastq.gz" ]; then
+        curl -sL "$fastq_r1" -o "data/fastq/${sample_id}_R1.fastq.gz"
+    fi
+    if [ ! -f "data/fastq/${sample_id}_R2.fastq.gz" ]; then
+        curl -sL "$fastq_r2" -o "data/fastq/${sample_id}_R2.fastq.gz"
+    fi
+
+    # FastQC
+    fastqc -q -o results/fastqc \
+        "data/fastq/${sample_id}_R1.fastq.gz" \
+        "data/fastq/${sample_id}_R2.fastq.gz"
+
+    # fastp
+    fastp \
+        -i "data/fastq/${sample_id}_R1.fastq.gz" \
+        -I "data/fastq/${sample_id}_R2.fastq.gz" \
+        -o "results/fastp/${sample_id}_trimmed_R1.fastq.gz" \
+        -O "results/fastp/${sample_id}_trimmed_R2.fastq.gz" \
+        -j "results/fastp/${sample_id}.fastp.json" \
+        -h "results/fastp/${sample_id}.fastp.html" \
+        2>/dev/null
+
+    # Salmon
+    salmon quant \
+        --index data/salmon_index/salmon \
+        --libType A \
+        --mates1 "results/fastp/${sample_id}_trimmed_R1.fastq.gz" \
+        --mates2 "results/fastp/${sample_id}_trimmed_R2.fastq.gz" \
+        --output "results/salmon/${sample_id}" \
+        --threads 2 \
+        --quiet
+
+    echo "[${sample_id}] Complete!"
+}
+
+# Export function so subshells can use it
+export -f process_sample
+
+START_TIME=$(date +%s)
+
+# Launch all samples in parallel using & (backgrounding)
+echo "Launching samples in parallel..."
+PIDS=()
+
+while IFS=',' read -r sample_id fastq_r1 fastq_r2; do
+    process_sample "$sample_id" "$fastq_r1" "$fastq_r2" &
+    PIDS+=($!)
+done < <(tail -n +2 "$SAMPLES_FILE")
+
+# Wait for all background jobs to complete
+wait
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+# Run MultiQC to aggregate reports
+echo ""
+echo "Running MultiQC..."
+multiqc results/ -o results/ --quiet --force
+echo ""
+
+echo "=========================================="
+echo "Pipeline complete!"
+echo "Total time: ${DURATION}s"
+echo "=========================================="
+echo ""
+echo "All samples ran in parallel - notice the speedup!"
+echo ""
+echo "BUT... what if you had 50 samples? Or 500?"
+echo "They would ALL start at once, potentially:"
+echo "  - Exhausting memory (each Salmon uses ~4GB)"
+echo "  - Overwhelming disk I/O"
+echo "  - Crashing your system"
+echo ""
+echo "To fix this, you'd need to add job limiting logic..."
+echo "...which is exactly what workflow managers do automatically."

--- a/side-quests/solutions/workflows_in_the_ai_era/bash/pipeline_sequential.sh
+++ b/side-quests/solutions/workflows_in_the_ai_era/bash/pipeline_sequential.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# pipeline_sequential.sh - Process all RNA-seq samples sequentially
+#
+# This is the loop-based script that learners build in Section 1.3.
+# It processes each sample one-by-one, waiting for each to complete.
+#
+# Usage: ./pipeline_sequential.sh <samples.csv>
+
+set -e
+
+SAMPLES_FILE=${1:-data/samples.csv}
+
+if [ ! -f "$SAMPLES_FILE" ]; then
+    echo "Error: Samples file not found: $SAMPLES_FILE"
+    exit 1
+fi
+
+echo "=========================================="
+echo "RNA-seq Pipeline (Sequential)"
+echo "=========================================="
+echo ""
+
+# Create output directories
+mkdir -p data/fastq results/fastqc results/fastp results/salmon data/salmon_index
+
+# Download salmon index once (shared by all samples)
+if [ ! -d "data/salmon_index/salmon" ]; then
+    echo "Downloading salmon index..."
+    curl -sL https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz \
+        -o data/salmon_index/salmon.tar.gz
+    tar -xzf data/salmon_index/salmon.tar.gz -C data/salmon_index/
+    rm data/salmon_index/salmon.tar.gz
+    echo ""
+fi
+
+# Read samples from CSV (skip header)
+START_TIME=$(date +%s)
+
+tail -n +2 "$SAMPLES_FILE" | while IFS=',' read -r sample_id fastq_r1 fastq_r2; do
+    echo "Processing: $sample_id"
+
+    # Download FASTQ files
+    echo "  Downloading FASTQ files..."
+    if [ ! -f "data/fastq/${sample_id}_R1.fastq.gz" ]; then
+        curl -sL "$fastq_r1" -o "data/fastq/${sample_id}_R1.fastq.gz"
+    fi
+    if [ ! -f "data/fastq/${sample_id}_R2.fastq.gz" ]; then
+        curl -sL "$fastq_r2" -o "data/fastq/${sample_id}_R2.fastq.gz"
+    fi
+
+    # FastQC
+    echo "  Running FastQC..."
+    fastqc -q -o results/fastqc \
+        "data/fastq/${sample_id}_R1.fastq.gz" \
+        "data/fastq/${sample_id}_R2.fastq.gz"
+
+    # fastp
+    echo "  Running fastp..."
+    fastp \
+        -i "data/fastq/${sample_id}_R1.fastq.gz" \
+        -I "data/fastq/${sample_id}_R2.fastq.gz" \
+        -o "results/fastp/${sample_id}_trimmed_R1.fastq.gz" \
+        -O "results/fastp/${sample_id}_trimmed_R2.fastq.gz" \
+        -j "results/fastp/${sample_id}.fastp.json" \
+        -h "results/fastp/${sample_id}.fastp.html" \
+        2>/dev/null
+
+    # Salmon
+    echo "  Running Salmon..."
+    salmon quant \
+        --index data/salmon_index/salmon \
+        --libType A \
+        --mates1 "results/fastp/${sample_id}_trimmed_R1.fastq.gz" \
+        --mates2 "results/fastp/${sample_id}_trimmed_R2.fastq.gz" \
+        --output "results/salmon/${sample_id}" \
+        --threads 2 \
+        --quiet
+
+    echo "  Done: $sample_id"
+    echo ""
+done
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+# Run MultiQC to aggregate reports
+echo "Running MultiQC..."
+multiqc results/ -o results/ --quiet --force
+echo ""
+
+echo "=========================================="
+echo "Pipeline complete!"
+echo "Total time: ${DURATION}s"
+echo "=========================================="
+echo ""
+echo "Notice how each sample waited for the previous one to finish."
+echo "Your CPUs were mostly idle during this time."

--- a/side-quests/solutions/workflows_in_the_ai_era/bash/process_sample.sh
+++ b/side-quests/solutions/workflows_in_the_ai_era/bash/process_sample.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# process_sample.sh - Process a single RNA-seq sample
+#
+# This is the foundation script that learners build in Section 1.2.
+# It runs the complete analysis pipeline for ONE sample.
+#
+# Usage: ./process_sample.sh <sample_id> <fastq_r1_url> <fastq_r2_url>
+
+set -e
+
+# Check arguments
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 <sample_id> <fastq_r1_url> <fastq_r2_url>"
+    echo "Example: $0 WT_REP1 https://...R1.fastq.gz https://...R2.fastq.gz"
+    exit 1
+fi
+
+SAMPLE_ID=$1
+FASTQ_R1_URL=$2
+FASTQ_R2_URL=$3
+
+echo "Processing sample: $SAMPLE_ID"
+
+# Create output directories
+mkdir -p data/fastq
+mkdir -p results/fastqc
+mkdir -p results/fastp
+mkdir -p results/salmon
+
+# Step 1: Download FASTQ files (if not already present)
+echo "  Downloading FASTQ files..."
+if [ ! -f "data/fastq/${SAMPLE_ID}_R1.fastq.gz" ]; then
+    curl -sL "$FASTQ_R1_URL" -o "data/fastq/${SAMPLE_ID}_R1.fastq.gz"
+fi
+if [ ! -f "data/fastq/${SAMPLE_ID}_R2.fastq.gz" ]; then
+    curl -sL "$FASTQ_R2_URL" -o "data/fastq/${SAMPLE_ID}_R2.fastq.gz"
+fi
+
+# Step 2: Run FastQC (quality control)
+echo "  Running FastQC..."
+fastqc -q -o results/fastqc \
+    "data/fastq/${SAMPLE_ID}_R1.fastq.gz" \
+    "data/fastq/${SAMPLE_ID}_R2.fastq.gz"
+
+# Step 3: Run fastp (adapter trimming)
+echo "  Running fastp..."
+fastp \
+    -i "data/fastq/${SAMPLE_ID}_R1.fastq.gz" \
+    -I "data/fastq/${SAMPLE_ID}_R2.fastq.gz" \
+    -o "results/fastp/${SAMPLE_ID}_trimmed_R1.fastq.gz" \
+    -O "results/fastp/${SAMPLE_ID}_trimmed_R2.fastq.gz" \
+    -j "results/fastp/${SAMPLE_ID}.fastp.json" \
+    -h "results/fastp/${SAMPLE_ID}.fastp.html" \
+    2>/dev/null
+
+# Step 4: Download salmon index (if not present)
+if [ ! -d "data/salmon_index/salmon" ]; then
+    echo "  Downloading salmon index..."
+    mkdir -p data/salmon_index
+    curl -sL https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz \
+        -o data/salmon_index/salmon.tar.gz
+    tar -xzf data/salmon_index/salmon.tar.gz -C data/salmon_index/
+    rm data/salmon_index/salmon.tar.gz
+fi
+
+# Step 5: Run Salmon (transcript quantification)
+echo "  Running Salmon..."
+salmon quant \
+    --index data/salmon_index/salmon \
+    --libType A \
+    --mates1 "results/fastp/${SAMPLE_ID}_trimmed_R1.fastq.gz" \
+    --mates2 "results/fastp/${SAMPLE_ID}_trimmed_R2.fastq.gz" \
+    --output "results/salmon/${SAMPLE_ID}" \
+    --threads 2 \
+    --quiet
+
+echo "Completed: $SAMPLE_ID"

--- a/side-quests/solutions/workflows_in_the_ai_era/data/samples.csv
+++ b/side-quests/solutions/workflows_in_the_ai_era/data/samples.csv
@@ -1,0 +1,4 @@
+sample,fastq_1,fastq_2
+WT_REP1,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357070_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357070_2.fastq.gz
+WT_REP2,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357072_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357072_2.fastq.gz
+RAP1_IAA_30M_REP1,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357076_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357076_2.fastq.gz

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/main.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/main.nf
@@ -1,0 +1,52 @@
+#!/usr/bin/env nextflow
+
+/*
+ * RNA-seq Analysis Pipeline - Nextflow Version
+ *
+ * This workflow demonstrates the benefits of workflow management:
+ * - Automatic parallelization based on data dependencies
+ * - Built-in resume/caching after failures
+ * - Per-process container isolation
+ * - Declarative resource management
+ * - Automatic provenance tracking
+ */
+
+// Include process definitions
+include { FASTQC } from './modules/fastqc'
+include { FASTP } from './modules/fastp'
+include { UNTAR; SALMON_QUANT } from './modules/salmon'
+
+// Pipeline parameters
+params.samples = '../data/samples.csv'
+params.salmon_index = 'https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz'
+params.outdir = '../results'
+
+// Main workflow
+workflow {
+
+    // Read sample sheet and create channel
+    // Each sample becomes an independent item that can be processed in parallel
+    ch_samples = Channel
+        .fromPath(params.samples)
+        .splitCsv(header: true)
+        .map { row ->
+            def meta = [id: row.sample]
+            def reads = [file(row.fastq_1), file(row.fastq_2)]
+            return [meta, reads]
+        }
+
+    // Download and extract pre-built salmon index
+    ch_salmon_index = Channel.fromPath(params.salmon_index)
+    UNTAR(ch_salmon_index)
+
+    // Run the pipeline
+    // Nextflow automatically determines what can run in parallel
+
+    // FastQC and FASTP both need only the raw reads - they run in PARALLEL
+    FASTQC(ch_samples)
+    FASTP(ch_samples)
+
+    // SALMON needs FASTP output - it WAITS for FASTP, but runs samples in PARALLEL
+    // .first() converts the index to a value channel so it's reused for all samples
+    SALMON_QUANT(FASTP.out.reads, UNTAR.out.index.first())
+}

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/main.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/main.nf
@@ -3,13 +3,15 @@
 /*
  * RNA-seq analysis pipeline.
  *
- * Quality control, adapter trimming, and transcript quantification
- * for paired-end RNA-seq samples listed in a CSV sample sheet.
+ * Quality control, adapter trimming, transcript quantification, and
+ * MultiQC aggregation for paired-end RNA-seq samples listed in a CSV
+ * sample sheet.
  */
 
 include { FASTQC } from './modules/fastqc'
 include { FASTP } from './modules/fastp'
 include { UNTAR; SALMON_QUANT } from './modules/salmon'
+include { MULTIQC } from './modules/multiqc'
 
 params.samples = '../data/samples.csv'
 params.salmon_index = 'https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz'
@@ -29,6 +31,14 @@ workflow {
     FASTP(ch_samples)
     SALMON_QUANT(FASTP.out.reads, UNTAR.out.index.first())
 
+    ch_multiqc = FASTQC.out.zip
+        .map { _id, files -> files }
+        .mix(FASTP.out.json.map { _id, files -> files })
+        .mix(SALMON_QUANT.out.results.map { _id, files -> files })
+        .collect()
+
+    MULTIQC(ch_multiqc)
+
     publish:
     fastqc_html = FASTQC.out.html
     fastqc_zip = FASTQC.out.zip
@@ -36,6 +46,7 @@ workflow {
     fastp_json = FASTP.out.json
     fastp_html = FASTP.out.html
     salmon_quant = SALMON_QUANT.out.results
+    multiqc_report = MULTIQC.out.report
 }
 
 output {
@@ -56,5 +67,8 @@ output {
     }
     salmon_quant {
         path 'salmon'
+    }
+    multiqc_report {
+        path 'multiqc'
     }
 }

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/main.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/main.nf
@@ -1,52 +1,60 @@
 #!/usr/bin/env nextflow
 
 /*
- * RNA-seq Analysis Pipeline - Nextflow Version
+ * RNA-seq analysis pipeline.
  *
- * This workflow demonstrates the benefits of workflow management:
- * - Automatic parallelization based on data dependencies
- * - Built-in resume/caching after failures
- * - Per-process container isolation
- * - Declarative resource management
- * - Automatic provenance tracking
+ * Quality control, adapter trimming, and transcript quantification
+ * for paired-end RNA-seq samples listed in a CSV sample sheet.
  */
 
-// Include process definitions
 include { FASTQC } from './modules/fastqc'
 include { FASTP } from './modules/fastp'
 include { UNTAR; SALMON_QUANT } from './modules/salmon'
 
-// Pipeline parameters
 params.samples = '../data/samples.csv'
 params.salmon_index = 'https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz'
-params.outdir = '../results'
 
-// Main workflow
 workflow {
 
-    // Read sample sheet and create channel
-    // Each sample becomes an independent item that can be processed in parallel
-    ch_samples = Channel
+    main:
+    ch_samples = channel
         .fromPath(params.samples)
         .splitCsv(header: true)
-        .map { row ->
-            def meta = [id: row.sample]
-            def reads = [file(row.fastq_1), file(row.fastq_2)]
-            return [meta, reads]
-        }
+        .map { row -> [row.sample, [file(row.fastq_1), file(row.fastq_2)]] }
 
-    // Download and extract pre-built salmon index
-    ch_salmon_index = Channel.fromPath(params.salmon_index)
+    ch_salmon_index = channel.fromPath(params.salmon_index)
     UNTAR(ch_salmon_index)
 
-    // Run the pipeline
-    // Nextflow automatically determines what can run in parallel
-
-    // FastQC and FASTP both need only the raw reads - they run in PARALLEL
     FASTQC(ch_samples)
     FASTP(ch_samples)
-
-    // SALMON needs FASTP output - it WAITS for FASTP, but runs samples in PARALLEL
-    // .first() converts the index to a value channel so it's reused for all samples
     SALMON_QUANT(FASTP.out.reads, UNTAR.out.index.first())
+
+    publish:
+    fastqc_html = FASTQC.out.html
+    fastqc_zip = FASTQC.out.zip
+    fastp_reads = FASTP.out.reads
+    fastp_json = FASTP.out.json
+    fastp_html = FASTP.out.html
+    salmon_quant = SALMON_QUANT.out.results
+}
+
+output {
+    fastqc_html {
+        path 'fastqc'
+    }
+    fastqc_zip {
+        path 'fastqc'
+    }
+    fastp_reads {
+        path 'fastp'
+    }
+    fastp_json {
+        path 'fastp'
+    }
+    fastp_html {
+        path 'fastp'
+    }
+    salmon_quant {
+        path 'salmon'
+    }
 }

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastp.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastp.nf
@@ -1,0 +1,35 @@
+/*
+ * FASTP - Adapter trimming and quality filtering
+ *
+ * Different container than FastQC - each process has its own
+ * isolated software environment. No version conflicts!
+ */
+process FASTP {
+    tag "$meta.id"
+    container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
+    publishDir "${params.outdir}/fastp", mode: 'copy'
+
+    cpus 4
+    memory '4.GB'
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path("*_trimmed*.fastq.gz"), emit: reads
+    tuple val(meta), path("*.json"), emit: json
+    tuple val(meta), path("*.html"), emit: html
+
+    script:
+    def prefix = meta.id
+    """
+    fastp \\
+        --in1 ${reads[0]} \\
+        --in2 ${reads[1]} \\
+        --out1 ${prefix}_trimmed_R1.fastq.gz \\
+        --out2 ${prefix}_trimmed_R2.fastq.gz \\
+        --json ${prefix}.fastp.json \\
+        --html ${prefix}.fastp.html \\
+        --thread $task.cpus
+    """
+}

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastp.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastp.nf
@@ -1,35 +1,30 @@
 /*
  * FASTP - Adapter trimming and quality filtering
- *
- * Different container than FastQC - each process has its own
- * isolated software environment. No version conflicts!
  */
 process FASTP {
-    tag "$meta.id"
+    tag "$id"
     container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
-    publishDir "${params.outdir}/fastp", mode: 'copy'
 
     cpus 4
     memory '4.GB'
 
     input:
-    tuple val(meta), path(reads)
+    tuple val(id), path(reads)
 
     output:
-    tuple val(meta), path("*_trimmed*.fastq.gz"), emit: reads
-    tuple val(meta), path("*.json"), emit: json
-    tuple val(meta), path("*.html"), emit: html
+    tuple val(id), path("*_trimmed*.fastq.gz"), emit: reads
+    tuple val(id), path("*.json"), emit: json
+    tuple val(id), path("*.html"), emit: html
 
     script:
-    def prefix = meta.id
     """
     fastp \\
         --in1 ${reads[0]} \\
         --in2 ${reads[1]} \\
-        --out1 ${prefix}_trimmed_R1.fastq.gz \\
-        --out2 ${prefix}_trimmed_R2.fastq.gz \\
-        --json ${prefix}.fastp.json \\
-        --html ${prefix}.fastp.html \\
-        --thread $task.cpus
+        --out1 ${id}_trimmed_R1.fastq.gz \\
+        --out2 ${id}_trimmed_R2.fastq.gz \\
+        --json ${id}.fastp.json \\
+        --html ${id}.fastp.html \\
+        --thread ${task.cpus}
     """
 }

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastp.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastp.nf
@@ -5,9 +5,6 @@ process FASTP {
     tag "$id"
     container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
 
-    cpus 4
-    memory '4.GB'
-
     input:
     tuple val(id), path(reads)
 
@@ -25,6 +22,6 @@ process FASTP {
         --out2 ${id}_trimmed_R2.fastq.gz \\
         --json ${id}.fastp.json \\
         --html ${id}.fastp.html \\
-        --thread ${task.cpus}
+        --thread 4
     """
 }

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastqc.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastqc.nf
@@ -1,0 +1,26 @@
+/*
+ * FASTQC - Quality control for sequencing reads
+ *
+ * Each process declares its own container - no manual installation needed.
+ * The exact version (0.12.1) is locked, ensuring reproducible results.
+ */
+process FASTQC {
+    tag "$meta.id"
+    container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'
+    publishDir "${params.outdir}/fastqc", mode: 'copy'
+
+    cpus 2
+    memory '2.GB'
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path("*.html"), emit: html
+    tuple val(meta), path("*.zip"), emit: zip
+
+    script:
+    """
+    fastqc --quiet --threads $task.cpus ${reads}
+    """
+}

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastqc.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastqc.nf
@@ -5,9 +5,6 @@ process FASTQC {
     tag "$id"
     container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'
 
-    cpus 2
-    memory '2.GB'
-
     input:
     tuple val(id), path(reads)
 
@@ -17,6 +14,6 @@ process FASTQC {
 
     script:
     """
-    fastqc --quiet --threads ${task.cpus} ${reads}
+    fastqc --quiet --threads 2 ${reads}
     """
 }

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastqc.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/fastqc.nf
@@ -1,26 +1,22 @@
 /*
  * FASTQC - Quality control for sequencing reads
- *
- * Each process declares its own container - no manual installation needed.
- * The exact version (0.12.1) is locked, ensuring reproducible results.
  */
 process FASTQC {
-    tag "$meta.id"
+    tag "$id"
     container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'
-    publishDir "${params.outdir}/fastqc", mode: 'copy'
 
     cpus 2
     memory '2.GB'
 
     input:
-    tuple val(meta), path(reads)
+    tuple val(id), path(reads)
 
     output:
-    tuple val(meta), path("*.html"), emit: html
-    tuple val(meta), path("*.zip"), emit: zip
+    tuple val(id), path("*.html"), emit: html
+    tuple val(id), path("*.zip"), emit: zip
 
     script:
     """
-    fastqc --quiet --threads $task.cpus ${reads}
+    fastqc --quiet --threads ${task.cpus} ${reads}
     """
 }

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/multiqc.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/multiqc.nf
@@ -1,0 +1,18 @@
+/*
+ * MULTIQC - Aggregate QC metrics from FastQC, fastp, and Salmon
+ */
+process MULTIQC {
+    container 'quay.io/biocontainers/multiqc:1.19--pyhdfd78af_0'
+
+    input:
+    path('*')
+
+    output:
+    path "multiqc_report.html", emit: report
+    path "multiqc_data", emit: data
+
+    script:
+    """
+    multiqc .
+    """
+}

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/salmon.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/salmon.nf
@@ -1,0 +1,52 @@
+/*
+ * UNTAR - Extract tarball archive
+ *
+ * Helper process to extract the pre-built salmon index.
+ */
+process UNTAR {
+    container 'ubuntu:22.04'
+
+    input:
+    path archive
+
+    output:
+    path "salmon", emit: index
+
+    script:
+    """
+    tar -xzf $archive
+    """
+}
+
+/*
+ * SALMON - Fast transcript quantification
+ *
+ * Salmon uses pseudo-alignment for rapid quantification.
+ * We use a pre-built index to keep the tutorial fast.
+ */
+process SALMON_QUANT {
+    tag "$meta.id"
+    container 'quay.io/biocontainers/salmon:1.10.3--h6dccd9a_2'
+    publishDir "${params.outdir}/salmon", mode: 'copy'
+
+    cpus 4
+    memory '8.GB'
+
+    input:
+    tuple val(meta), path(reads)
+    path index
+
+    output:
+    tuple val(meta), path("${meta.id}"), emit: results
+
+    script:
+    """
+    salmon quant \\
+        --index $index \\
+        --libType A \\
+        --mates1 ${reads[0]} \\
+        --mates2 ${reads[1]} \\
+        --output ${meta.id} \\
+        --threads $task.cpus
+    """
+}

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/salmon.nf
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/modules/salmon.nf
@@ -14,39 +14,35 @@ process UNTAR {
 
     script:
     """
-    tar -xzf $archive
+    tar -xzf ${archive}
     """
 }
 
 /*
- * SALMON - Fast transcript quantification
- *
- * Salmon uses pseudo-alignment for rapid quantification.
- * We use a pre-built index to keep the tutorial fast.
+ * SALMON_QUANT - Fast transcript quantification
  */
 process SALMON_QUANT {
-    tag "$meta.id"
+    tag "$id"
     container 'quay.io/biocontainers/salmon:1.10.3--h6dccd9a_2'
-    publishDir "${params.outdir}/salmon", mode: 'copy'
 
     cpus 4
     memory '8.GB'
 
     input:
-    tuple val(meta), path(reads)
+    tuple val(id), path(reads)
     path index
 
     output:
-    tuple val(meta), path("${meta.id}"), emit: results
+    tuple val(id), path("${id}"), emit: results
 
     script:
     """
     salmon quant \\
-        --index $index \\
+        --index ${index} \\
         --libType A \\
         --mates1 ${reads[0]} \\
         --mates2 ${reads[1]} \\
-        --output ${meta.id} \\
-        --threads $task.cpus
+        --output ${id} \\
+        --threads ${task.cpus}
     """
 }

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/nextflow.config
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/nextflow.config
@@ -1,0 +1,99 @@
+/*
+ * Nextflow Configuration
+ *
+ * This file demonstrates the separation of LOGIC from INFRASTRUCTURE.
+ * The workflow (main.nf) describes WHAT to do.
+ * This config describes HOW and WHERE to do it.
+ *
+ * Same workflow code runs on laptop, cluster, or cloud - just change the profile.
+ */
+
+// Default parameters
+params {
+    samples = '../data/samples.csv'
+    salmon_index = 'https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz'
+    outdir = '../results'
+}
+
+// Process defaults
+process {
+    cpus = 2
+    memory = '4.GB'
+    time = '2.h'
+}
+
+// Automatic report generation - provenance tracking built-in!
+timeline {
+    enabled = true
+    file = "${params.outdir}/timeline.html"
+}
+
+report {
+    enabled = true
+    file = "${params.outdir}/report.html"
+}
+
+trace {
+    enabled = true
+    file = "${params.outdir}/trace.txt"
+}
+
+// Execution profiles - same workflow, different infrastructure
+profiles {
+
+    // Local execution with Docker (default)
+    standard {
+        process.executor = 'local'
+        docker.enabled = true
+        docker.runOptions = '-u $(id -u):$(id -g)'
+    }
+
+    // Local execution with Docker
+    docker {
+        docker.enabled = true
+        docker.runOptions = '-u $(id -u):$(id -g)'
+    }
+
+    // HPC cluster with SLURM scheduler
+    slurm {
+        process.executor = 'slurm'
+        process.queue = 'general'
+        process.clusterOptions = '--account=myproject'
+        singularity.enabled = true
+        singularity.cacheDir = '/shared/containers'
+        docker.enabled = false
+    }
+
+    // HPC cluster with PBS scheduler
+    pbs {
+        process.executor = 'pbs'
+        process.queue = 'batch'
+        singularity.enabled = true
+        docker.enabled = false
+    }
+
+    // AWS cloud execution
+    aws {
+        process.executor = 'awsbatch'
+        process.queue = 'genomics-queue'
+        workDir = 's3://my-bucket/work'
+        aws.region = 'us-east-1'
+        aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
+    }
+
+    // Google Cloud execution
+    gcp {
+        process.executor = 'google-lifesciences'
+        google.location = 'us-central1'
+        google.region = 'us-central1'
+        google.project = 'my-project'
+        workDir = 'gs://my-bucket/work'
+    }
+
+    // Minimal resources for testing
+    test {
+        params.samples = '../data/samples.csv'
+        process.cpus = 1
+        process.memory = '2.GB'
+    }
+}

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/nextflow.config
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/nextflow.config
@@ -17,33 +17,17 @@ process {
     time = '2.h'
 }
 
-// Provenance reports written next to the run directory.
-timeline {
-    enabled = true
-    file = 'pipeline_info/timeline.html'
-}
-
-report {
-    enabled = true
-    file = 'pipeline_info/report.html'
-}
-
-trace {
-    enabled = true
-    file = 'pipeline_info/trace.txt'
-}
-
 profiles {
 
     standard {
         process.executor = 'local'
         docker.enabled = true
-        docker.runOptions = '-u $(id -u):$(id -g)'
+        docker.runOptions = '-u $(id -u):$(id -g) --platform=linux/amd64'
     }
 
     docker {
         docker.enabled = true
-        docker.runOptions = '-u $(id -u):$(id -g)'
+        docker.runOptions = '-u $(id -u):$(id -g) --platform=linux/amd64'
     }
 
     singularity {

--- a/side-quests/solutions/workflows_in_the_ai_era/nextflow/nextflow.config
+++ b/side-quests/solutions/workflows_in_the_ai_era/nextflow/nextflow.config
@@ -1,98 +1,72 @@
 /*
- * Nextflow Configuration
+ * Nextflow configuration.
  *
- * This file demonstrates the separation of LOGIC from INFRASTRUCTURE.
- * The workflow (main.nf) describes WHAT to do.
- * This config describes HOW and WHERE to do it.
- *
- * Same workflow code runs on laptop, cluster, or cloud - just change the profile.
+ * The workflow describes what to do; this config describes how and where.
+ * The same workflow runs locally, on a cluster, or in the cloud.
+ * Choose one with `-profile`.
  */
 
-// Default parameters
 params {
     samples = '../data/samples.csv'
     salmon_index = 'https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz'
-    outdir = '../results'
 }
 
-// Process defaults
 process {
     cpus = 2
     memory = '4.GB'
     time = '2.h'
 }
 
-// Automatic report generation - provenance tracking built-in!
+// Provenance reports written next to the run directory.
 timeline {
     enabled = true
-    file = "${params.outdir}/timeline.html"
+    file = 'pipeline_info/timeline.html'
 }
 
 report {
     enabled = true
-    file = "${params.outdir}/report.html"
+    file = 'pipeline_info/report.html'
 }
 
 trace {
     enabled = true
-    file = "${params.outdir}/trace.txt"
+    file = 'pipeline_info/trace.txt'
 }
 
-// Execution profiles - same workflow, different infrastructure
 profiles {
 
-    // Local execution with Docker (default)
     standard {
         process.executor = 'local'
         docker.enabled = true
         docker.runOptions = '-u $(id -u):$(id -g)'
     }
 
-    // Local execution with Docker
     docker {
         docker.enabled = true
         docker.runOptions = '-u $(id -u):$(id -g)'
     }
 
-    // HPC cluster with SLURM scheduler
+    singularity {
+        singularity.enabled = true
+        docker.enabled = false
+    }
+
     slurm {
         process.executor = 'slurm'
         process.queue = 'general'
-        process.clusterOptions = '--account=myproject'
         singularity.enabled = true
         singularity.cacheDir = '/shared/containers'
         docker.enabled = false
     }
 
-    // HPC cluster with PBS scheduler
-    pbs {
-        process.executor = 'pbs'
-        process.queue = 'batch'
-        singularity.enabled = true
-        docker.enabled = false
-    }
-
-    // AWS cloud execution
-    aws {
+    awsbatch {
         process.executor = 'awsbatch'
         process.queue = 'genomics-queue'
         workDir = 's3://my-bucket/work'
         aws.region = 'us-east-1'
-        aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
     }
 
-    // Google Cloud execution
-    gcp {
-        process.executor = 'google-lifesciences'
-        google.location = 'us-central1'
-        google.region = 'us-central1'
-        google.project = 'my-project'
-        workDir = 'gs://my-bucket/work'
-    }
-
-    // Minimal resources for testing
     test {
-        params.samples = '../data/samples.csv'
         process.cpus = 1
         process.memory = '2.GB'
     }

--- a/side-quests/workflows_in_the_ai_era/README.md
+++ b/side-quests/workflows_in_the_ai_era/README.md
@@ -1,0 +1,62 @@
+# Workflow Management Fundamentals
+
+This side quest teaches why workflow managers exist by having you experience the pain points firsthand.
+
+## Structure
+
+```
+workflow_management_fundamentals/
+├── bash/                    # Part 1: Build scripts here
+├── data/
+│   └── samples.csv          # Sample metadata (real RNA-seq data URLs)
+└── nextflow/                # Part 2: Build workflow here
+    ├── main.nf              # Starter template
+    ├── modules/             # Add process modules here
+    └── nextflow.config      # Starter configuration
+```
+
+## Tutorial Parts
+
+### Part 1: Building a Bash Pipeline
+
+You'll build an RNA-seq pipeline from scratch in bash, experiencing:
+
+- Tool installation friction (conda/mamba setup)
+- Sequential processing limitations
+- Parallelization complexity (& and wait)
+- Failure recovery challenges
+- Reproducibility problems
+- Portability issues
+
+### Part 2: Building a Nextflow Pipeline
+
+You'll rebuild the same pipeline in Nextflow, seeing how each problem is solved:
+
+- Container-based tool management
+- Automatic parallelization from data flow
+- Built-in resume capability
+- Declarative resource management
+- Configuration profiles for any platform
+- Automatic provenance tracking
+
+## Solutions
+
+Complete solutions are in `../solutions/workflow_management_fundamentals/`:
+
+- `bash/` - Final bash scripts (process_sample.sh, pipeline_sequential.sh, pipeline_parallel.sh)
+- `nextflow/` - Final Nextflow workflow with all modules
+
+## Prerequisites
+
+- Docker (for Nextflow containers)
+- Conda/Mamba (for Part 1 bash tools)
+- Basic command line familiarity
+
+## Data
+
+This tutorial uses real RNA-seq data from the nf-core test-datasets repository.
+The FASTQ files are small (~30 seconds per sample) to keep execution fast while using actual bioinformatics tools.
+
+## Getting Started
+
+See the full tutorial: [Workflow Management Fundamentals](https://training.nextflow.io/side_quests/workflow_management_fundamentals/)

--- a/side-quests/workflows_in_the_ai_era/README.md
+++ b/side-quests/workflows_in_the_ai_era/README.md
@@ -1,62 +1,61 @@
-# Workflow Management Fundamentals
+# Workflows in the AI era
 
-This side quest teaches why workflow managers exist by having you experience the pain points firsthand.
+This side quest teaches why workflow managers still matter when an AI agent can run your analysis or generate the pipeline for you.
 
 ## Structure
 
 ```
-workflow_management_fundamentals/
-├── bash/                    # Part 1: Build scripts here
+workflows_in_the_ai_era/
+├── bash/                    # Part 1: build scripts here
 ├── data/
-│   └── samples.csv          # Sample metadata (real RNA-seq data URLs)
-└── nextflow/                # Part 2: Build workflow here
-    ├── main.nf              # Starter template
-    ├── modules/             # Add process modules here
-    └── nextflow.config      # Starter configuration
+│   └── samples.csv          # sample metadata (real RNA-seq data URLs)
+└── nextflow/                # Part 2: build workflow here
+    ├── main.nf              # starter template
+    ├── modules/             # add process modules here
+    └── nextflow.config      # starter configuration
 ```
 
-## Tutorial Parts
+## Tutorial parts
 
-### Part 1: Building a Bash Pipeline
+### Part 1: Building a bash pipeline
 
 You'll build an RNA-seq pipeline from scratch in bash, experiencing:
 
 - Tool installation friction (conda/mamba setup)
 - Sequential processing limitations
-- Parallelization complexity (& and wait)
+- Parallelisation complexity (`&` and `wait`)
 - Failure recovery challenges
 - Reproducibility problems
 - Portability issues
 
-### Part 2: Building a Nextflow Pipeline
+### Part 2: Building a Nextflow pipeline
 
 You'll rebuild the same pipeline in Nextflow, seeing how each problem is solved:
 
 - Container-based tool management
-- Automatic parallelization from data flow
+- Automatic parallelisation from data flow
 - Built-in resume capability
 - Declarative resource management
 - Configuration profiles for any platform
-- Automatic provenance tracking
+- The workflow output system for stable result layouts
 
 ## Solutions
 
-Complete solutions are in `../solutions/workflow_management_fundamentals/`:
+Complete solutions are in `../solutions/workflows_in_the_ai_era/`:
 
-- `bash/` - Final bash scripts (process_sample.sh, pipeline_sequential.sh, pipeline_parallel.sh)
-- `nextflow/` - Final Nextflow workflow with all modules
+- `bash/`: final bash scripts (`process_sample.sh`, `pipeline_sequential.sh`, `pipeline_parallel.sh`)
+- `nextflow/`: final Nextflow workflow with all modules
 
 ## Prerequisites
 
 - Docker (for Nextflow containers)
-- Conda/Mamba (for Part 1 bash tools)
-- Basic command line familiarity
+- Conda or mamba (for Part 1 bash tools)
+- Basic command-line familiarity
 
 ## Data
 
-This tutorial uses real RNA-seq data from the nf-core test-datasets repository.
-The FASTQ files are small (~30 seconds per sample) to keep execution fast while using actual bioinformatics tools.
+This tutorial uses real RNA-seq data from the nf-core test-datasets repository. The FASTQ files are small (about 30 seconds per sample) to keep execution fast while using actual bioinformatics tools.
 
-## Getting Started
+## Getting started
 
-See the full tutorial: [Workflow Management Fundamentals](https://training.nextflow.io/side_quests/workflow_management_fundamentals/)
+See the full tutorial: [Workflows in the AI era](https://training.nextflow.io/side_quests/workflows_in_the_ai_era/).

--- a/side-quests/workflows_in_the_ai_era/bash/pipeline_parallel.sh
+++ b/side-quests/workflows_in_the_ai_era/bash/pipeline_parallel.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Process all RNA-seq samples in PARALLEL
+#
+# Usage: ./pipeline_parallel.sh [samples.csv]
+
+set -e
+
+SAMPLES_FILE=${1:-data/samples.csv}
+
+echo "=========================================="
+echo "RNA-seq Pipeline (Parallel)"
+echo "=========================================="
+
+mkdir -p data/fastq results/fastqc results/fastp results/salmon data/salmon_index
+
+# Download salmon index once (shared by all samples)
+if [ ! -d "data/salmon_index/salmon" ]; then
+    echo "Downloading salmon index..."
+    curl -sL https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz \
+        -o data/salmon_index/salmon.tar.gz
+    tar -xzf data/salmon_index/salmon.tar.gz -C data/salmon_index/
+    rm data/salmon_index/salmon.tar.gz
+fi
+
+# Function to process one sample (all steps for a single sample)
+process_sample() {
+    local sample_id=$1
+    local fastq_r1=$2
+    local fastq_r2=$3
+
+    echo "[${sample_id}] Starting..."
+
+    # Download
+    curl -sL "$fastq_r1" -o "data/fastq/${sample_id}_R1.fastq.gz"
+    curl -sL "$fastq_r2" -o "data/fastq/${sample_id}_R2.fastq.gz"
+
+    # FastQC
+    fastqc -q -o results/fastqc "data/fastq/${sample_id}_R1.fastq.gz" "data/fastq/${sample_id}_R2.fastq.gz"
+
+    # fastp
+    fastp -i "data/fastq/${sample_id}_R1.fastq.gz" -I "data/fastq/${sample_id}_R2.fastq.gz" \
+        -o "results/fastp/${sample_id}_trimmed_R1.fastq.gz" -O "results/fastp/${sample_id}_trimmed_R2.fastq.gz" \
+        -j "results/fastp/${sample_id}.fastp.json" -h "results/fastp/${sample_id}.fastp.html" 2>/dev/null
+
+    # Salmon
+    salmon quant --index data/salmon_index/salmon --libType A \
+        --mates1 "results/fastp/${sample_id}_trimmed_R1.fastq.gz" \
+        --mates2 "results/fastp/${sample_id}_trimmed_R2.fastq.gz" \
+        --output "results/salmon/${sample_id}" --threads 2 --quiet
+
+    echo "[${sample_id}] Complete!"
+}
+
+export -f process_sample
+
+echo "Launching samples..."
+
+# Process each sample
+# TODO: Modify this loop to run samples in PARALLEL
+# Hint: Add & after the function call to run in background
+while IFS=',' read -r sample_id fastq_r1 fastq_r2; do
+    process_sample "$sample_id" "$fastq_r1" "$fastq_r2"
+done < <(tail -n +2 "$SAMPLES_FILE")
+
+# TODO: Add wait command to wait for all background jobs
+
+echo ""
+echo "Pipeline complete!"

--- a/side-quests/workflows_in_the_ai_era/bash/pipeline_sequential.sh
+++ b/side-quests/workflows_in_the_ai_era/bash/pipeline_sequential.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Process all RNA-seq samples sequentially
+#
+# Usage: ./pipeline_sequential.sh [samples.csv]
+
+set -e
+
+SAMPLES_FILE=${1:-data/samples.csv}
+
+echo "=========================================="
+echo "RNA-seq Pipeline (Sequential)"
+echo "=========================================="
+
+mkdir -p data/fastq results/fastqc results/fastp results/salmon data/salmon_index
+
+# Download salmon index once (shared by all samples)
+if [ ! -d "data/salmon_index/salmon" ]; then
+    echo "Downloading salmon index..."
+    curl -sL https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz \
+        -o data/salmon_index/salmon.tar.gz
+    tar -xzf data/salmon_index/salmon.tar.gz -C data/salmon_index/
+    rm data/salmon_index/salmon.tar.gz
+fi
+
+# Process each sample from the CSV (skip header line)
+tail -n +2 "$SAMPLES_FILE" | while IFS=',' read -r sample_id fastq_r1 fastq_r2; do
+    echo ""
+    echo "Processing: $sample_id"
+
+    # TODO: Add the processing steps for each sample
+    # - Download FASTQ files
+    # - Run FastQC
+    # - Run fastp
+    # - Run Salmon
+
+    echo "  Done: $sample_id"
+done
+
+echo ""
+echo "Pipeline complete!"

--- a/side-quests/workflows_in_the_ai_era/bash/process_sample.sh
+++ b/side-quests/workflows_in_the_ai_era/bash/process_sample.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Process a single RNA-seq sample
+#
+# Usage: ./process_sample.sh <sample_id> <fastq_r1_url> <fastq_r2_url>
+
+set -e  # Exit on error
+
+SAMPLE_ID=$1
+FASTQ_R1_URL=$2
+FASTQ_R2_URL=$3
+
+echo "Processing sample: $SAMPLE_ID"
+
+# Create output directories
+mkdir -p data/fastq results/fastqc results/fastp results/salmon data/salmon_index
+
+# Step 1: Download FASTQ files
+# TODO: Add curl commands to download R1 and R2 files
+
+# Step 2: Run FastQC
+# TODO: Add fastqc command
+
+# Step 3: Run fastp
+# TODO: Add fastp command
+
+# Step 4: Download salmon index (if needed)
+# TODO: Add conditional download of salmon index
+
+# Step 5: Run Salmon quantification
+# TODO: Add salmon quant command
+
+echo "Completed: $SAMPLE_ID"

--- a/side-quests/workflows_in_the_ai_era/data/samples.csv
+++ b/side-quests/workflows_in_the_ai_era/data/samples.csv
@@ -1,0 +1,4 @@
+sample,fastq_1,fastq_2
+WT_REP1,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357070_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357070_2.fastq.gz
+WT_REP2,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357072_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357072_2.fastq.gz
+RAP1_IAA_30M_REP1,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357076_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/testdata/GSE110004/SRR6357076_2.fastq.gz

--- a/side-quests/workflows_in_the_ai_era/nextflow/main.nf
+++ b/side-quests/workflows_in_the_ai_era/nextflow/main.nf
@@ -1,0 +1,41 @@
+#!/usr/bin/env nextflow
+
+/*
+ * RNA-seq Analysis Pipeline - Nextflow Version
+ */
+
+// Include processes from modules
+include { FASTQC } from './modules/fastqc'
+include { FASTP } from './modules/fastp'
+include { UNTAR; SALMON_QUANT } from './modules/salmon'
+
+// Pipeline parameters
+params.samples = '../data/samples.csv'
+params.outdir = '../results'
+params.salmon_index = 'https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz'
+
+// Main workflow
+workflow {
+    // Create channel from sample sheet
+    // Each sample becomes [meta, [read1, read2]]
+    ch_samples = Channel
+        .fromPath(params.samples)
+        .splitCsv(header: true)
+        .map { row ->
+            def meta = [id: row.sample]
+            def reads = [file(row.fastq_1), file(row.fastq_2)]
+            return [meta, reads]
+        }
+
+    // Prepare salmon index
+    ch_salmon_index = Channel.fromPath(params.salmon_index)
+    UNTAR(ch_salmon_index)
+
+    // TODO: Call FASTQC process with ch_samples
+
+    // TODO: Call FASTP process with ch_samples
+
+    // TODO: Call SALMON_QUANT with FASTP output and the index
+    // Hint: Use FASTP.out.reads for the trimmed reads
+    // Hint: Use UNTAR.out.index.first() for the index
+}

--- a/side-quests/workflows_in_the_ai_era/nextflow/main.nf
+++ b/side-quests/workflows_in_the_ai_era/nextflow/main.nf
@@ -1,41 +1,45 @@
 #!/usr/bin/env nextflow
 
 /*
- * RNA-seq Analysis Pipeline - Nextflow Version
+ * RNA-seq analysis pipeline (starter).
+ *
+ * You will fill in the TODO sections through the tutorial.
  */
 
-// Include processes from modules
 include { FASTQC } from './modules/fastqc'
 include { FASTP } from './modules/fastp'
 include { UNTAR; SALMON_QUANT } from './modules/salmon'
 
-// Pipeline parameters
 params.samples = '../data/samples.csv'
-params.outdir = '../results'
 params.salmon_index = 'https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/reference/salmon.tar.gz'
 
-// Main workflow
 workflow {
-    // Create channel from sample sheet
-    // Each sample becomes [meta, [read1, read2]]
-    ch_samples = Channel
+
+    main:
+    // Each sample becomes [id, [read1, read2]]
+    ch_samples = channel
         .fromPath(params.samples)
         .splitCsv(header: true)
-        .map { row ->
-            def meta = [id: row.sample]
-            def reads = [file(row.fastq_1), file(row.fastq_2)]
-            return [meta, reads]
-        }
+        .map { row -> [row.sample, [file(row.fastq_1), file(row.fastq_2)]] }
 
-    // Prepare salmon index
-    ch_salmon_index = Channel.fromPath(params.salmon_index)
+    ch_salmon_index = channel.fromPath(params.salmon_index)
     UNTAR(ch_salmon_index)
 
-    // TODO: Call FASTQC process with ch_samples
+    // TODO: Call FASTQC with ch_samples
 
-    // TODO: Call FASTP process with ch_samples
+    // TODO: Call FASTP with ch_samples
 
     // TODO: Call SALMON_QUANT with FASTP output and the index
-    // Hint: Use FASTP.out.reads for the trimmed reads
-    // Hint: Use UNTAR.out.index.first() for the index
+    // Hint: Use FASTP.out.reads and UNTAR.out.index.first()
+
+    publish:
+    // TODO: Publish the outputs you want kept after the run.
+    // Hint: each line names a published channel, e.g.
+    //     fastqc_html = FASTQC.out.html
+}
+
+output {
+    // TODO: Configure output paths for each published channel.
+    // Hint: each block names a subdirectory, e.g.
+    //     fastqc_html { path 'fastqc' }
 }

--- a/side-quests/workflows_in_the_ai_era/nextflow/modules/fastp.nf
+++ b/side-quests/workflows_in_the_ai_era/nextflow/modules/fastp.nf
@@ -1,0 +1,22 @@
+process FASTP {
+    tag "$meta.id"
+    container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
+    publishDir "${params.outdir}/fastp", mode: 'copy'
+
+    input:
+    // TODO: Define input - same pattern as FASTQC
+    ???
+
+    output:
+    // TODO: Define outputs - trimmed reads, JSON report, HTML report
+    // Important: The trimmed reads output needs 'emit: reads' for downstream processes
+    ???
+
+    script:
+    // TODO: Add the fastp command
+    // Hint: Use ${reads[0]} and ${reads[1]} for input files
+    // Hint: Use ${meta.id} for output file prefixes
+    """
+    ???
+    """
+}

--- a/side-quests/workflows_in_the_ai_era/nextflow/modules/fastp.nf
+++ b/side-quests/workflows_in_the_ai_era/nextflow/modules/fastp.nf
@@ -1,7 +1,6 @@
 process FASTP {
-    tag "$meta.id"
+    tag "$id"
     container 'quay.io/biocontainers/fastp:0.23.4--hadf994f_2'
-    publishDir "${params.outdir}/fastp", mode: 'copy'
 
     input:
     // TODO: Define input - same pattern as FASTQC
@@ -9,13 +8,13 @@ process FASTP {
 
     output:
     // TODO: Define outputs - trimmed reads, JSON report, HTML report
-    // Important: The trimmed reads output needs 'emit: reads' for downstream processes
+    // Important: The trimmed reads output needs `emit: reads` for downstream processes
     ???
 
     script:
     // TODO: Add the fastp command
     // Hint: Use ${reads[0]} and ${reads[1]} for input files
-    // Hint: Use ${meta.id} for output file prefixes
+    // Hint: Use ${id} for output file prefixes
     """
     ???
     """

--- a/side-quests/workflows_in_the_ai_era/nextflow/modules/fastqc.nf
+++ b/side-quests/workflows_in_the_ai_era/nextflow/modules/fastqc.nf
@@ -1,0 +1,19 @@
+process FASTQC {
+    tag "$meta.id"
+    container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'
+    publishDir "${params.outdir}/fastqc", mode: 'copy'
+
+    input:
+    // TODO: Define input - a tuple with sample metadata and read files
+    ???
+
+    output:
+    // TODO: Define outputs - HTML reports and ZIP files
+    ???
+
+    script:
+    // TODO: Add the fastqc command
+    """
+    ???
+    """
+}

--- a/side-quests/workflows_in_the_ai_era/nextflow/modules/fastqc.nf
+++ b/side-quests/workflows_in_the_ai_era/nextflow/modules/fastqc.nf
@@ -1,10 +1,9 @@
 process FASTQC {
-    tag "$meta.id"
+    tag "$id"
     container 'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0'
-    publishDir "${params.outdir}/fastqc", mode: 'copy'
 
     input:
-    // TODO: Define input - a tuple with sample metadata and read files
+    // TODO: Define input - a tuple with sample id and the read files
     ???
 
     output:

--- a/side-quests/workflows_in_the_ai_era/nextflow/modules/salmon.nf
+++ b/side-quests/workflows_in_the_ai_era/nextflow/modules/salmon.nf
@@ -1,0 +1,42 @@
+// Helper process to extract the pre-built salmon index
+process UNTAR {
+    container 'ubuntu:22.04'
+
+    input:
+    path archive
+
+    output:
+    path "salmon", emit: index
+
+    script:
+    """
+    tar -xzf $archive
+    """
+}
+
+process SALMON_QUANT {
+    tag "$meta.id"
+    container 'quay.io/biocontainers/salmon:1.10.3--h6dccd9a_2'
+    publishDir "${params.outdir}/salmon", mode: 'copy'
+
+    cpus 4
+    memory '8.GB'
+
+    input:
+    // TODO: Define inputs - trimmed reads AND the salmon index
+    // Hint: This process needs two inputs (one tuple, one path)
+    ???
+
+    output:
+    // TODO: Define output - the quantification results directory
+    ???
+
+    script:
+    // TODO: Add the salmon quant command
+    // Hint: Use $index for the index path
+    // Hint: Use ${reads[0]} and ${reads[1]} for input reads
+    // Hint: Use $task.cpus for thread count
+    """
+    ???
+    """
+}

--- a/side-quests/workflows_in_the_ai_era/nextflow/modules/salmon.nf
+++ b/side-quests/workflows_in_the_ai_era/nextflow/modules/salmon.nf
@@ -10,14 +10,13 @@ process UNTAR {
 
     script:
     """
-    tar -xzf $archive
+    tar -xzf ${archive}
     """
 }
 
 process SALMON_QUANT {
-    tag "$meta.id"
+    tag "$id"
     container 'quay.io/biocontainers/salmon:1.10.3--h6dccd9a_2'
-    publishDir "${params.outdir}/salmon", mode: 'copy'
 
     cpus 4
     memory '8.GB'
@@ -33,9 +32,9 @@ process SALMON_QUANT {
 
     script:
     // TODO: Add the salmon quant command
-    // Hint: Use $index for the index path
+    // Hint: Use ${index} for the index path
     // Hint: Use ${reads[0]} and ${reads[1]} for input reads
-    // Hint: Use $task.cpus for thread count
+    // Hint: Use ${task.cpus} for thread count
     """
     ???
     """

--- a/side-quests/workflows_in_the_ai_era/nextflow/nextflow.config
+++ b/side-quests/workflows_in_the_ai_era/nextflow/nextflow.config
@@ -1,0 +1,18 @@
+/*
+ * Nextflow Configuration
+ *
+ * You will expand this configuration in Part 2 of the tutorial,
+ * adding resource directives, execution profiles, and provenance tracking.
+ */
+
+// Default parameters
+params {
+    samples = '../data/samples.csv'
+    outdir = '../results'
+}
+
+// Enable Docker by default for running containerized processes
+docker {
+    enabled = true
+    runOptions = '-u $(id -u):$(id -g)'
+}

--- a/side-quests/workflows_in_the_ai_era/nextflow/nextflow.config
+++ b/side-quests/workflows_in_the_ai_era/nextflow/nextflow.config
@@ -11,5 +11,5 @@ params {
 
 docker {
     enabled = true
-    runOptions = '-u $(id -u):$(id -g)'
+    runOptions = '-u $(id -u):$(id -g) --platform=linux/amd64'
 }

--- a/side-quests/workflows_in_the_ai_era/nextflow/nextflow.config
+++ b/side-quests/workflows_in_the_ai_era/nextflow/nextflow.config
@@ -1,17 +1,14 @@
 /*
- * Nextflow Configuration
+ * Nextflow configuration (starter).
  *
  * You will expand this configuration in Part 2 of the tutorial,
  * adding resource directives, execution profiles, and provenance tracking.
  */
 
-// Default parameters
 params {
     samples = '../data/samples.csv'
-    outdir = '../results'
 }
 
-// Enable Docker by default for running containerized processes
 docker {
     enabled = true
     runOptions = '-u $(id -u):$(id -g)'


### PR DESCRIPTION
## Summary

A new side quest that answers, hands-on, the question newcomers actually arrive with in 2026: **"why should I use a workflow tool when an AI agent can run my analysis or generate the whole pipeline for me?"**

The reader builds a real RNA-seq analysis (FastQC, fastp, Salmon) twice. Once as a bash pipeline of the kind an agent would produce on demand, hitting each engineering limit in turn. Once as a Nextflow workflow, where reproducibility, software tracking, scalability, parallelisation, resource awareness, failure recovery, and portability come from the workflow boundary itself. A short closing section addresses the second half of the question (_what if the AI writes the Nextflow?_) with the punchline _Claude needs them too_.

## Page

- `docs/en/docs/side_quests/workflows_in_the_ai_era/index.md` (~1170 lines, ~75 minutes)
- Entry in `docs/en/docs/side_quests/index.md` table and `docs/en/mkdocs.yml` nav, slotted between Development Environment and Essential Scripting Patterns.

## Runnable assets

`side-quests/workflows_in_the_ai_era/` (starter, with TODOs) and `side-quests/solutions/workflows_in_the_ai_era/` (full solutions). Real RNA-seq test data from `nf-core/test-datasets`.

## Compared to the original PR

This PR was opened in October 2025 as _Workflow Management Fundamentals_ and has been substantially restructured:

- **Renamed** to _Workflows in the AI era_, including the file path (`docs/en/docs/side_quests/workflows_in_the_ai_era/index.md`) and the runnable-asset directories. The mechanism (build in bash, rebuild in Nextflow, contrast at each step) is preserved.
- **New opening** that leads with the agent question and answers it directly, plus a **new closing section** addressing AI-authored Nextflow.
- **Each Part 1 'Reflection' rewritten** as a short observation tying back to AI-style ad-hoc execution; gushing toned down throughout per Adam's review.
- **Each Part 2 'Contrast with scripts' tip** now includes the agent-on-its-own clause, so the AI angle lands in the recovery, not just the failure.
- **Install moved out of the way of teaching**: section 3.2 is now a short _Kick off the tool install_ block; the `mamba activate` + version check is a new 3.3.7 placed right before the learner actually needs to run anything. The 3-minute install finishes invisibly while the learner reads and edits.

## Repo standards (brought up to current)

- Migrated to the `docs/en/` subtree and the dir-per-side-quest layout.
- Migrated `publishDir` -> workflow output system (`publish:` block + top-level `output {}` + `-output-dir` on the CLI). No `params.outdir` left.
- Stripped `meta` maps in favour of `tuple val(id), path(reads)`. The `metadata` side quest is the right home for maps.
- Repo heading numbering applied (`## 1.` / `### 1.1.` with trailing periods); passes `check_headings.py`.
- All em-dashes removed from prose; passes `prettier`.
- Adam's prior inline review comments (LLM-cliche line, polyglot terminology, table tidying, container-line accuracy, FASTQC paste-and-explain framing, `val(meta)` -> `val(id)`) addressed; some were already fixed in earlier commits and are now consolidated into the rewrite.

## Verified

- `nextflow lint side-quests/solutions/workflows_in_the_ai_era/` returns zero errors. (Starter copy keeps `???` placeholders; CI lints `**/solutions/*` only per `.github/workflows/nextflow-lint.yml`.)
- `uv run .github/check_headings.py` clean.
- `prettier --check` clean.
- Solution Nextflow pipeline runs end-to-end in Docker (10 tasks, ~1 min); `-resume` is a full cache hit; outputs land at `results/{fastqc,fastp,salmon}/`.
- Tutorial walkthrough using the `/run-tutorial` skill inside the `ghcr.io/nextflow-io/training:latest` container: Part 1 mamba install completes in ~3 min, fastp + salmon run on real test data; Part 2 already covered above.

## Test plan

- [ ] Render the page on the Netlify deploy preview and confirm the new opening, the kick-off section, the agent clauses in Part 2 callbacks, and the closing section read as intended.
- [ ] Walk through Part 1 in a fresh Codespace to confirm the `mamba activate` + version check at 3.3.7 lands when the install would have finished naturally.
- [ ] Walk through Part 2 in a fresh Codespace to confirm the `nextflow run main.nf -output-dir results -profile docker` flow.