### PR TITLE
Improve motivation for workflow-level output{} block

### DIFF
--- a/docs/hello_nextflow/01_hello_world.md
+++ b/docs/hello_nextflow/01_hello_world.md
@@ -588,7 +588,7 @@ We'll show you how to use them in due time in your Nextflow journey.
 
 ### 2.4. (FYI) Process-level `publishDir` directive
 
-Until very recently, the established way to publish outputs was to do it at the level of each individual process using a `publishDir` directive.
+Until recently, the established way to publish outputs was to do it at the level of each individual process using a `publishDir` directive.
 
 To achieve what we just did for the outputs of the `sayHello` process, we would have instead added the following line to the process definition:
 
@@ -607,8 +607,15 @@ process sayHello {
 }
 ```
 
-You will still find this code pattern all over the place in older Nextflow pipelines and process modules, so it's important to be aware of it.
-However, we do not recommend using it in any new work as it will eventually be disallowed in future versions of the Nextflow language.
+You will still find this code pattern in older Nextflow pipelines and process modules, so it's important to recognize it.
+However, we recommend using the workflow-level `output {}` block for new work.
+
+**Why workflow-level outputs are better:**
+
+The `output {}` block requires more lines of code, but provides meaningful benefits:
+
+- **Separation of concerns**: Processes handle computation; workflows decide where outputs go. A process shouldn't dictate where its results are published—that's the workflow's job.
+- **Visibility**: With `publishDir`, output logic gets scattered across many files. In a complex pipeline, understanding where results end up requires searching through every process definition and config file. With workflow-level outputs, all publishing decisions are in one place.
 
 ### Takeaway
 

--- a/docs/hello_nextflow/03_hello_workflow.md
+++ b/docs/hello_nextflow/03_hello_workflow.md
@@ -272,8 +272,9 @@ Once again, the logic is the same as before.
 This shows you that you can control the output settings at a very granular level, for every individual output.
 Feel free to try changing the paths or the publish mode for one of the processes to see what happens.
 
-Of course, that does mean we're repeating some information here, which could become inconvenient if we wanted to update the location for all the outputs in the same way.
-Later in the course, you'll learn how to configure these settings for multiple outputs in a structured way.
+This does mean writing more lines than a process-level `publishDir` would require.
+The trade-off is worth it: deciding where outputs go is the workflow's job, not the process's, and having all output settings in one place makes the pipeline's structure easier to understand.
+Later in the course, you'll see how to configure these settings for multiple outputs in a structured way.
 
 ### 1.6. Run the workflow with `-resume`
 


### PR DESCRIPTION
## Summary

Addresses feedback that the `output {}` block's verbosity compared to `publishDir` is not compellingly motivated in the training materials.

Uses framing from live teaching: "it's really the workflow's job to decide where outputs should be published. It shouldn't really be done by a process."

## Changes

| File | Section | Change |
|------|---------|--------|
| `docs/hello_nextflow/01_hello_world.md` | 2.4 (FYI) Process-level publishDir | Reframed benefits around separation of concerns and scattered logic problem |
| `docs/hello_nextflow/03_hello_workflow.md` | 1.5.2 Update the output block | Simplified trade-off explanation using "workflow's job" framing |

## Before

Part 1:
> "You will still find this code pattern all over the place in older Nextflow pipelines and process modules, so it's important to be aware of it. However, we do not recommend using it in any new work as it will eventually be disallowed in future versions of the Nextflow language."

Part 3:
> "Of course, that does mean we're repeating some information here, which could become inconvenient if we wanted to update the location for all the outputs in the same way."

## After

Part 1 now explains using "workflow's job" framing:
> **Why workflow-level outputs are better:**
> - **Separation of concerns**: Processes handle computation; workflows decide where outputs go. A process shouldn't dictate where its results are published—that's the workflow's job.
> - **Visibility**: With `publishDir`, output logic gets scattered across many files. In a complex pipeline, understanding where results end up requires searching through every process definition and config file. With workflow-level outputs, all publishing decisions are in one place.

Part 3 now uses concise trade-off explanation:
> "This does mean writing more lines than a process-level publishDir would require. The trade-off is worth it: deciding where outputs go is the workflow's job, not the process's, and having all output settings in one place makes the pipeline's structure easier to understand."

## Testing

- [x] No functional changes to code
- [x] Documentation reads clearly
- [x] Framing tested in live teaching session

🤖 Generated with [Claude Code](https://claude.ai/claude-code)