### PR TITLE
Fix bug with linting results comments.

### DIFF
--- a/.github/workflows/nextflow-lint-comment.yml
+++ b/.github/workflows/nextflow-lint-comment.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           issue-number: ${{ steps.pr-info.outputs.pr_number }}
           comment-author: "github-actions[bot]"
-          body-includes: "Nextflow Lint Results"
+          body-includes: "Nextflow linting complete!"
 
       - name: Create or update PR comment
         uses: peter-evans/create-or-update-comment@v4


### PR DESCRIPTION
Action should update existing comments instead of posting new ones, but there was an error from it looking for some outdated text which was changed. Merging this should stop it from posting new comments each time a new commit is pushed to a PR.