### PR TITLE
Add Portuguese translation for Hello Nextflow course

### DIFF
--- a/docs/pt/docs/envsetup/01_setup.md
+++ b/docs/pt/docs/envsetup/01_setup.md
@@ -1,0 +1,111 @@
+# GitHub Codespaces
+
+GitHub Codespaces é uma plataforma baseada na web que nos permite fornecer um ambiente pré-configurado para treinamento, suportado por máquinas virtuais na nuvem.
+A plataforma é operada pelo GitHub (que pertence à Microsoft) e está acessível gratuitamente (com cotas de uso) para qualquer pessoa com uma conta GitHub.
+
+!!! warning "Aviso"
+
+    Contas vinculadas a organizações podem estar sujeitas a certas restrições adicionais.
+    Se esse for o seu caso, você pode precisar usar uma conta pessoal independente ou usar uma instalação local.
+
+## Criando uma conta GitHub
+
+Você pode criar uma conta GitHub gratuita na [página inicial do GitHub](https://github.com/).
+
+## Iniciando seu GitHub Codespace
+
+Depois de fazer login no GitHub, abra este link no seu navegador para abrir o ambiente de treinamento Nextflow: <https://codespaces.new/nextflow-io/training?quickstart=1&ref=master>
+
+Como alternativa, você pode clicar no botão mostrado abaixo, que é repetido em cada curso de treinamento (normalmente na página de Orientação).
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
+
+Você deve ver uma página onde pode criar um novo GitHub Codespace:
+
+![Create a GitHub Codespace](img/codespaces_create.png)
+
+### Configuração
+
+Para uso geral, você não deve precisar configurar nada.
+A menos que seja especificado de outra forma no curso que você está iniciando, você pode simplesmente clicar no botão principal para continuar.
+
+No entanto, é possível personalizar o ambiente clicando no botão "Change options".
+
+??? info "Opções de configuração"
+
+    Se você clicar no botão "Change options", terá a opção de personalizar o seguinte:
+
+    #### Branch
+
+    Isso permite que você selecione uma versão diferente dos materiais de treinamento.
+    O branch `master` geralmente contém correções de bugs e materiais que foram desenvolvidos e aprovados recentemente, mas ainda não foram lançados no site.
+    Outros branches contêm trabalhos em andamento que podem não estar totalmente funcionais.
+
+    #### Machine type
+
+    Isso permite que você personalize a máquina virtual que usará para trabalhar no treinamento.
+
+    Usar uma máquina com mais núcleos permite aproveitar melhor a capacidade do Nextflow de paralelizar a execução do fluxo de trabalho.
+    No entanto, isso consumirá sua cota gratuita mais rapidamente, então não recomendamos alterar esta configuração, a menos que seja aconselhado nas instruções do curso que você planeja fazer.
+
+    Veja 'Cotas do GitHub Codespaces' abaixo para mais detalhes sobre cotas.
+
+### Tempo de inicialização
+
+Abrir um novo ambiente GitHub Codespaces pela primeira vez pode levar vários minutos, porque o sistema precisa configurar sua máquina virtual, então não se preocupe se houver um tempo de espera.
+No entanto, não deve levar mais de cinco minutos.
+
+## Navegando pela interface de treinamento
+
+Depois que seu GitHub Codespaces carregar, você deve ver algo semelhante ao seguinte (que pode abrir no modo claro, dependendo das preferências da sua conta):
+
+![GitHub Codespaces welcome](img/codespaces_welcome.png)
+
+Esta é a interface do VSCode IDE, uma aplicação popular de desenvolvimento de código que recomendamos usar para o desenvolvimento com Nextflow.
+
+- **O editor principal** é onde o código Nextflow e outros arquivos de texto serão abertos. É aqui que você editará o código. Quando você abrir o codespace, isso mostrará uma prévia do arquivo `README.md`.
+- **O terminal** abaixo do editor principal permite executar comandos. É aqui que você executará todas as linhas de comando fornecidas nas instruções do curso.
+- **A barra lateral** permite personalizar seu ambiente e realizar tarefas básicas (copiar, colar, abrir arquivos, pesquisar, git, etc.). Por padrão, ela está aberta no explorador de arquivos, que permite navegar pelo conteúdo do repositório. Clicar em um arquivo no explorador o abrirá na janela do editor principal.
+
+Você pode ajustar as proporções relativas dos painéis da janela como preferir.
+
+<!-- TODO (future) Link to development best practices side quest? -->
+
+## Outras observações sobre o uso do GitHub Codespaces
+
+### Retomando uma sessão
+
+Depois de criar um ambiente, você pode facilmente retomá-lo ou reiniciá-lo e continuar de onde parou.
+Seu ambiente expirará após 30 minutos de inatividade e salvará suas alterações por até 2 semanas.
+
+Você pode reabrir um ambiente em <https://github.com/codespaces/>.
+Os ambientes anteriores serão listados.
+Clique em uma sessão para retomá-la.
+
+![List GitHub Codespace sessions](img/codespaces_list.png)
+
+Se você salvou a URL do seu ambiente GitHub Codespaces anterior, pode simplesmente abri-la no seu navegador.
+Como alternativa, clique no mesmo botão que você usou para criá-lo inicialmente:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
+
+Você deve ver a sessão anterior, a opção padrão é retomá-la:
+
+![Resume a GitHub Codespace](img/codespaces_resume.png)
+
+### Salvando arquivos na sua máquina local
+
+Para salvar qualquer arquivo do painel explorador, clique com o botão direito no arquivo e selecione `Download`.
+
+### Gerenciando cotas do GitHub Codespaces
+
+GitHub Codespaces oferece até 15 GB-mês de armazenamento por mês e 120 horas-núcleo por mês.
+Isso é equivalente a cerca de 60 horas de tempo de execução do ambiente padrão usando o espaço de trabalho padrão (2 núcleos, 8 GB de RAM e 32 GB de armazenamento).
+
+Você pode criá-los com mais recursos (veja a explicação acima), mas isso consumirá seu uso gratuito mais rapidamente e você terá menos horas de acesso a este espaço.
+Por exemplo, se você selecionar uma máquina de 4 núcleos em vez do padrão de 2 núcleos, sua cota se esgotará na metade do tempo.
+
+Opcionalmente, você pode comprar acesso a mais recursos.
+
+Para mais informações, consulte a documentação do GitHub:
+[About billing for GitHub Codespaces](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-codespaces/about-billing-for-github-codespaces)

--- a/docs/pt/docs/envsetup/02_local.md
+++ b/docs/pt/docs/envsetup/02_local.md
@@ -1,0 +1,60 @@
+# Instalação manual
+
+É possível instalar tudo o que você precisa para executar o treinamento no seu próprio ambiente local manualmente.
+
+Aqui documentamos como fazer isso em sistemas compatíveis com POSIX padrão (assumindo uma máquina pessoal como um laptop).
+Tenha em mente que alguns detalhes podem ser diferentes dependendo do seu sistema específico.
+
+!!! tip "Dica"
+
+    Antes de prosseguir, você considerou usar a [abordagem de Devcontainers](03_devcontainer.md)?
+    Ela fornece todas as ferramentas e dependências necessárias sem exigir instalação manual.
+
+## Requisitos gerais de software
+
+Nextflow pode ser usado em qualquer sistema compatível com POSIX (Linux, macOS, Windows Subsystem for Linux, etc.) com Java instalado.
+Nossos cursos de treinamento têm alguns requisitos adicionais.
+
+No total, você precisará ter o seguinte software instalado:
+
+- Bash ou shell equivalente
+- [Java 11 (ou posterior, até 21)](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
+- [Git](https://git-scm.com/)
+- [Docker](https://docs.docker.com/get-docker/)
+- [Conda](https://conda.io/) 4.5 (ou posterior)
+- [VSCode](https://code.visualstudio.com) com a [extensão Nextflow](https://www.nextflow.io/docs/latest/developer-env.html#devenv-nextflow)
+
+A aplicação VSCode é tecnicamente opcional, mas recomendamos fortemente que você a use para trabalhar nos cursos, bem como para seu trabalho de desenvolvimento em Nextflow em geral.
+
+O manual de documentação do Nextflow fornece instruções para instalar essas dependências em [Environment setup](https://www.nextflow.io/docs/latest/developer-env.html).
+
+## Nextflow e ferramentas nf-core
+
+Você precisará instalar o próprio Nextflow, mais as ferramentas nf-core, conforme detalhado nos artigos vinculados abaixo:
+
+- [Instalação do Nextflow](https://www.nextflow.io/docs/latest/install.html)
+- [Ferramentas nf-core](https://nf-co.re/docs/nf-core-tools/installation)
+
+Recomendamos usar a opção de auto-instalação para Nextflow e a opção PyPI para ferramentas nf-core.
+
+!!! warning "Aviso"
+
+    <!-- Any update to this content needs to be copied to the home page -->
+    **A partir de janeiro de 2026, todos os nossos cursos de treinamento em Nextflow requerem Nextflow versão 25.10.2 ou posterior, com sintaxe v2 estrita ativada, salvo indicação em contrário.**
+
+    Para mais informações sobre requisitos de versão e sintaxe v2 estrita, consulte o guia [Versões do Nextflow](../info/nxf_versions.md).
+
+    Versões mais antigas do material de treinamento correspondentes à sintaxe anterior estão disponíveis através do seletor de versão na barra de menu desta página web.
+
+## Materiais de treinamento
+
+A maneira mais fácil de baixar os materiais de treinamento é clonar o repositório inteiro usando este comando:
+
+```bash
+git clone https://github.com/nextflow-io/training.git
+```
+
+Cada curso tem seu próprio diretório.
+Para trabalhar em um curso, abra uma janela de terminal (idealmente, de dentro da aplicação VSCode) e use `cd` para entrar no diretório relevante.
+
+Você pode então seguir as instruções do curso fornecidas no site.

--- a/docs/pt/docs/envsetup/03_devcontainer.md
+++ b/docs/pt/docs/envsetup/03_devcontainer.md
@@ -1,0 +1,106 @@
+# Devcontainers Locais
+
+Se você tem uma instalação local do Docker ou está disposto a instalar uma, a maneira mais fácil de trabalhar localmente com esses materiais é usar o recurso de devcontainer do Visual Studio Code. Essa abordagem fornece todas as ferramentas e dependências necessárias sem exigir instalação manual.
+
+## Requisitos
+
+Para usar a configuração de devcontainer local, você precisará de:
+
+- [Visual Studio Code](https://code.visualstudio.com/)
+- Uma instalação local do Docker, por exemplo:
+  - [Docker Desktop](https://docs.docker.com/get-docker/) (para Windows/macOS)
+  - [Docker Engine](https://docs.docker.com/engine/install/) (para Linux)
+  - [Colima](https://github.com/abiosoft/colima) (alternativa para macOS)
+- [Docker Buildx](https://docs.docker.com/build/concepts/overview/#install-buildx) (incluído no Docker Desktop, mas pode precisar de instalação separada com outras configurações do Docker)
+- [Extensão Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) para VS Code
+
+Sua instalação do Docker deve estar em execução antes de você tentar abrir o devcontainer.
+
+Para verificar se o Docker buildx está disponível, execute:
+
+```bash
+docker buildx version
+```
+
+Se este comando falhar, você precisará instalar a extensão buildx antes de prosseguir.
+
+## Instruções de Configuração
+
+Siga estas etapas para configurar seu ambiente local usando devcontainers do VS Code:
+
+### Instalar a extensão "Dev Containers" no VS Code
+
+- Abra o VS Code
+- Vá para Extensões (Ctrl+Shift+X ou Cmd+Shift+X no macOS)
+- Pesquise por "Dev Containers"
+- Clique em "Install"
+
+![Instalando a extensão Dev Containers no VS Code](img/install_extension.png)
+
+### Clone o repositório:
+
+```bash
+git clone https://github.com/nextflow-io/training.git
+cd training
+```
+
+### Abra o repositório no VS Code:
+
+- Inicie o VS Code
+- Selecione **File -> Open Folder** no menu
+- Navegue até e selecione a pasta do repositório de treinamento que você acabou de clonar
+- Clique em **Open**
+
+### Reabrir no Contêiner
+
+Se solicitado pelo VS Code para "Reopen in Container", clique nele. Alternativamente:
+
+- Pressione F1 (ou Ctrl+Shift+P / Cmd+Shift+P no macOS)
+- Digite "Dev Containers: Reopen in Container"
+- **Importante**: Quando solicitado a selecionar uma configuração, escolha a configuração de devcontainer **local-dev**
+
+![Prompt Reopen in Container](img/reopen_prompt.png)
+
+![Selecionando configuração local](img/select_local_config.png)
+
+Aguarde a construção do contêiner. Isso pode levar alguns minutos na primeira vez, pois ele baixa e configura todos os componentes necessários.
+
+Uma vez que o contêiner esteja construído e em execução, você terá um ambiente totalmente configurado com todas as ferramentas necessárias instaladas, incluindo:
+
+- Java
+- Nextflow
+- Docker
+- Git
+- E todas as outras dependências necessárias para o treinamento
+
+![VS Code com devcontainer em execução](img/running_container.png)
+
+## Benefícios de Usar Devcontainers
+
+Usar a abordagem de devcontainer oferece várias vantagens:
+
+- **Consistência**: Garante um ambiente de desenvolvimento consistente em diferentes máquinas
+- **Simplicidade**: Todas as dependências são pré-instaladas e configuradas
+- **Isolamento**: O ambiente de desenvolvimento é isolado do seu sistema local
+- **Reprodutibilidade**: Todos que usam o devcontainer obtêm a mesma configuração
+- **Sem instalação manual**: Não é necessário instalar manualmente Java, Nextflow e outras ferramentas
+
+## Verificando Seu Ambiente
+
+Uma vez que seu devcontainer esteja em execução, você pode verificar se tudo está configurado corretamente executando:
+
+```bash
+nextflow info
+```
+
+Isso deve exibir a versão do Nextflow e informações de tempo de execução, confirmando que seu ambiente está configurado corretamente.
+
+## Solução de Problemas
+
+Se você encontrar problemas com a configuração do devcontainer:
+
+1. Certifique-se de que sua instalação do Docker (Docker Desktop, Colima, Docker Engine, etc.) está em execução antes de abrir o devcontainer
+2. Verifique se você selecionou a configuração **local-dev** quando solicitado
+3. Verifique se o Docker buildx está instalado e funcionando executando `docker buildx version`
+4. Se o contêiner falhar ao construir, tente reconstruí-lo executando o comando "Dev Containers: Rebuild Container"
+5. Para problemas persistentes, consulte o [guia de solução de problemas do VS Code Dev Containers](https://code.visualstudio.com/docs/devcontainers/troubleshooting)

--- a/docs/pt/docs/envsetup/index.md
+++ b/docs/pt/docs/envsetup/index.md
@@ -1,0 +1,51 @@
+---
+title: Opções de ambiente
+description: Opções para configurar seu ambiente para os treinamentos Nextflow
+hide:
+  - toc
+  - footer
+---
+
+# Opções de ambiente
+
+Nosso objetivo é fornecer um ambiente consistente e completamente testado que permita aos alunos se concentrarem em aprender Nextflow sem ter que gastar tempo e esforço gerenciando software.
+Para isso, desenvolvemos um ambiente em contêiner que contém todo o software necessário, arquivos de código e dados de exemplo para trabalhar em todos os nossos cursos.
+
+Este ambiente em contêiner pode ser executado diretamente no Github Codespaces ou localmente no VS Code com a extensão Devcontainers.
+
+<div class="grid cards" markdown>
+
+-   :material-cloud-outline:{ .lg .middle } __Github Codespaces__
+
+    ---
+
+    GitHub Codespaces é um serviço baseado na web que nos permite fornecer um ambiente pré-construído para treinamento, com todas as ferramentas e dados incluídos, apoiado por máquinas virtuais na nuvem. É acessível gratuitamente para qualquer pessoa com uma conta Github.
+
+    [Usar Github Codespaces:material-arrow-right:](01_setup.md){ .md-button .md-button--primary .mt-1 }
+
+-   :material-laptop:{ .lg .middle } __Devcontainers Locais__
+
+    ---
+
+    VS Code com Devcontainers fornece um ambiente de desenvolvimento em contêiner executado localmente com todas as ferramentas de treinamento pré-configuradas. Oferece o mesmo ambiente pré-construído do Codespaces, mas executando inteiramente em seu hardware local.
+
+    [Usar Devcontainers localmente :material-arrow-right:](03_devcontainer.md){ .md-button .md-button--primary .mt-1 }
+
+</div>
+
+## Instruções para instalação manual
+
+Se nenhuma das opções acima atender às suas necessidades, você pode replicar este ambiente em seu próprio sistema local instalando as dependências de software manualmente e clonando o repositório de treinamento.
+
+[Instalação manual :material-arrow-right:](02_local.md){ .md-button .md-button--primary .mt-1 }
+
+---
+
+!!! info "Descontinuação do Gitpod"
+
+    O Treinamento Nextflow costumava usar o [Gitpod](https://gitpod.io) até fevereiro de 2025.
+    No entanto, os criadores do Gitpod decidiram encerrar a funcionalidade gratuita em favor do sistema [Gitpod Flex](https://www.gitpod.io/blog/introducing-gitpod-flex).
+    Por esse motivo, mudamos para o uso do GitHub Codespaces, que também oferece um ambiente de desenvolvimento com um clique, sem configuração prévia.
+
+    Dependendo de quando você se cadastrou no Gitpod e quando exatamente eles encerrarem o serviço, você ainda pode conseguir iniciar o treinamento em seu antigo IDE na nuvem, embora não possamos garantir acesso confiável daqui para frente:
+    [Abrir no Gitpod](https://gitpod.io/#https://github.com/nextflow-io/training).

--- a/docs/pt/docs/hello_nextflow/00_orientation.md
+++ b/docs/pt/docs/hello_nextflow/00_orientation.md
@@ -1,0 +1,135 @@
+# Começando
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/G3CV-FcV-rc?si=nyLvwhrSB2m1NPc5&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Veja [a playlist completa](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) no canal do Nextflow no YouTube.
+
+:green_book: A transcrição do vídeo está disponível [aqui](./transcripts/00_orientation.md).
+///
+
+!!! tip "Dica"
+
+    Os vídeos do YouTube têm alguns superpoderes!
+
+    - :fontawesome-solid-closed-captioning: Legendas de alta qualidade (manualmente curadas). Ative-as com o ícone :material-subtitles:
+    - :material-bookmark: Capítulos de vídeo na linha do tempo que correspondem aos títulos das páginas.
+
+## Inicie um ambiente de treinamento
+
+Para usar o ambiente pré-construído que fornecemos no GitHub Codespaces, clique no botão "Open in GitHub Codespaces" abaixo. Para outras opções, consulte [Opções de ambiente](../envsetup/index.md).
+
+Recomendamos abrir o ambiente de treinamento em uma nova aba ou janela do navegador (use clique com botão direito, ctrl-clique ou cmd-clique dependendo do seu equipamento) para que você possa continuar lendo enquanto o ambiente carrega.
+Você precisará manter essas instruções abertas em paralelo para acompanhar o curso.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
+
+### Noções básicas do ambiente
+
+Este ambiente de treinamento contém todo o software, código e dados necessários para trabalhar no curso de treinamento, então você não precisa instalar nada por conta própria.
+
+O codespace é configurado com uma interface VSCode, que inclui um explorador de sistema de arquivos, um editor de código e um terminal shell.
+Todas as instruções dadas durante o curso (por exemplo, 'abra o arquivo', 'edite o código' ou 'execute este comando') se referem a essas três partes da interface do VSCode, salvo indicação em contrário.
+
+Se você está trabalhando neste curso por conta própria, por favor, familiarize-se com as [noções básicas do ambiente](../envsetup/01_setup.md) para mais detalhes.
+
+### Requisitos de versão
+
+Este treinamento é projetado para Nextflow 25.10.2 ou posterior **com o analisador de sintaxe v2 ATIVADO**.
+Se você está usando um ambiente local ou personalizado, certifique-se de estar usando as configurações corretas conforme documentado [aqui](../info/nxf_versions.md).
+
+## Prepare-se para trabalhar
+
+Assim que seu codespace estiver em execução, há duas coisas que você precisa fazer antes de mergulhar no treinamento: definir seu diretório de trabalho para este curso específico e dar uma olhada nos materiais fornecidos.
+
+### Defina o diretório de trabalho
+
+Por padrão, o codespace abre com o diretório de trabalho definido na raiz de todos os cursos de treinamento, mas para este curso, trabalharemos no diretório `hello-nextflow/`.
+
+Mude de diretório agora executando este comando no terminal:
+
+```bash
+cd hello-nextflow/
+```
+
+Você pode configurar o VSCode para focar neste diretório, de modo que apenas os arquivos relevantes apareçam na barra lateral do explorador de arquivos:
+
+```bash
+code .
+```
+
+!!! tip "Dica"
+
+    Se por algum motivo você sair deste diretório (por exemplo, seu codespace adormecer), você pode sempre usar o caminho completo para retornar a ele, assumindo que você está executando isso dentro do ambiente de treinamento do GitHub Codespaces:
+
+    ```bash
+    cd /workspaces/training/hello-nextflow
+    ```
+
+Agora vamos dar uma olhada no conteúdo.
+
+### Explore os materiais fornecidos
+
+Você pode explorar o conteúdo deste diretório usando o explorador de arquivos no lado esquerdo do espaço de trabalho de treinamento.
+Alternativamente, você pode usar o comando `tree`.
+
+Ao longo do curso, usamos a saída do `tree` para representar a estrutura e o conteúdo do diretório de forma legível, às vezes com pequenas modificações para maior clareza.
+
+Aqui geramos um índice até o segundo nível:
+
+```bash
+tree . -L 2
+```
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    .
+    ├── data
+    │   └── greetings.csv
+    ├── hello-channels.nf
+    ├── hello-config.nf
+    ├── hello-containers.nf
+    ├── hello-modules.nf
+    ├── hello-workflow.nf
+    ├── hello-world.nf
+    ├── nextflow.config
+    ├── solutions
+    │   ├── 1-hello-world
+    │   ├── 2-hello-channels
+    │   ├── 3-hello-workflow
+    │   ├── 4-hello-modules
+    │   ├── 5-hello-containers
+    │   └── 6-hello-config
+    ├── test-params.json
+    └── test-params.yaml
+    ```
+
+Clique na caixa colorida para expandir a seção e visualizar seu conteúdo.
+Usamos seções recolhíveis como esta para incluir a saída esperada do comando de forma concisa.
+
+- **Os arquivos `.nf`** são scripts de fluxo de trabalho que são nomeados com base em qual parte do curso eles são usados.
+
+- **O arquivo `nextflow.config`** é um arquivo de configuração que define propriedades mínimas do ambiente.
+  Você pode ignorá-lo por enquanto.
+
+- **O arquivo `greetings.csv`** em `data/` contém dados de entrada que usaremos na maior parte do curso. Ele é descrito na Parte 2 (Canais), quando o introduzimos pela primeira vez.
+
+- **Os arquivos `test-params.*`** são arquivos de configuração que usaremos na Parte 6 (Configuração). Você pode ignorá-los por enquanto.
+
+- **O diretório `solutions`** contém os scripts de fluxo de trabalho completos que resultam de cada etapa do curso.
+  Eles são destinados a serem usados como referência para verificar seu trabalho e solucionar quaisquer problemas.
+
+## Lista de verificação de prontidão
+
+Acha que está pronto para mergulhar?
+
+- [ ] Eu entendo o objetivo deste curso e seus pré-requisitos
+- [ ] Meu ambiente está funcionando
+- [ ] Eu defini meu diretório de trabalho apropriadamente
+
+Se você pode marcar todas as caixas, está pronto para começar.
+
+**Para continuar para a [Parte 1: Hello World](./01_hello_world.md), clique na seta no canto inferior direito desta página.**

--- a/docs/pt/docs/hello_nextflow/01_hello_world.md
+++ b/docs/pt/docs/hello_nextflow/01_hello_world.md
@@ -1,0 +1,1224 @@
+# Parte 1: Hello World
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/8X2hHI-9vms?si=F0t9LFYLjAWoyRXj&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Veja [a playlist completa](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) no canal do Nextflow no YouTube.
+
+:green_book: A transcrição do vídeo está disponível [aqui](./transcripts/01_hello_world.md).
+///
+
+Nesta primeira parte do curso de treinamento Hello Nextflow, começamos com um exemplo Hello World muito básico e independente de domínio, que vamos construir progressivamente para demonstrar o uso da lógica e componentes fundamentais do Nextflow.
+
+??? info "O que é um exemplo Hello World?"
+
+    Um "Hello World!" é um exemplo minimalista que tem como objetivo demonstrar a sintaxe e estrutura básicas de uma linguagem de programação ou framework de software.
+    O exemplo geralmente consiste em imprimir a frase "Hello, World!" no dispositivo de saída, como o console ou terminal, ou escrevê-la em um arquivo.
+
+---
+
+## 0. Aquecimento: Execute um exemplo Hello World diretamente
+
+Vamos demonstrar isso com um comando simples que executamos diretamente no terminal, para mostrar o que ele faz antes de encapsulá-lo no Nextflow.
+
+!!! tip "Dica"
+
+    Lembre-se de que você deve estar dentro do diretório `hello-nextflow/` conforme descrito na página [Primeiros Passos](00_orientation.md).
+
+### 0.1. Faça o terminal dizer olá
+
+Execute o seguinte comando no seu terminal.
+
+```bash
+echo 'Hello World!'
+```
+
+??? success "Saída do comando"
+
+    ```console
+    Hello World!
+    ```
+
+Isso exibe o texto 'Hello World' diretamente no terminal.
+
+### 0.2. Escreva a saída em um arquivo
+
+A execução de pipelines envolve principalmente a leitura de dados de arquivos e a escrita de resultados em outros arquivos, então vamos modificar o comando para escrever a saída de texto em um arquivo para tornar o exemplo um pouco mais relevante.
+
+```bash
+echo 'Hello World!' > output.txt
+```
+
+??? success "Saída do comando"
+
+    ```console
+
+    ```
+
+Isso não exibe nada no terminal.
+
+### 0.3. Encontre a saída
+
+O texto 'Hello World' agora deve estar no arquivo de saída que especificamos, chamado `output.txt`.
+Você pode abri-lo no explorador de arquivos ou pela linha de comando usando o utilitário `cat`, por exemplo.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="output.txt" linenums="1"
+    Hello World!
+    ```
+
+Isso é o que vamos tentar replicar com nosso primeiro fluxo de trabalho Nextflow.
+
+### Resumo
+
+Você agora sabe como executar um comando simples no terminal que exibe algum texto e, opcionalmente, como fazer com que ele escreva a saída em um arquivo.
+
+### O que vem a seguir?
+
+Descubra como isso ficaria escrito como um fluxo de trabalho Nextflow.
+
+---
+
+## 1. Examine o script e execute-o
+
+Fornecemos um script de fluxo de trabalho totalmente funcional, embora minimalista, chamado `hello-world.nf` que faz a mesma coisa que antes (escrever 'Hello World!'), mas com Nextflow.
+
+Para começar, vamos abrir o script do fluxo de trabalho para que você tenha uma noção de como ele está estruturado.
+Então vamos executá-lo e procurar suas saídas.
+
+### 1.1. Examine o código
+
+Você encontrará o script `hello-world.nf` no seu diretório atual, que deve ser `hello-nextflow`. Abra-o no painel do editor.
+
+??? full-code "Arquivo de código completo"
+
+    ```groovy title="hello-world.nf" linenums="1"
+    #!/usr/bin/env nextflow
+
+    /*
+    * Use echo to print 'Hello World!' to a file
+    */
+    process sayHello {
+
+        output:
+        path 'output.txt'
+
+        script:
+        """
+        echo 'Hello World!' > output.txt
+        """
+    }
+
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello()
+    }
+    ```
+
+Um script de fluxo de trabalho Nextflow normalmente inclui uma ou mais definições de **processo** e o **fluxo de trabalho** em si, além de alguns blocos opcionais (não presentes aqui) que apresentaremos mais tarde.
+
+Cada **processo** descreve quais operações a etapa correspondente no pipeline deve realizar, enquanto o **fluxo de trabalho** descreve a lógica de fluxo de dados que conecta as várias etapas.
+
+Vamos examinar primeiro o bloco **processo** e depois veremos o bloco **fluxo de trabalho**.
+
+#### 1.1.1. A definição de `process`
+
+O primeiro bloco de código descreve um **processo**.
+
+A definição do processo começa com a palavra-chave `process`, seguida pelo nome do processo e finalmente o corpo do processo delimitado por chaves.
+O corpo do processo deve conter um bloco script que especifica o comando a ser executado, que pode ser qualquer coisa que você seria capaz de executar em um terminal de linha de comando.
+
+```groovy title="hello-world.nf" linenums="3"
+/*
+* Use echo to print 'Hello World!' to a file
+*/
+process sayHello {
+
+    output:
+    path 'output.txt'
+
+    script:
+    """
+    echo 'Hello World!' > output.txt
+    """
+}
+```
+
+Aqui temos um **processo** chamado `sayHello` que escreve sua **saída** em um arquivo chamado `output.txt`.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_world.svg"
+</figure>
+
+Esta é uma definição de processo muito mínima que contém apenas uma definição de `output` e o `script` a ser executado.
+
+A definição de `output` inclui o qualificador `path`, que diz ao Nextflow que isso deve ser tratado como um caminho (inclui tanto caminhos de diretório quanto arquivos).
+Outro qualificador comum é `val`.
+
+É importante notar que a definição de saída não _determina_ qual saída será criada.
+Ela simplesmente _declara_ qual é a saída esperada, para que o Nextflow possa procurá-la assim que a execução estiver completa.
+Isso é necessário para verificar se o comando foi executado com sucesso e para passar a saída para processos subsequentes, se necessário. A saída produzida que não corresponder ao que está declarado no bloco de saída não será passada para processos subsequentes.
+
+!!! warning "Aviso"
+
+    Este exemplo é frágil porque codificamos o nome do arquivo de saída em dois lugares separados (o script e os blocos de saída).
+    Se mudarmos um mas não o outro, o script vai falhar.
+    Mais tarde, você aprenderá maneiras de usar variáveis para mitigar esse problema.
+
+Em um pipeline do mundo real, um processo geralmente contém blocos adicionais como diretivas e entradas, que apresentaremos em breve.
+
+#### 1.1.2. A definição de `workflow`
+
+O segundo bloco de código descreve o **fluxo de trabalho** em si.
+A definição de fluxo de trabalho começa com a palavra-chave `workflow`, seguida por um nome opcional, depois o corpo do fluxo de trabalho delimitado por chaves.
+
+Aqui temos um **fluxo de trabalho** que consiste em um bloco `main:` (que diz 'este é o corpo principal do fluxo de trabalho') contendo uma chamada ao processo `sayHello`.
+
+```groovy title="hello-world.nf" linenums="17"
+workflow {
+
+    main:
+    // emit a greeting
+    sayHello()
+}
+```
+
+Esta é uma definição de **fluxo de trabalho** muito mínima.
+Em um pipeline do mundo real, o fluxo de trabalho geralmente contém múltiplas chamadas a **processos** conectados por **canais**, e os processos esperam uma ou mais **entradas** variáveis.
+
+Você aprenderá como adicionar entradas variáveis mais tarde neste módulo de treinamento; e aprenderá como adicionar mais processos e conectá-los por canais na Parte 3 deste curso.
+
+!!! tip "Dica"
+
+    Tecnicamente, a linha `main:` não é necessária para fluxos de trabalho simples como este, então você pode encontrar fluxos de trabalho que não a tenham.
+    Mas precisaremos dela para aproveitar as saídas em nível de fluxo de trabalho, então podemos incluí-la desde o início.
+
+### 1.2. Execute o fluxo de trabalho
+
+Olhar para o código não é tão divertido quanto executá-lo, então vamos experimentar isso na prática.
+
+#### 1.2.1. Lance o fluxo de trabalho e monitore a execução
+
+No terminal, execute o seguinte comando:
+
+```bash
+nextflow run hello-world.nf
+```
+
+??? success "Saída do comando"
+
+    ```console hl_lines="7"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [goofy_torvalds] DSL2 - revision: c33d41f479
+
+    executor >  local (1)
+    [65/7be2fa] sayHello | 1 of 1 ✔
+    ```
+
+Se a saída do seu console se parece com isso, então parabéns, você acabou de executar seu primeiro fluxo de trabalho Nextflow!
+
+A saída mais importante aqui é a última linha, que está destacada na saída acima:
+
+```console
+[65/7be2fa] sayHello | 1 of 1 ✔
+```
+
+Isso nos diz que o processo `sayHello` foi executado com sucesso uma vez (`1 of 1 ✔`).
+
+É importante notar que esta linha também informa onde encontrar a saída da chamada do processo `sayHello`.
+Vamos ver isso agora.
+
+#### 1.2.2. Encontre a saída e os logs no diretório `work`
+
+Quando você executa o Nextflow pela primeira vez em um determinado diretório, ele cria um diretório chamado `work` onde escreverá todos os arquivos (e quaisquer links simbólicos) gerados durante a execução.
+
+Dentro do diretório `work`, o Nextflow organiza saídas e logs por chamada de processo.
+Para cada chamada de processo, o Nextflow cria um subdiretório aninhado, nomeado com um hash para torná-lo único, onde preparará todas as entradas necessárias (usando links simbólicos por padrão), escreverá arquivos auxiliares e escreverá logs e quaisquer saídas do processo.
+
+O caminho para esse subdiretório é mostrado de forma truncada entre colchetes na saída do console.
+Olhando para o que obtivemos na execução mostrada acima, a linha de log do console para o processo sayHello começa com `[65/7be2fa]`. Isso corresponde ao seguinte caminho de diretório: `work/65/7be2fa7be2fad5e71e5f49998f795677fd68`
+
+Vamos dar uma olhada no que há lá.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    work
+    └── 65
+        └── 7be2fad5e71e5f49998f795677fd68
+            ├── .command.begin
+            ├── .command.err
+            ├── .command.log
+            ├── .command.out
+            ├── .command.run
+            ├── .command.sh
+            ├── .exitcode
+            └── output.txt
+    ```
+
+??? question "Não está vendo a mesma coisa?"
+
+    Os nomes exatos dos subdiretórios serão diferentes no seu sistema.
+
+    Se você navegar pelo conteúdo do subdiretório de tarefa no explorador de arquivos do VSCode, verá todos os arquivos imediatamente.
+    No entanto, os arquivos de log estão configurados para serem invisíveis no terminal, então se você quiser usar `ls` ou `tree` para visualizá-los, precisará definir a opção relevante para exibir arquivos invisíveis.
+
+    ```bash
+    tree -a work
+    ```
+
+A primeira coisa que você deseja ver é a saída real do fluxo de trabalho, ou seja, o arquivo `output.txt` produzido pelo processo `sayHello`.
+Abra-o e você encontrará a saudação `Hello World!`, que era o objetivo do nosso fluxo de trabalho minimalista.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="output.txt"
+    Hello World!
+    ```
+
+Funcionou!
+
+Concedido, pode parecer muito código de wrapper para um resultado tão pequeno, mas o valor de todo esse código de wrapper se tornará mais óbvio quando começarmos a ler arquivos de entrada e encadear várias etapas.
+
+Dito isso, vamos também olhar os outros arquivos naquele diretório. Esses são arquivos auxiliares e de log produzidos pelo Nextflow como parte da execução da tarefa.
+
+- **`.command.begin`**: Metadados relacionados ao início da execução da chamada do processo
+- **`.command.err`**: Mensagens de erro (`stderr`) emitidas pela chamada do processo
+- **`.command.log`**: Saída de log completa emitida pela chamada do processo
+- **`.command.out`**: Saída regular (`stdout`) pela chamada do processo
+- **`.command.run`**: Script completo executado pelo Nextflow para executar a chamada do processo
+- **`.command.sh`**: O comando que foi realmente executado pela chamada do processo
+- **`.exitcode`**: O código de saída resultante do comando
+
+O arquivo `.command.sh` é especialmente útil porque informa o comando principal que o Nextflow executou, não incluindo toda a contabilidade e configuração de tarefa/ambiente.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title=".command.sh"
+    #!/bin/bash -ue
+    echo 'Hello World!' > output.txt
+    ```
+
+Isso corresponde ao que executamos anteriormente manualmente.
+
+Neste caso é muito direto porque o comando do processo foi codificado, mas mais adiante no curso você verá comandos de processo que envolvem alguma interpolação de variáveis.
+Isso torna especialmente valioso poder ver exatamente como o Nextflow interpretou o código e qual comando foi produzido quando você está solucionando problemas de uma execução com falha.
+
+### 1.3. Execute o fluxo de trabalho novamente
+
+Tente executar novamente o fluxo de trabalho algumas vezes e depois olhe os diretórios de tarefa em `work/`.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    work
+    ├── 0f
+    │   └── 52b7e07b0e274a80843fca48ed21b8
+    │       ├── .command.begin
+    │       ├── .command.err
+    │       ├── .command.log
+    │       ├── .command.out
+    │       ├── .command.run
+    │       ├── .command.sh
+    │       ├── .exitcode
+    │       └── output.txt
+    ├── 65
+        └── 7be2fad5e71e5f49998f795677fd68
+    │   │   ├── .command.begin
+    │   │   ├── .command.err
+    │   │   ├── .command.log
+    │   │   ├── .command.out
+    │   │   ├── .command.run
+    │   │   ├── .command.sh
+    │   │   ├── .exitcode
+    │   │   └── output.txt
+    │   └── e029f2e75305874a9ab263d21ebc2c
+    │       ├── .command.begin
+    │       ├── .command.err
+    │       ├── .command.log
+    │       ├── .command.out
+    │       ├── .command.run
+    │       ├── .command.sh
+    │       ├── .exitcode
+    │       └── output.txt
+    ├── 6c
+    │   └── d4fd787e0b01b3c82e85696c297500
+    │       ├── .command.begin
+    │       ├── .command.err
+    │       ├── .command.log
+    │       ├── .command.out
+    │       ├── .command.run
+    │       ├── .command.sh
+    │       ├── .exitcode
+    │       └── output.txt
+    └── e8
+        └── ab99fad46ade52905ec973ff39bb80
+            ├── .command.begin
+            ├── .command.err
+            ├── .command.log
+            ├── .command.out
+            ├── .command.run
+            ├── .command.sh
+            ├── .exitcode
+            └── output.txt
+    ```
+
+Você verá que um novo subdiretório com um conjunto completo de arquivos de saída e log foi criado para cada execução.
+Isso mostra que executar o mesmo fluxo de trabalho várias vezes não sobrescreverá os resultados de execuções anteriores.
+
+### Resumo
+
+Você sabe como decifrar um script Nextflow simples, executá-lo e encontrar a saída e arquivos de log relevantes no diretório work.
+
+### O que vem a seguir?
+
+Aprenda como publicar as saídas do fluxo de trabalho em um local mais conveniente.
+
+---
+
+## 2. Publique saídas
+
+Como você acabou de aprender, a saída produzida pelo nosso pipeline está enterrada em um diretório de trabalho várias camadas abaixo.
+Isso é feito propositalmente; o Nextflow está no controle deste diretório e não devemos interagir com ele.
+No entanto, isso torna inconveniente recuperar saídas que nos interessam.
+
+Felizmente, o Nextflow fornece uma maneira de publicar saídas em um diretório designado usando [definições de saída em nível de fluxo de trabalho](https://www.nextflow.io/docs/latest/workflow.html#workflow-outputs).
+
+### 2.1. Uso básico
+
+Isso vai envolver dois novos pedaços de código:
+
+1. Um bloco `publish:` dentro do corpo do `workflow`, declarando saídas de processo.
+2. Um bloco `output` no script especificando opções de saída como modo e localização.
+
+#### 2.1.1. Declare a saída do processo `sayHello`
+
+Precisamos adicionar um bloco `publish:` ao corpo do fluxo de trabalho (mesmo tipo de elemento de código que o bloco `main:`) e listar a saída do processo `sayHello()`.
+
+No arquivo de script do fluxo de trabalho `hello-world.nf`, adicione as seguintes linhas de código:
+
+=== "Depois"
+
+    ```groovy title="hello-world.nf" linenums="17" hl_lines="7-8"
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello()
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-world.nf" linenums="17"
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello()
+    }
+    ```
+
+Você vê que podemos nos referir à saída do processo simplesmente fazendo `sayHello().out`, e atribuir a ela um nome arbitrário, `first_output`.
+
+#### 2.1.2. Adicione um bloco `output:` ao script
+
+Agora só precisamos adicionar o bloco `output:` onde o caminho do diretório de saída será especificado. Note que este novo bloco fica **fora** e **abaixo** do bloco `workflow` dentro do script.
+
+No arquivo de script do fluxo de trabalho `hello-world.nf`, adicione as seguintes linhas de código:
+
+=== "Depois"
+
+    ```groovy title="hello-world.nf" linenums="17" hl_lines="11-15"
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello()
+
+        publish:
+        first_output = sayHello.out
+    }
+
+    output {
+        first_output {
+            path '.'
+        }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-world.nf" linenums="17"
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello()
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Podemos usar isso para atribuir caminhos específicos a quaisquer saídas de processo declaradas no bloco `workflow`.
+Mais tarde, você aprenderá sobre maneiras de gerar estruturas sofisticadas de diretório de saída, mas por enquanto, estamos apenas codificando um caminho mínimo para simplicidade.
+
+#### 2.1.3. Execute o fluxo de trabalho
+
+Agora execute o script de fluxo de trabalho modificado:
+
+```bash
+nextflow run hello-world.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [jovial_mayer] DSL2 - revision: 35bd3425e5
+
+    executor >  local (1)
+    [9f/48ef97] sayHello | 1 of 1 ✔
+    ```
+
+A saída do terminal deve parecer familiar. Externamente, nada mudou.
+
+No entanto, verifique seu explorador de arquivos: desta vez, o Nextflow criou um novo diretório chamado `results/`.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console hl_lines="10-11 22"
+    .
+    ├── greetings.csv
+    ├── hello-channels.nf
+    ├── hello-config.nf
+    ├── hello-containers.nf
+    ├── hello-modules.nf
+    ├── hello-workflow.nf
+    ├── hello-world.nf
+    ├── nextflow.config
+    ├── results
+    │   └── output.txt -> /workspaces/training/hello-nextflow/work/9f/48ef97f110b0dbd83635d7cbe288d2/output.txt
+    ├── solutions
+    │   ├── 1-hello-world
+    │   ├── 2-hello-channels
+    │   ├── 3-hello-workflow
+    │   ├── 4-hello-modules
+    │   ├── 5-hello-containers
+    │   └── 6-hello-config
+    ├── test-params.json
+    └── work
+        ├── 65
+        └── 9f
+    ```
+
+Dentro do diretório `results`, encontramos um link simbólico para o `output.txt` produzido no diretório work pelo comando que acabamos de executar.
+
+Isso nos permite recuperar facilmente arquivos de saída sem ter que vasculhar o subdiretório work.
+
+### 2.2. Defina um local personalizado
+
+Ter um local padrão é ótimo, mas você pode querer personalizar onde os resultados são salvos e como eles são organizados.
+
+Por exemplo, você pode querer organizar suas saídas em subdiretórios.
+A maneira mais simples de fazer isso é atribuir um caminho de saída específico por saída.
+
+#### 2.2.1. Modifique o caminho de saída
+
+Mais uma vez, modificar o comportamento de publicação para uma saída específica é realmente direto.
+Para definir um local personalizado, basta editar o `path` de acordo:
+
+=== "Depois"
+
+    ```groovy title="hello-world.nf" linenums="27" hl_lines="3"
+    output {
+        first_output {
+            path 'hello_world'
+        }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-world.nf" linenums="27" hl_lines="3"
+    output {
+        first_output {
+            path '.'
+        }
+    }
+    ```
+
+Como isso é definido no nível da saída individual, você pode especificar diferentes locais e subdiretórios para atender às suas necessidades.
+
+#### 2.2.2. Execute o fluxo de trabalho novamente
+
+Vamos experimentar.
+
+```bash
+nextflow run hello-world.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [tiny_shaw] DSL2 - revision: 757723adc1
+
+    executor >  local (1)
+    [8c/79499c] process > sayHello [100%] 1 of 1 ✔
+    ```
+
+Desta vez o resultado é escrito no subdiretório especificado.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console hl_lines="2-3"
+    results/
+    ├── hello_world
+    │   └── output.txt -> /workspaces/training/hello-nextflow/work/8c/79499c2e506b79e2e01acb808d9d12/output.txt
+    └── output.txt -> /workspaces/training/hello-nextflow/work/65/f56f2cd75df1352e106fcdd084b97b/output.txt
+    ```
+
+Você vê que o resultado da execução anterior ainda está lá.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_world_output.svg"
+</figure>
+
+Você pode usar quantos níveis de aninhamento desejar.
+Também é possível usar o nome do processo ou outras variáveis para nomear os diretórios usados para organizar resultados, e é possível alterar o nome padrão do diretório de saída de nível superior (que é controlado pela variável especial `outputDir`).
+Cobriremos essas opções em treinamentos posteriores.
+
+### 2.3. Defina o modo de publicação para copiar
+
+Por padrão, as saídas são publicadas como links simbólicos do diretório `work`.
+Isso significa que há apenas um único arquivo no sistema de arquivos.
+
+Isso é ótimo quando você está lidando com arquivos muito grandes, para os quais você não quer armazenar várias cópias.
+No entanto, se você excluir o diretório work em algum momento (abordaremos operações de limpeza em breve), você perderá o acesso ao arquivo.
+Portanto, você precisa ter um plano para salvar cópias de quaisquer arquivos importantes em um local seguro.
+
+Uma opção fácil é mudar o modo de publicação para copiar para as saídas que você se importa.
+
+#### 2.3.1. Adicione a diretiva mode
+
+Esta parte é realmente direta.
+Basta adicionar `mode 'copy'` à definição de saída relevante em nível de fluxo de trabalho:
+
+=== "Depois"
+
+    ```groovy title="hello-world.nf" linenums="27" hl_lines="4"
+    output {
+        first_output {
+            path 'hello_world'
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-world.nf" linenums="27"
+    output {
+        first_output {
+            path 'hello_world'
+        }
+    }
+    ```
+
+Isso define o modo de publicação para essa saída específica.
+
+#### 2.3.2. Execute o fluxo de trabalho novamente
+
+Vamos experimentar.
+
+```bash
+nextflow run hello-world.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [tiny_shaw] DSL2 - revision: 757723adc1
+
+    executor >  local (1)
+    [df/521638] process > sayHello [100%] 1 of 1 ✔
+    ```
+
+Desta vez, se você olhar os resultados, o arquivo é uma cópia adequada em vez de apenas um link simbólico.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console hl_lines="3"
+    results/
+    ├── hello_world
+    │   └── output.txt
+    └── output.txt -> /workspaces/training/hello-nextflow/work/65/f56f2cd75df1352e106fcdd084b97b/output.txt
+    ```
+
+Como isso também é definido no nível da saída individual, permite que você defina o modo de publicação de forma granular.
+Isso será especialmente útil mais tarde quando passarmos para pipelines de múltiplas etapas, onde você pode querer copiar apenas as saídas finais e deixar saídas intermediárias como links simbólicos, por exemplo.
+
+Como observado anteriormente, existem outras opções mais sofisticadas para controlar como as saídas são publicadas.
+Mostraremos como usá-las no devido tempo em sua jornada com o Nextflow.
+
+### 2.4. Nota sobre diretivas `publishDir` em nível de processo
+
+Até muito recentemente, a forma estabelecida de publicar saídas era fazê-lo no nível de cada processo individual usando uma diretiva `publishDir`.
+
+Para conseguir o que acabamos de fazer para as saídas do processo `sayHello`, teríamos adicionado a seguinte linha à definição do processo:
+
+```groovy title="hello-world.nf" linenums="6" hl_lines="3"
+process sayHello {
+
+    publishDir 'results/hello_world', mode: 'copy'
+
+    output:
+    path 'output.txt'
+
+    script:
+    """
+    echo 'Hello World!' > output.txt
+    """
+}
+```
+
+Você ainda encontrará este padrão de código por toda parte em pipelines e módulos de processo Nextflow mais antigos, por isso é importante estar ciente dele.
+No entanto, não recomendamos usá-lo em qualquer trabalho novo, pois eventualmente será proibido em versões futuras da linguagem Nextflow.
+
+### Resumo
+
+Você sabe como publicar saídas de fluxo de trabalho em um local mais conveniente.
+
+### O que vem a seguir?
+
+Aprenda a fornecer uma entrada variável via parâmetro de linha de comando e utilizar valores padrão de forma eficaz.
+
+---
+
+## 3. Use uma entrada variável passada na linha de comando
+
+Em seu estado atual, nosso fluxo de trabalho usa uma saudação codificada no comando do processo.
+Queremos adicionar alguma flexibilidade usando uma variável de entrada, para que possamos mudar mais facilmente a saudação em tempo de execução.
+
+Isso requer que façamos três conjuntos de mudanças em nosso script:
+
+1. Alterar o processo para esperar uma entrada variável
+2. Configurar um parâmetro de linha de comando para capturar a entrada do usuário
+3. Passar a entrada para o processo no corpo do fluxo de trabalho
+
+Vamos fazer essas mudanças uma de cada vez.
+
+### 3.1. Altere o processo `sayHello` para esperar uma entrada variável
+
+Precisamos editar a definição do processo para (1) aceitar uma variável de entrada e (2) usar essa variável na linha de comando.
+
+#### 3.1.1. Adicione um bloco de entrada à definição do processo
+
+Primeiro, vamos adaptar a definição do processo para aceitar uma entrada chamada `greeting`.
+
+No bloco do processo, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-world.nf" linenums="6" hl_lines="3-4"
+    process sayHello {
+
+        input:
+        val greeting
+
+        output:
+        path 'output.txt'
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-world.nf" linenums="6"
+    process sayHello {
+
+        output:
+        path 'output.txt'
+    ```
+
+A variável `greeting` é prefixada por `val` para dizer ao Nextflow que é um valor (não um caminho).
+
+#### 3.1.2. Edite o comando do processo para usar a variável de entrada
+
+Agora trocamos o valor codificado original pelo valor da variável de entrada que esperamos receber.
+
+No bloco do processo, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-world.nf" linenums="14" hl_lines="3"
+    script:
+    """
+    echo '${greeting}' > output.txt
+    """
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-world.nf" linenums="14" hl_lines="3"
+    script:
+    """
+    echo 'Hello World!' > output.txt
+    """
+    ```
+
+O símbolo `$` e as chaves (`{ }`) dizem ao Nextflow que este é um nome de variável que precisa ser substituído pelo valor de entrada real (=interpolado).
+
+!!! tip "Dica"
+
+    As chaves (`{ }`) eram tecnicamente opcionais em versões anteriores do Nextflow, então você pode ver fluxos de trabalho mais antigos onde isso está escrito como `echo '$greeting' > output.txt`.
+
+Agora que o processo `sayHello()` está pronto para aceitar uma entrada variável, precisamos de uma maneira de fornecer um valor de entrada para a chamada do processo em nível de fluxo de trabalho.
+
+### 3.2. Configure um parâmetro de linha de comando para capturar a entrada do usuário
+
+Poderíamos simplesmente codificar uma entrada diretamente fazendo a chamada do processo `sayHello('Hello World!')`.
+No entanto, quando estivermos fazendo trabalho real com nosso fluxo de trabalho, vamos querer ser capazes de controlar suas entradas a partir da linha de comando.
+
+Boa notícia: o Nextflow tem um sistema de parâmetros de fluxo de trabalho integrado chamado `params`, que facilita declarar e usar parâmetros CLI.
+
+A sintaxe geral é declarar `params.<nome_do_parâmetro>` para dizer ao Nextflow para esperar um parâmetro `--<nome_do_parâmetro>` na linha de comando.
+
+Aqui, queremos criar um parâmetro chamado `--input`, então precisamos declarar `params.input` em algum lugar no fluxo de trabalho.
+Em princípio podemos escrevê-lo em qualquer lugar; mas como vamos querer passá-lo para a chamada do processo `sayHello()`, podemos conectá-lo lá diretamente escrevendo `sayHello(params.input)`.
+
+No bloco do fluxo de trabalho, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-world.nf" linenums="23" hl_lines="2"
+    // emit a greeting
+    sayHello(params.input)
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-world.nf" linenums="23" hl_lines="2"
+    // emit a greeting
+    sayHello()
+    ```
+
+Isso diz ao Nextflow para executar o processo `sayHello` no valor fornecido através do parâmetro `--input`.
+
+Na prática, realizamos as etapas (2) e (3) descritas no início da seção de uma só vez.
+
+### 3.3. Execute o comando do fluxo de trabalho
+
+Vamos executá-lo!
+
+```bash
+nextflow run hello-world.nf --input 'Bonjour le monde!'
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [elated_lavoisier] DSL2 - revision: 7c031b42ea
+
+    executor >  local (1)
+    [4b/654319] sayHello | 1 of 1 ✔
+    ```
+
+Se você fez todas essas edições corretamente, deve obter outra execução bem-sucedida.
+
+Certifique-se de abrir o arquivo de saída para verificar se você agora tem a nova versão da saudação.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/hello_world/output.txt"
+    Bonjour le monde!
+    ```
+
+Voilà!
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_world_input.svg"
+</figure>
+
+Note como a nova execução sobrescreveu o arquivo de saída publicado no diretório `results`.
+No entanto, os resultados das execuções anteriores ainda estão preservados nos diretórios de tarefa em `work`.
+
+!!! tip "Dica"
+
+    Você pode distinguir facilmente parâmetros em nível de Nextflow de parâmetros em nível de pipeline.
+
+    - Parâmetros que se aplicam a um pipeline sempre levam um hífen duplo (`--`).
+    - Parâmetros que modificam uma configuração do Nextflow, _por exemplo_ o recurso `-resume` que usamos anteriormente, levam um hífen simples (`-`).
+
+### 3.4. Use valores padrão para parâmetros de linha de comando
+
+Ok, isso foi conveniente, mas em muitos casos, faz sentido fornecer um valor padrão para um determinado parâmetro para que você não precise especificá-lo para cada execução.
+
+#### 3.4.1. Defina um valor padrão para o parâmetro CLI
+
+Vamos dar ao parâmetro `input` um valor padrão declarando-o antes da definição do fluxo de trabalho.
+
+```groovy title="hello-world.nf" linenums="20"
+/*
+ * Pipeline parameters
+ */
+params {
+    input: String = 'Holà mundo!'
+}
+```
+
+Como você vê, podemos especificar o tipo de entrada que o fluxo de trabalho espera (Nextflow 25.10.2 e posterior).
+A sintaxe é `nome: Tipo = valor_padrão`.
+Os tipos suportados incluem `String`, `Integer`, `Float`, `Boolean` e `Path`.
+
+!!! info
+
+    Em fluxos de trabalho mais antigos, você pode ver que todo o bloco `params` está escrito como apenas `input = 'Holà mundo!'`.
+
+À medida que você adiciona mais parâmetros ao seu pipeline, deve adicioná-los todos a este bloco, quer você precise ou não dar a eles um valor padrão.
+Isso facilitará encontrar todos os parâmetros configuráveis de relance.
+
+#### 3.4.2. Execute o fluxo de trabalho novamente sem especificar o parâmetro
+
+Agora que você tem um valor padrão definido, pode executar o fluxo de trabalho novamente sem ter que especificar um valor na linha de comando.
+
+```bash
+nextflow run hello-world.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [determined_edison] DSL2 - revision: 3539118582
+
+    executor >  local (1)
+    [72/394147] sayHello | 1 of 1 ✔
+    ```
+
+A saída estará no mesmo lugar que anteriormente, mas o conteúdo deve ser atualizado com o novo texto.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/hello_world/output.txt"
+    Holà mundo!
+    ```
+
+O Nextflow usou o valor padrão do parâmetro de saudação para criar a saída.
+
+#### 3.4.3. Substitua o valor padrão
+
+Se você fornecer o parâmetro na linha de comando, o valor CLI substituirá o valor padrão.
+
+Experimente:
+
+```bash
+nextflow run hello-world.nf --input 'Konnichiwa!'
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [elegant_faraday] DSL2 - revision: 3539118582
+
+    executor >  local (1)
+    [6f/a12a91] sayHello | 1 of 1 ✔
+    ```
+
+Mais uma vez, você deve encontrar a saída atualizada correspondente no seu diretório de resultados.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/hello_world/output.txt"
+    Konnichiwa!
+    ```
+
+!!! note "Nota"
+
+    No Nextflow, há vários lugares onde você pode especificar valores para parâmetros.
+    Se o mesmo parâmetro for definido com valores diferentes em vários lugares, o Nextflow determinará qual valor usar com base na ordem de precedência descrita [aqui](https://www.nextflow.io/docs/latest/config.html).
+
+    Cobriremos isso com mais detalhes na Parte 6 (Configuração).
+
+### Resumo
+
+Você sabe como usar uma entrada variável simples fornecida em tempo de execução via parâmetro de linha de comando, bem como configurar, usar e substituir valores padrão.
+
+### O que vem a seguir?
+
+Aprenda como gerenciar execuções de forma mais conveniente.
+
+---
+
+## 4. Gerencie execuções de fluxo de trabalho
+
+Saber como lançar fluxos de trabalho e recuperar saídas é ótimo, mas você rapidamente descobrirá que há alguns outros aspectos do gerenciamento de fluxo de trabalho que tornarão sua vida mais fácil, especialmente se você estiver desenvolvendo seus próprios fluxos de trabalho.
+
+Aqui mostramos como usar o recurso `resume` para quando você precisar relançar o mesmo fluxo de trabalho, como inspecionar o log de execuções passadas com `nextflow log`, e como excluir diretórios work mais antigos com `nextflow clean`.
+
+<!-- Any other cool options we should include? Added log -->
+
+### 4.1. Relance um fluxo de trabalho com `-resume`
+
+Às vezes, você vai querer executar novamente um pipeline que já lançou anteriormente sem refazer nenhuma etapa que já foi concluída com sucesso.
+
+O Nextflow tem uma opção chamada `-resume` que permite fazer isso.
+Especificamente, neste modo, quaisquer processos que já foram executados com exatamente o mesmo código, configurações e entradas serão ignorados.
+Isso significa que o Nextflow só executará processos que você adicionou ou modificou desde a última execução, ou aos quais você está fornecendo novas configurações ou entradas.
+
+Existem duas vantagens principais em fazer isso:
+
+- Se você está no meio do desenvolvimento do seu pipeline, pode iterar mais rapidamente, pois só precisa executar o(s) processo(s) em que está trabalhando ativamente para testar suas alterações.
+- Se você está executando um pipeline em produção e algo dá errado, em muitos casos você pode corrigir o problema e relançar o pipeline, e ele retomará a execução do ponto de falha, o que pode economizar muito tempo e computação.
+
+Para usá-lo, basta adicionar `-resume` ao seu comando e executá-lo:
+
+```bash
+nextflow run hello-world.nf -resume
+```
+
+??? success "Saída do comando"
+
+    ```console hl_lines="5"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [golden_cantor] DSL2 - revision: 35bd3425e5
+
+    [62/49a1f8] sayHello | 1 of 1, cached: 1 ✔
+    ```
+
+A saída do console deve parecer familiar, mas há uma coisa que é um pouco diferente em comparação com antes.
+
+Procure pela parte `cached:` que foi adicionada na linha de status do processo (linha 5), o que significa que o Nextflow reconheceu que já fez este trabalho e simplesmente reutilizou o resultado da execução anterior bem-sucedida.
+
+Você também pode ver que o hash do subdiretório work é o mesmo da execução anterior.
+O Nextflow está literalmente apontando para a execução anterior e dizendo "Eu já fiz isso lá."
+
+!!! tip "Dica"
+
+    Quando você executa novamente um pipeline com `resume`, o Nextflow não sobrescreve nenhum arquivo publicado fora do diretório work por quaisquer execuções que foram executadas com sucesso anteriormente.
+
+### 4.2. Inspecione o log de execuções passadas
+
+Quer você esteja desenvolvendo um novo pipeline ou executando pipelines em produção, em algum momento você provavelmente precisará consultar informações sobre execuções passadas.
+Aqui está como fazer isso.
+
+Sempre que você lança um fluxo de trabalho nextflow, uma linha é escrita em um arquivo de log chamado `history`, em um diretório oculto chamado `.nextflow` no diretório de trabalho atual.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```txt title=".nextflow/history" linenums="1"
+    2025-07-04 19:27:09	1.8s	wise_watson	OK	3539118582ccde68dde471cc2c66295c	a02c9c46-c3c7-4085-9139-d1b9b5b194c8	nextflow run 1-hello.nf --input 'Hello World'
+    2025-07-04 19:27:20	2.9s	spontaneous_blackwell	OK	3539118582ccde68dde471cc2c66295c	59a5db23-d83c-4c02-a54e-37ddb73a337e	nextflow run 1-hello.nf --input Bonjour
+    2025-07-04 19:27:31	1.8s	gigantic_yonath	OK	3539118582ccde68dde471cc2c66295c	5acaa83a-6ad6-4509-bebc-cb25d5d7ddd0	nextflow run 1-hello.nf --input 'Dobry den'
+    2025-07-04 19:27:45	2.4s	backstabbing_swartz	OK	3539118582ccde68dde471cc2c66295c	5f4b3269-5b53-404a-956c-cac915fbb74e	nextflow run 1-hello.nf --input Konnichiwa
+    2025-07-04 19:27:57	2.1s	goofy_wilson	OK	3539118582ccde68dde471cc2c66295c	5f4b3269-5b53-404a-956c-cac915fbb74e	nextflow run 1-hello.nf --input Konnichiwa -resume
+    ```
+
+Este arquivo fornece o timestamp, nome da execução, status, ID de revisão, ID de sessão e linha de comando completa para cada execução do Nextflow que foi lançada a partir do diretório de trabalho atual.
+
+Uma maneira mais conveniente de acessar essas informações é usar o comando `nextflow log`.
+
+```bash
+nextflow log
+```
+
+??? success "Saída do comando"
+
+    ```console linenums="1"
+    TIMESTAMP               DURATION        RUN NAME                STATUS  REVISION ID     SESSION ID                              COMMAND
+    2025-07-04 19:27:09     1.8s            wise_watson             OK       3539118582     a02c9c46-c3c7-4085-9139-d1b9b5b194c8    nextflow run 1-hello.nf --input 'Hello World'
+    2025-07-04 19:27:20     2.9s            spontaneous_blackwell   OK       3539118582     59a5db23-d83c-4c02-a54e-37ddb73a337e    nextflow run 1-hello.nf --input Bonjour
+    2025-07-04 19:27:31     1.8s            gigantic_yonath         OK       3539118582     5acaa83a-6ad6-4509-bebc-cb25d5d7ddd0    nextflow run 1-hello.nf --input 'Dobry den'
+    2025-07-04 19:27:45     2.4s            backstabbing_swartz     OK       3539118582     5f4b3269-5b53-404a-956c-cac915fbb74e    nextflow run 1-hello.nf --input Konnichiwa
+    2025-07-04 19:27:57     2.1s            goofy_wilson            OK       3539118582     5f4b3269-5b53-404a-956c-cac915fbb74e    nextflow run 1-hello.nf --input Konnichiwa -resume
+    ```
+
+Isso exibirá o conteúdo do arquivo de log no terminal, aumentado com uma linha de cabeçalho.
+
+Você notará que o ID de sessão muda sempre que você executa um novo comando `nextflow run`, EXCETO se você estiver usando a opção `-resume`.
+Nesse caso, o ID de sessão permanece o mesmo.
+
+O Nextflow usa o ID de sessão para agrupar informações de cache de execução no diretório `cache`, também localizado em `.nextflow`.
+
+### 4.3. Exclua diretórios work mais antigos
+
+Durante o processo de desenvolvimento, você normalmente executará seu rascunho de pipeline um grande número de vezes, o que pode levar a um acúmulo de muitos arquivos em muitos subdiretórios.
+
+Felizmente, o Nextflow inclui um subcomando útil `clean` que pode excluir automaticamente os subdiretórios work de execuções passadas que você não se importa mais.
+
+#### 4.3.1. Determine os critérios de exclusão
+
+Existem várias [opções](https://www.nextflow.io/docs/latest/reference/cli.html#clean) para determinar o que excluir.
+
+Aqui mostramos um exemplo que exclui todos os subdiretórios de execuções antes de uma determinada execução, especificada usando seu nome de execução.
+
+Procure a execução bem-sucedida mais recente onde você não usou `-resume`; no nosso caso, o nome da execução foi `golden_cantor`.
+
+O nome da execução é a string de duas partes gerada por máquina mostrada entre colchetes na linha de saída do console `Launching (...)`.
+Você também pode usar o log do Nextflow para procurar uma execução com base em seu timestamp e/ou linha de comando.
+
+#### 4.3.2. Faça uma execução de teste
+
+Primeiro usamos a flag de execução de teste `-n` para verificar o que será excluído dado o comando:
+
+```bash
+nextflow clean -before golden_cantor -n
+```
+
+??? success "Saída do comando"
+
+    ```console
+    Would remove /workspaces/training/hello-nextflow/work/a3/7be2fad5e71e5f49998f795677fd68
+    ```
+
+Sua saída terá nomes de diretório de tarefa diferentes e pode ter um número diferente de linhas, mas deve parecer semelhante ao exemplo.
+
+Se você não ver nenhuma linha de saída, você não forneceu um nome de execução válido ou não há execuções passadas para excluir. Certifique-se de alterar `golden_cantor` no comando de exemplo para qualquer que seja o nome de execução mais recente correspondente no seu log.
+
+#### 4.3.3. Prossiga com a exclusão
+
+Se a saída parecer como esperado e você quiser prosseguir com a exclusão, execute novamente o comando com a flag `-f` em vez de `-n`:
+
+```bash
+nextflow clean -before golden_cantor -f
+```
+
+??? success "Saída do comando"
+
+    ```console
+    Removed /workspaces/training/hello-nextflow/work/a3/7be2fad5e71e5f49998f795677fd68
+    ```
+
+A saída deve ser semelhante à anterior, mas agora dizendo 'Removed' em vez de 'Would remove'.
+Note que isso não remove os subdiretórios de dois caracteres (como `a3/` acima), mas esvazia seu conteúdo.
+
+!!! Warning "Aviso"
+
+    Excluir subdiretórios work de execuções passadas os remove do cache do Nextflow e exclui quaisquer saídas que foram armazenadas nesses diretórios.
+    Isso significa que quebra a capacidade do Nextflow de retomar a execução sem executar novamente os processos correspondentes.
+
+    Você é responsável por salvar quaisquer saídas que você se importa ou planeja confiar! Essa é a principal razão pela qual preferimos usar o modo `copy` em vez do modo `symlink` para a diretiva `publish`.
+
+### Resumo
+
+Você sabe como publicar saídas em um diretório específico, relançar um pipeline sem repetir etapas que já foram executadas de forma idêntica e usar o comando `nextflow clean` para limpar diretórios work antigos.
+
+De forma mais geral, você sabe como interpretar um fluxo de trabalho Nextflow simples, gerenciar sua execução e recuperar saídas.
+
+### O que vem a seguir?
+
+Faça uma pequena pausa, você mereceu!
+
+Quando estiver pronto, passe para [**Parte 2: Hello Channels**](./02_hello_channels.md) para aprender como usar canais para alimentar entradas em seu fluxo de trabalho, o que permitirá que você aproveite o paralelismo de fluxo de dados integrado do Nextflow e outros recursos poderosos.
+
+---
+
+## Quiz
+
+<quiz>
+Quais são os componentes mínimos necessários de um processo Nextflow?
+- [ ] Apenas blocos de entrada e saída
+- [x] Blocos de saída e script
+- [ ] Blocos de entrada, saída e script
+- [ ] Apenas um bloco script
+
+Saiba mais: [1.1.1. A definição de processo](#111-a-definição-de-process)
+</quiz>
+
+<quiz>
+Qual é o propósito do bloco de saída em um processo?
+- [ ] Imprimir resultados no console
+- [ ] Salvar arquivos no diretório work
+- [x] Declarar saídas esperadas do processo
+- [ ] Definir variáveis de ambiente
+
+Saiba mais: [1.1.1. A definição de processo](#111-a-definição-de-process)
+</quiz>
+
+<quiz>
+Qual comando é usado para executar um fluxo de trabalho Nextflow?
+- [ ] `nextflow start`
+- [ ] `nextflow execute`
+- [x] `nextflow run`
+- [ ] `nextflow launch`
+</quiz>
+
+<quiz>
+Olhando para o diretório work de uma tarefa, qual arquivo contém o comando real que foi executado?
+
+```
+work/a3/7be2fa.../
+├── .command.begin
+├── .command.err
+├── .command.log
+├── .command.out
+├── .command.run
+├── .command.sh
+├── .exitcode
+└── output.txt
+```
+
+- [ ] `.command.run`
+- [x] `.command.sh`
+- [ ] `.command.log`
+- [ ] `.command.out`
+
+Saiba mais: [1.2.2. Encontre a saída e os logs no diretório `work`](#122-encontre-a-saída-e-os-logs-no-diretório-work)
+</quiz>
+
+<quiz>
+O que a flag `-resume` faz?
+- [ ] Reinicia o fluxo de trabalho do início
+- [ ] Pausa o fluxo de trabalho
+- [x] Ignora processos que já foram concluídos com sucesso
+- [ ] Cria um backup do fluxo de trabalho
+
+Saiba mais: [4.1. Relance um fluxo de trabalho com `-resume`](#41-relance-um-fluxo-de-trabalho-com--resume)
+</quiz>
+
+<quiz>
+Qual é o modo padrão para publicar saídas de fluxo de trabalho?
+- [ ] Copiar arquivos para o diretório de saída
+- [x] Criar links simbólicos no diretório de saída
+- [ ] Mover arquivos para o diretório de saída
+- [ ] Comprimir arquivos no diretório de saída
+
+Saiba mais: [2.3. Defina o modo de publicação para copiar](#23-defina-o-modo-de-publicação-para-copiar)
+</quiz>
+
+<quiz>
+Como você passa um valor de parâmetro para um fluxo de trabalho Nextflow a partir da linha de comando?
+- [ ] `-parameter value`
+- [ ] `--parameter:value`
+- [x] `--parameter value`
+- [ ] `-p parameter=value`
+
+Saiba mais: [3.2. Configure um parâmetro de linha de comando para capturar a entrada do usuário](#32-configure-um-parâmetro-de-linha-de-comando-para-capturar-a-entrada-do-usuário)
+</quiz>
+
+<quiz>
+Como você referencia uma variável dentro de um bloco script do Nextflow?
+- [ ] Use a sintaxe `%variable%`
+- [x] Use a sintaxe `#!groovy ${variable}`
+- [ ] Use a sintaxe `{{variable}}`
+- [ ] Use a sintaxe `[variable]`
+</quiz>

--- a/docs/pt/docs/hello_nextflow/02_hello_channels.md
+++ b/docs/pt/docs/hello_nextflow/02_hello_channels.md
@@ -1,0 +1,1429 @@
+# Parte 2: Olá Canais
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/lJ41WMMm44M?si=xCItHLiOQWqoqBB9&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Veja [a playlist completa](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) no canal do Nextflow no YouTube.
+
+:green_book: A transcrição do vídeo está disponível [aqui](./transcripts/02_hello_channels.md).
+///
+
+Na Parte 1 deste curso (Hello World), mostramos como fornecer uma entrada variável para um processo fornecendo a entrada diretamente na chamada do processo: `sayHello(params.input)`.
+Essa foi uma abordagem deliberadamente simplificada.
+Na prática, essa abordagem tem grandes limitações; ou seja, ela só funciona para casos muito simples onde queremos executar o processo apenas uma vez, em um único valor.
+Na maioria dos casos de uso realistas de fluxos de trabalho, queremos processar múltiplos valores (dados experimentais para múltiplas amostras, por exemplo), então precisamos de uma maneira mais sofisticada de lidar com entradas.
+
+É para isso que servem os **canais** do Nextflow.
+Canais são filas projetadas para lidar com entradas eficientemente e transportá-las de uma etapa para outra em fluxos de trabalho de múltiplas etapas, ao mesmo tempo que fornecem paralelismo integrado e muitos benefícios adicionais.
+
+Nesta parte do curso, você aprenderá como usar um canal para lidar com múltiplas entradas de uma variedade de fontes diferentes.
+Você também aprenderá a usar **operadores** para transformar o conteúdo dos canais conforme necessário.
+
+??? info "Como começar a partir desta seção"
+
+    Esta seção do curso pressupõe que você completou a Parte 1 do curso [Hello Nextflow](./index.md), mas se você está confortável com os conceitos básicos cobertos naquela seção, pode começar a partir daqui sem fazer nada especial.
+
+---
+
+## 0. Aquecimento: Execute `hello-channels.nf`
+
+Vamos usar o script de fluxo de trabalho `hello-channels.nf` como ponto de partida.
+Ele é equivalente ao script produzido ao trabalhar na Parte 1 deste curso de treinamento, exceto que mudamos o destino da saída:
+
+```groovy title="hello-channels.nf" linenums="37" hl_lines="3"
+output {
+    first_output {
+        path 'hello_channels'
+        mode 'copy'
+    }
+}
+```
+
+Apenas para garantir que tudo está funcionando, execute o script uma vez antes de fazer qualquer alteração:
+
+```bash
+nextflow run hello-channels.nf --input 'Hello Channels!'
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [wise_jennings] DSL2 - revision: b24f4902d6
+
+    executor >  local (1)
+    [6f/824bc1] process > sayHello [100%] 1 of 1 ✔
+    ```
+
+Como anteriormente, você encontrará o arquivo de saída chamado `output.txt` no diretório `results/hello_channels` (como especificado no bloco `output` do script de fluxo de trabalho, mostrado acima).
+
+??? abstract "Conteúdo do diretório"
+
+    ```console title="results/hello_channels" hl_lines="2-3"
+    results
+    ├── hello_channels
+    │   └── output.txt
+    ├── hello_world
+    │   └── output.txt
+    └── output.txt -> /workspaces/training/hello-nextflow/work/8c/79499c11beea6e9d43605141f2817f/output.txt
+    ```
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/hello_channels/output.txt"
+    Hello Channels!
+    ```
+
+Se isso funcionou para você, está pronto para aprender sobre canais.
+
+---
+
+## 1. Forneça entradas variáveis através de um canal explicitamente
+
+Vamos criar um **canal** para passar a entrada variável para o processo `sayHello()` em vez de depender do tratamento implícito, que tem certas limitações.
+
+### 1.1. Crie um canal de entrada
+
+Existem várias **fábricas de canais** que podemos usar para configurar um canal.
+Para manter as coisas simples por enquanto, vamos usar a fábrica de canais mais básica, chamada `channel.of`, que criará um canal contendo um único valor.
+Funcionalmente, isso será semelhante a como tínhamos configurado antes, mas em vez de ter o Nextflow criando um canal implicitamente, estamos fazendo isso explicitamente agora.
+
+Esta é a linha de código que vamos usar:
+
+```console title="Sintaxe"
+greeting_ch = channel.of('Hello Channels!')
+```
+
+Isso cria um canal chamado `greeting_ch` usando a fábrica de canais `channel.of()`, que configura um canal de fila simples, e carrega a string `'Hello Channels!'` para usar como o valor da saudação.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-pipeline-channel.svg"
+</figure>
+
+!!! note
+
+    Estamos temporariamente voltando a usar strings codificadas em vez de usar um parâmetro CLI para fins de legibilidade. Voltaremos a usar parâmetros CLI assim que tivermos coberto o que está acontecendo no nível do canal.
+
+No bloco workflow, adicione o código da fábrica de canais:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="4 5"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello Channels!')
+        // emit a greeting
+        sayHello(params.input)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="27"
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello(params.input)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Isso ainda não está funcional, pois ainda não mudamos a entrada para a chamada do processo.
+
+### 1.2. Adicione o canal como entrada para a chamada do processo
+
+Agora precisamos realmente conectar nosso canal recém-criado à chamada do processo `sayHello()`, substituindo o parâmetro CLI que estávamos fornecendo diretamente antes.
+
+No bloco workflow, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello Channels!')
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello Channels!')
+        // emit a greeting
+        sayHello(params.input)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Isso informa ao Nextflow para executar o processo `sayHello` no conteúdo do canal `greeting_ch`.
+
+Agora nosso fluxo de trabalho está devidamente funcional; é o equivalente explícito de escrever `sayHello('Hello Channels!')`.
+
+### 1.3. Execute o fluxo de trabalho
+
+Vamos executá-lo!
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [fabulous_crick] DSL2 - revision: 23e20f76e8
+
+    executor >  local (1)
+    [c0/4f1872] process > sayHello (1) [100%] 1 of 1 ✔
+    ```
+
+Se você fez ambas as edições corretamente, deve obter uma execução bem-sucedida.
+Você pode verificar o diretório de resultados para se certificar de que o resultado ainda é o mesmo de antes.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/hello_channels/output.txt"
+    Hello Channels!
+    ```
+
+Então aumentamos a flexibilidade do nosso fluxo de trabalho ao mesmo tempo que alcançamos o mesmo resultado final.
+Isso pode parecer que estamos escrevendo mais código sem benefício tangível, mas o valor ficará claro assim que começarmos a lidar com mais entradas.
+
+Como uma prévia disso, vamos olhar mais uma coisa antes de seguir em frente: um benefício pequeno mas conveniente de usar um canal explícito para gerenciar a entrada de dados.
+
+### 1.4. Use `view()` para inspecionar o conteúdo do canal
+
+Os canais do Nextflow são construídos de uma maneira que nos permite operar em seu conteúdo usando operadores, que cobriremos em detalhes mais tarde neste capítulo.
+
+Por enquanto, vamos apenas mostrar como usar um operador super simples chamado [`view()`](https://www.nextflow.io/docs/latest/reference/operator.html#view) para inspecionar o conteúdo de um canal.
+Você pode pensar em `view()` como uma ferramenta de depuração, como uma instrução `print()` em Python, ou seu equivalente em outras linguagens.
+
+Adicione esta pequena linha ao bloco workflow:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello Channels!')
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="27"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello Channels!')
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+A quantidade exata de espaços não importa, desde que seja um múltiplo de 4; estamos apenas tentando alinhar o início da instrução `.view()` com a parte `.of()` da construção do canal.
+
+Agora execute o fluxo de trabalho novamente:
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Saída do comando"
+
+    ```console hl_lines="7"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [scruffy_shaw] DSL2 - revision: 2ede41e14a
+
+    executor >  local (1)
+    [ef/f7e40a] sayHello (1) [100%] 1 of 1 ✔
+    Hello Channels!
+    ```
+
+Como você pode ver, isso exibe o conteúdo do canal no console.
+Aqui temos apenas um elemento, mas quando começarmos a carregar múltiplos valores no canal na próxima seção, você verá que isso está configurado para exibir um elemento por linha.
+
+### Conclusão
+
+Você sabe como usar uma fábrica de canais básica para fornecer uma entrada a um processo.
+
+### O que vem a seguir?
+
+Aprenda como usar canais para fazer o fluxo de trabalho iterar sobre múltiplos valores de entrada.
+
+---
+
+## 2. Modifique o fluxo de trabalho para executar em múltiplos valores de entrada
+
+Fluxos de trabalho normalmente executam em lotes de entradas que devem ser processadas em massa, então queremos atualizar o fluxo de trabalho para aceitar múltiplos valores de entrada.
+
+### 2.1. Carregue múltiplas saudações no canal de entrada
+
+Convenientemente, a fábrica de canais `channel.of()` que estivemos usando está bastante feliz em aceitar mais de um valor, então não precisamos modificar isso de jeito nenhum.
+Podemos apenas carregar múltiplos valores no canal.
+
+Vamos fazê-los `'Hello'`, `'Bonjour'` e `'Holà'`.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-pipeline-channel-multi.svg"
+</figure>
+
+_No diagrama, o canal é representado em verde, e a ordem dos elementos é representada como bolas de gude em um tubo: o primeiro carregado está à direita, depois o segundo no meio, depois o terceiro está à esquerda._
+
+#### 2.1.1. Adicione mais saudações
+
+Antes do bloco workflow, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="30" hl_lines="2"
+    // create a channel for inputs
+    greeting_ch = channel.of('Hello','Bonjour','Holà')
+                         .view()
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="30" hl_lines="2"
+    // create a channel for inputs
+    greeting_ch = channel.of('Hello Channels')
+                         .view()
+    ```
+
+A documentação nos diz que isso deve funcionar. Pode ser realmente tão simples?
+
+#### 2.1.2. Execute o comando e observe a saída do log
+
+Vamos tentar.
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Saída do comando"
+
+    ```console hl_lines="6"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [amazing_crick] DSL2 - revision: 59a9a5888a
+
+    executor >  local (3)
+    [f4/c9962c] process > sayHello (1) [100%] 3 of 3 ✔
+    Hello
+    Bonjour
+    Holà
+    ```
+
+Certamente parece ter executado bem.
+O monitor de execução mostra que `3 of 3` chamadas foram feitas para o processo `sayHello`, e vemos as três saudações enumeradas pela instrução `view()`, uma por linha como prometido.
+
+No entanto, ainda há apenas uma saída no diretório de resultados:
+
+??? abstract "Conteúdo do diretório"
+
+    ```console title="results/hello_channels" hl_lines="3"
+    results
+    ├── hello_channels
+    │   └── output.txt
+    ├── hello_world
+    │   └── output.txt
+    └── output.txt -> /workspaces/training/hello-nextflow/work/8c/79499c11beea6e9d43605141f2817f/output.txt
+    ```
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/hello_channels/output.txt"
+    Holà
+    ```
+
+Você deve ver uma das três saudações lá, mas a que você obteve pode ser diferente do que é mostrado aqui.
+Consegue pensar por que isso pode ser?
+
+Olhando de volta para o monitor de execução, ele nos deu apenas um caminho de subdiretório (`f4/c9962c`).
+Vamos dar uma olhada lá.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console hl_lines="9"
+    work/f4/c9962ce91ef87480babcb86b2b9042/
+    ├── .command.begin
+    ├── .command.err
+    ├── .command.log
+    ├── .command.out
+    ├── .command.run
+    ├── .command.sh
+    ├── .exitcode
+    └── output.txt
+    ```
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="work/f4/c9962ce91ef87480babcb86b2b9042/output.txt"
+    Hello
+    ```
+
+Essa nem é a mesma saudação que obtivemos no diretório de resultados! O que está acontecendo?
+
+Neste ponto, precisamos informar que, por padrão, o sistema de log ANSI escreve o log de múltiplas chamadas ao mesmo processo na mesma linha.
+Então o status de todas as três chamadas ao processo sayHello() estão chegando no mesmo lugar.
+
+Felizmente, podemos desabilitar esse comportamento para ver a lista completa de chamadas de processo.
+
+#### 2.1.3. Execute o comando novamente com a opção `-ansi-log false`
+
+Para expandir o log para exibir uma linha por chamada de processo, adicione `-ansi-log false` ao comando.
+
+```bash
+nextflow run hello-channels.nf -ansi-log false
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W  ~  version 25.10.2
+    Launching `hello-channels.nf` [desperate_monod] DSL2 - revision: 59a9a5888a
+    Hello
+    Bonjour
+    Holà
+    [23/871c7e] Submitted process > sayHello (2)
+    [7f/21e2c2] Submitted process > sayHello (1)
+    [f4/ea10a6] Submitted process > sayHello (3)
+    ```
+
+Desta vez vemos todas as três execuções de processo e seus subdiretórios de trabalho associados listados na saída.
+
+Isso é muito melhor, pelo menos para um fluxo de trabalho simples.
+Para um fluxo de trabalho complexo, ou um grande número de entradas, ter a lista completa exibida no terminal ficaria um pouco avassalador.
+É por isso que `-ansi-log false` não é o comportamento padrão.
+
+!!! tip
+
+    A maneira como o status é relatado é um pouco diferente entre os dois modos de log.
+    No modo condensado, o Nextflow relata se as chamadas foram concluídas com sucesso ou não.
+    Neste modo expandido, ele apenas relata que foram submetidas.
+
+De qualquer forma, agora que temos os subdiretórios de cada chamada de processo, podemos procurar seus logs e saídas.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    work/23/871c7ec3642a898ecd5e6090d21300/
+    ├── .command.begin
+    ├── .command.err
+    ├── .command.log
+    ├── .command.out
+    ├── .command.run
+    ├── .command.sh
+    ├── .exitcode
+    └── output.txt
+    ```
+
+    ```console
+    work/7f/21e2c2f3cc8833ef3858b236e5575c/
+    ├── .command.begin
+    ├── .command.err
+    ├── .command.log
+    ├── .command.out
+    ├── .command.run
+    ├── .command.sh
+    ├── .exitcode
+    └── output.txt
+    ```
+
+    ```console
+    work/f4/ea10a680d5687596d3eaa3fcf69272/
+    ├── .command.begin
+    ├── .command.err
+    ├── .command.log
+    ├── .command.out
+    ├── .command.run
+    ├── .command.sh
+    ├── .exitcode
+    └── output.txt
+    ```
+
+??? abstract "Conteúdo do arquivo"
+
+    ```txt title="work/23/871c7ec3642a898ecd5e6090d21300/output.txt"
+    Bonjour
+    ```
+
+    ```txt title="work/7f/21e2c2f3cc8833ef3858b236e5575c/output.txt"
+    Hello
+    ```
+
+    ```txt title="work/f4/ea10a680d5687596d3eaa3fcf69272/output.txt"
+    Holà
+    ```
+
+Isso mostra que todos os três processos foram executados com sucesso (eba).
+
+Dito isso, ainda temos o problema de que há apenas um arquivo de saída no diretório de resultados.
+
+Você pode se lembrar de que codificamos o nome do arquivo de saída para o processo `sayHello`, então todas as três chamadas produziram um arquivo chamado `output.txt`.
+
+Enquanto os arquivos de saída permanecerem nos subdiretórios de trabalho, isolados dos outros processos, isso está ok.
+Mas quando são publicados no mesmo diretório de resultados, aquele que foi copiado primeiro é sobrescrito pelo próximo, e assim por diante.
+
+### 2.2. Garanta que os nomes dos arquivos de saída sejam únicos
+
+Podemos continuar publicando todas as saídas no mesmo diretório de resultados, mas precisamos garantir que terão nomes únicos.
+Especificamente, precisamos modificar o primeiro processo para gerar um nome de arquivo dinamicamente para que os nomes de arquivo finais sejam únicos.
+
+Então como tornamos os nomes de arquivo únicos?
+Uma maneira comum de fazer isso é usar alguma informação única dos metadados das entradas (recebidos do canal de entrada) como parte do nome do arquivo de saída.
+Aqui, por conveniência, vamos apenas usar a própria saudação, já que é apenas uma string curta, e prefixá-la ao nome base do arquivo de saída.
+
+#### 2.2.1. Construa um nome de arquivo de saída dinâmico
+
+No bloco process, faça as seguintes alterações de código:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="6" hl_lines="7 11"
+    process sayHello {
+
+        input:
+        val greeting
+
+        output:
+        path "${greeting}-output.txt"
+
+        script:
+        """
+        echo '${greeting}' > '${greeting}-output.txt'
+        """
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="6" hl_lines="7 11"
+    process sayHello {
+
+        input:
+        val greeting
+
+        output:
+        path 'output.txt'
+
+        script:
+        """
+        echo '${greeting}' > output.txt
+        """
+    }
+    ```
+
+Certifique-se de substituir `output.txt` tanto na definição de saída quanto no bloco de comando `script:`.
+
+!!! tip
+
+    Na definição de saída, você DEVE usar aspas duplas em torno da expressão do nome do arquivo (NÃO aspas simples), caso contrário falhará.
+
+Isso deve produzir um nome de arquivo de saída único toda vez que o processo for chamado, para que possa ser distinguido das saídas de outras chamadas ao mesmo processo no diretório de saída.
+
+#### 2.2.2. Execute o fluxo de trabalho
+
+Vamos executá-lo. Note que estamos de volta a executar com as configurações de log ANSI padrão.
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [sharp_minsky] DSL2 - revision: 16a291febe
+
+    executor >  local (3)
+    [e8/33ee64] sayHello (2) [100%] 3 of 3 ✔
+    Hello
+    Bonjour
+    Holà
+    ```
+
+Voltando à visualização de resumo, a saída é resumida em uma linha novamente.
+Dê uma olhada no diretório `results` para ver se todas as saudações de saída estão lá.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    results/hello_channels/
+    ├── Bonjour-output.txt
+    ├── Hello-output.txt
+    ├── Holà-output.txt
+    └── output.txt
+    ```
+
+Sim! E cada uma tem o conteúdo esperado.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="Bonjour-output.txt"
+    Bonjour
+    ```
+
+    ```console title="Hello-output.txt"
+    Hello
+    ```
+
+    ```console title="Holà-output.txt"
+    Holà
+    ```
+
+Sucesso! Agora podemos adicionar quantas saudações quisermos sem nos preocupar com arquivos de saída sendo sobrescritos.
+
+!!! tip
+
+    Na prática, nomear arquivos com base nos dados de entrada em si é quase sempre impraticável.
+    A melhor maneira de gerar nomes de arquivo dinâmicos é passar metadados para um processo junto com os arquivos de entrada.
+    Os metadados são normalmente fornecidos através de uma 'planilha de amostras' ou equivalentes.
+    Você aprenderá como fazer isso mais tarde no seu treinamento de Nextflow (veja [Missão secundária de metadados](../side_quests/metadata.md)).
+
+### Conclusão
+
+Você sabe como alimentar múltiplos elementos de entrada através de um canal.
+
+### O que vem a seguir?
+
+Aprenda a usar um operador para transformar o conteúdo de um canal.
+
+---
+
+## 3. Forneça múltiplas entradas através de um array
+
+Acabamos de mostrar como lidar com múltiplos elementos de entrada que foram codificados diretamente na fábrica de canais.
+E se quisermos fornecer essas múltiplas entradas de uma maneira diferente?
+
+Por exemplo, imagine que configuramos uma variável de entrada contendo um array de elementos assim:
+
+`greetings_array = ['Hello','Bonjour','Holà']`
+
+Podemos carregar isso em nosso canal de saída e esperar que funcione?
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-pipeline-multi-inputs-array.svg"
+</figure>
+
+Vamos descobrir.
+
+### 3.1. Forneça um array de valores como entrada para o canal
+
+O bom senso sugere que deveríamos ser capazes de simplesmente passar um array de valores em vez de um único valor.
+Vamos tentar; precisaremos configurar a variável de entrada e carregá-la na fábrica de canais.
+
+#### 3.1.1. Configure a variável de entrada
+
+Vamos pegar a variável `greetings_array` que acabamos de imaginar e torná-la realidade adicionando-a ao bloco workflow:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="4 5"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello','Bonjour','Holà')
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="27"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello','Bonjour','Holà')
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Isso ainda não está funcional, apenas adicionamos uma declaração para o array.
+
+#### 3.1.2. Defina o array de saudações como entrada para a fábrica de canais
+
+Agora vamos substituir os valores `'Hello','Bonjour','Holà'` atualmente codificados na fábrica de canais pelo `greetings_array` que acabamos de criar.
+
+No bloco workflow, faça a seguinte alteração:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello','Bonjour','Holà')
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Isso deve estar funcional agora.
+
+#### 3.1.3. Execute o fluxo de trabalho
+
+Vamos tentar executá-lo:
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? failure "Saída do comando"
+
+    ```console hl_lines="7 11 16"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [friendly_koch] DSL2 - revision: 97256837a7
+
+    executor >  local (1)
+    [a8/1f6ead] sayHello (1) | 0 of 1
+    [Hello, Bonjour, Holà]
+    ERROR ~ Error executing process > 'sayHello (1)'
+
+    Caused by:
+      Missing output file(s) `[Hello, Bonjour, Holà]-output.txt` expected by process `sayHello (1)`
+
+
+    Command executed:
+
+      echo '[Hello, Bonjour, Holà]' > '[Hello, Bonjour, Holà]-output.txt'
+
+    Command exit status:
+      0
+
+    Command output:
+      (empty)
+
+    Work dir:
+      /workspaces/training/hello-nextflow/work/a8/1f6ead5f3fa30a3c508e2e7cf83ffb
+
+    Tip: you can replicate the issue by changing to the process work dir and entering the command `bash .command.run`
+
+    -- Check '.nextflow.log' file for details
+    ```
+
+Oh não! Há um erro!
+
+Observe a saída de `view()` e as mensagens de erro.
+
+Parece que o Nextflow tentou executar uma única chamada de processo, usando `[Hello, Bonjour, Holà]` como um valor de string, em vez de usar as três strings no array como valores separados.
+
+Então é o 'empacotamento' que está causando o problema.
+Como fazemos o Nextflow desempacotar o array e carregar as strings individuais no canal?
+
+### 3.2. Use um operador para transformar o conteúdo do canal
+
+É aqui que os **[operadores](https://www.nextflow.io/docs/latest/reference/operator.html)** entram em jogo.
+Você já usou o operador `.view()`, que apenas observa o que está lá.
+Agora vamos olhar para operadores que nos permitem agir sobre o conteúdo de um canal.
+
+Se você examinar a [lista de operadores](https://www.nextflow.io/docs/latest/reference/operator.html) na documentação do Nextflow, encontrará [`flatten()`](https://www.nextflow.io/docs/latest/reference/operator.html#flatten), que faz exatamente o que precisamos: desempacotar o conteúdo de um array e emiti-los como itens individuais.
+
+#### 3.2.1. Adicione o operador `flatten()`
+
+Para aplicar o operador `flatten()` ao nosso canal de entrada, anexamos ele à declaração da fábrica de canais.
+
+No bloco workflow, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="9"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view()
+                             .flatten()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="27"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Aqui adicionamos o operador na próxima linha para legibilidade, mas você pode adicionar operadores na mesma linha que a fábrica de canais se preferir, assim:
+`greeting_ch = channel.of(greetings_array).view().flatten()`
+
+#### 3.2.2. Refine a(s) instrução(ões) `view()`
+
+Poderíamos executar isso imediatamente para testar se funciona, mas enquanto estamos nisso, vamos refinar como inspecionamos o conteúdo do canal.
+
+Queremos ser capazes de contrastar como o conteúdo se parece antes e depois que o operador `flatten()` é aplicado, então vamos adicionar um segundo, E vamos adicionar um pouco de código para obtê-los rotulados mais claramente na saída.
+
+No bloco workflow, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="8-10"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view { greeting -> "Before flatten: $greeting" }
+                             .flatten()
+                             .view { greeting -> "After flatten: $greeting" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="8-9"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view()
+                             .flatten()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Você vê que adicionamos uma segunda instrução `.view`, e para cada uma delas, substituímos os parênteses vazios (`()`) por chaves contendo algum código, como `{ greeting -> "Before flatten: $greeting" }`.
+
+Essas são chamadas _closures_. O código que elas contêm será executado para cada item no canal.
+Definimos uma variável temporária para o valor interno, aqui chamada `greeting` (mas poderia ser qualquer nome arbitrário), que é usada apenas dentro do escopo dessa closure.
+
+Neste exemplo, `$greeting` representa cada item individual carregado no canal.
+Isso resultará em uma saída de console bem rotulada.
+
+!!! info
+
+    Em alguns pipelines você pode ver uma variável especial chamada `$it` usada dentro de closures de operadores.
+    Esta é uma variável _implícita_ que permite um acesso de forma abreviada à variável interna,
+    sem precisar defini-la com um `->`.
+
+    Preferimos ser explícitos para ajudar na clareza do código, como tal a sintaxe `$it` é desencorajada e será lentamente eliminada da linguagem Nextflow.
+
+#### 3.2.3. Execute o fluxo de trabalho
+
+Finalmente, você pode tentar executar o fluxo de trabalho novamente!
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Saída do comando"
+
+    ```console hl_lines="7-10"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [sleepy_gutenberg] DSL2 - revision: 1db4f760ee
+
+    executor >  local (3)
+    [b1/6a1e15] sayHello (2) [100%] 3 of 3 ✔
+    Before flatten: [Hello, Bonjour, Holà]
+    After flatten: Hello
+    After flatten: Bonjour
+    After flatten: Holà
+    ```
+
+Desta vez funciona E nos dá a percepção adicional do que o conteúdo do canal parece antes e depois de executarmos o operador `flatten()`.
+
+- Você vê que obtemos uma única instrução `Before flatten:` porque nesse ponto o canal contém um item, o array original.
+  Então obtemos três instruções `After flatten:` separadas, uma para cada saudação, que agora são itens individuais no canal.
+
+Importante, isso significa que cada item agora pode ser processado separadamente pelo fluxo de trabalho.
+
+!!! tip
+
+    É tecnicamente possível alcançar os mesmos resultados usando uma fábrica de canais diferente, [`channel.fromList`](https://nextflow.io/docs/latest/reference/channel.html#fromlist), que inclui uma etapa de mapeamento implícita em sua operação.
+    Aqui escolhemos não usar isso para demonstrar o uso de um operador em um caso de uso simples.
+
+### Conclusão
+
+Você sabe como usar um operador como `flatten()` para transformar o conteúdo de um canal, e como usar o operador `view()` para inspecionar o conteúdo do canal antes e depois de aplicar um operador.
+
+### O que vem a seguir?
+
+Aprenda como fazer o fluxo de trabalho receber um arquivo como sua fonte de valores de entrada.
+
+---
+
+## 4. Leia valores de entrada de um arquivo CSV
+
+Realisticamente, raramente se alguma vez vamos começar de um array de valores.
+Muito provavelmente, teremos um ou mais arquivos contendo os dados que precisam ser processados, em algum tipo de formato estruturado.
+
+Preparamos um arquivo CSV chamado `greetings.csv` que contém várias saudações de entrada, imitando o tipo de dados colunar que você pode querer processar em uma análise de dados real, armazenado em `data/`.
+(Os números não são significativos, eles estão lá apenas para fins ilustrativos.)
+
+```csv title="data/greetings.csv" linenums="1"
+Hello,English,123
+Bonjour,French,456
+Holà,Spanish,789
+```
+
+Nossa próxima tarefa é adaptar nosso fluxo de trabalho para ler os valores deste arquivo.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-pipeline-multi-inputs-csv.svg"
+</figure>
+
+Vamos ver como podemos fazer isso acontecer.
+
+### 4.1. Modifique o script para esperar um arquivo CSV como fonte de saudações
+
+Para começar, vamos precisar fazer duas alterações principais no script:
+
+- Mudar o parâmetro de entrada para apontar para o arquivo CSV
+- Mudar a fábrica de canais para uma projetada para lidar com um arquivo
+
+#### 4.1.1. Mude o parâmetro de entrada para apontar para o arquivo CSV
+
+Lembra do parâmetro `params.input` que configuramos na Parte 1?
+Vamos atualizá-lo para apontar para o arquivo CSV contendo nossas saudações.
+
+Faça a seguinte edição na declaração do parâmetro:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="20" hl_lines="5"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path = 'data/greetings.csv'
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="20" hl_lines="5"
+    /*
+     * Pipeline parameters
+     */
+    input: String = 'Holà mundo!'
+    ```
+
+Isso assume que o arquivo está localizado junto com o código do fluxo de trabalho.
+Você aprenderá como lidar com outros locais de dados mais tarde em sua jornada com Nextflow.
+
+#### 4.1.2. Mude para uma fábrica de canais projetada para lidar com um arquivo
+
+Como agora queremos usar um arquivo em vez de strings simples como entrada, não podemos usar a fábrica de canais `channel.of()` de antes.
+Precisamos mudar para usar uma nova fábrica de canais, [`channel.fromPath()`](https://www.nextflow.io/docs/latest/reference/channel.html#channel-path), que tem alguma funcionalidade integrada para lidar com caminhos de arquivo.
+
+No bloco workflow, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="4-8"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                             .view { greeting -> "Before flatten: $greeting" }
+                             // .flatten()
+                             // .view { greeting -> "After flatten: $greeting" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="4-8"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view { greeting -> "Before flatten: $greeting" }
+                             .flatten()
+                             .view { greeting -> "After flatten: $greeting" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Você notará que mudamos a entrada do canal de volta para `param.input`, e deletamos a declaração `greetings_array` já que não precisaremos mais dela.
+Também comentamos o `flatten()` e a segunda instrução `view()`.
+
+#### 4.1.3. Execute o fluxo de trabalho
+
+Vamos tentar executar o fluxo de trabalho com a nova fábrica de canais e o arquivo de entrada.
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? failure "Saída do comando"
+
+    ```console hl_lines="5 6 9 14"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [peaceful_poisson] DSL2 - revision: a286c08ad5
+
+    [-        ] sayHello [  0%] 0 of 1
+    Before flatten: /workspaces/training/hello-nextflow/data/greetings.csv
+    ERROR ~ Error executing process > 'sayHello (1)'
+
+    Caused by:
+      File `/workspaces/training/hello-nextflow/data/greetings.csv-output.txt` is outside the scope of the process work directory: /workspaces/training/hello-nextflow/work/30/e610cb4ea5ae8693f456ac3329c92f
+
+
+    Command executed:
+
+      echo '/workspaces/training/hello-nextflow/data/greetings.csv' > '/workspaces/training/hello-nextflow/data/greetings.csv-output.txt'
+
+    Command exit status:
+      -
+
+    Command output:
+      (empty)
+
+    Work dir:
+      /workspaces/training/hello-nextflow/work/30/e610cb4ea5ae8693f456ac3329c92f
+
+    Tip: when you have fixed the problem you can continue the execution adding the option `-resume` to the run command line
+
+    -- Check '.nextflow.log' file for details
+    ```
+
+Oh não, não funciona. Dê uma olhada no início da saída do console e na mensagem de erro.
+A parte `Command executed:` é especialmente útil aqui.
+
+Isso pode parecer um pouco familiar.
+Parece que o Nextflow tentou executar uma única chamada de processo usando o próprio caminho do arquivo como um valor de string.
+Então ele resolveu o caminho do arquivo corretamente, mas não analisou realmente seu conteúdo, que é o que queríamos.
+
+Como fazemos o Nextflow abrir o arquivo e carregar seu conteúdo no canal?
+
+Parece que precisamos de outro [operador](https://www.nextflow.io/docs/latest/reference/operator.html)!
+
+### 4.2. Use o operador `splitCsv()` para analisar o arquivo
+
+Olhando através da lista de operadores novamente, encontramos [`splitCsv()`](https://www.nextflow.io/docs/latest/reference/operator.html#splitCsv), que é projetado para analisar e dividir texto formatado em CSV.
+
+#### 4.2.1. Aplique `splitCsv()` ao canal
+
+Para aplicar o operador, anexamos ele à linha da fábrica de canais como anteriormente.
+
+No bloco workflow, faça a seguinte alteração de código para substituir `flatten()` por `splitcsv()` (descomentado):
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="6-8"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                             .view { csv -> "Before splitCsv: $csv" }
+                             .splitCsv()
+                             .view { csv -> "After splitCsv: $csv" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="6-8"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                             .view { greeting -> "Before flatten: $greeting" }
+                             // .flatten()
+                             // .view { greeting -> "After flatten: $greeting" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Como você pode ver, também atualizamos as instruções `view()` de antes/depois.
+Tecnicamente poderíamos ter usado o mesmo nome de variável (`greeting`) mas atualizamos para algo mais apropriado (`csv`) para tornar o código mais legível por outros.
+
+#### 4.2.2. Execute o fluxo de trabalho novamente
+
+Vamos tentar executar o fluxo de trabalho com a lógica de análise de CSV adicionada.
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? failure "Saída do comando"
+
+    ```console hl_lines="7-11 14 19"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [insane_fermat] DSL2 - revision: 8e62fcbeb1
+
+    executor >  local (3)
+    [24/76da2f] sayHello (2) [  0%] 0 of 3 ✘
+    Before splitCsv: /workspaces/training/hello-nextflow/data/greetings.csv
+    After splitCsv: [Hello, English, 123]
+    After splitCsv: [Bonjour, French, 456]
+    After splitCsv: [Holà, Spanish, 789]
+    ERROR ~ Error executing process > 'sayHello (2)'
+
+    Caused by:
+      Missing output file(s) `[Bonjour, French, 456]-output.txt` expected by process `sayHello (2)`
+
+
+    Command executed:
+
+      echo '[Bonjour, French, 456]' > '[Bonjour, French, 456]-output.txt'
+
+    Command exit status:
+      0
+
+    Command output:
+      (empty)
+
+    Work dir:
+      /workspaces/training/hello-nextflow/work/24/76da2fcc4876b61632749f99e26a50
+
+    Tip: you can try to figure out what's wrong by changing to the process work dir and showing the script file named `.command.sh`
+
+    -- Check '.nextflow.log' file for details
+    ```
+
+Interessantemente, isso também falha, mas com um erro diferente.
+Desta vez o Nextflow analisou o conteúdo do arquivo (eba!) mas carregou cada linha como um array, e cada array é um elemento no canal.
+
+Precisamos dizer a ele para pegar apenas a primeira coluna em cada linha.
+Então como desempacotamos isso?
+
+Usamos anteriormente `flatten()` para desempacotar o conteúdo de um canal, mas isso não funcionaria aqui porque flatten desempacota _tudo_ (sinta-se livre para tentar se quiser ver por si mesmo).
+
+Em vez disso, usaremos outro operador chamado `map()` que é realmente útil e aparece muito em pipelines Nextflow.
+
+### 4.3. Use o operador `map()` para extrair as saudações
+
+O operador [`map()`](https://www.nextflow.io/docs/latest/reference/operator.html#map) é uma ferramenta muito útil que nos permite fazer todos os tipos de mapeamentos para o conteúdo de um canal.
+
+Neste caso, vamos usá-lo para extrair aquele único elemento que queremos de cada linha em nosso arquivo de dados.
+Esta é a aparência da sintaxe:
+
+```groovy title="Sintaxe"
+.map { row -> row[0] }
+```
+
+Isso significa 'para cada linha no canal, pegue o 0º (primeiro) item que ela contém'.
+
+Então vamos aplicar isso à nossa análise de CSV.
+
+#### 4.3.1. Aplique `map()` ao canal
+
+No bloco workflow, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="9 10"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                             .view { csv -> "Before splitCsv: $csv" }
+                             .splitCsv()
+                             .view { csv -> "After splitCsv: $csv" }
+                             .map { item -> item[0] }
+                             .view { csv -> "After map: $csv" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-channels.nf" linenums="27"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                             .view { csv -> "Before splitCsv: $csv" }
+                             .splitCsv()
+                             .view { csv -> "After splitCsv: $csv" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Você vê que adicionamos outra chamada `view()` para confirmar que o operador faz o que esperamos.
+
+#### 4.3.2. Execute o fluxo de trabalho
+
+Vamos executar isso mais uma vez:
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [focused_volhard] DSL2 - revision: de435e45be
+
+    executor >  local (3)
+    [54/6eebe3] sayHello (3) [100%] 3 of 3 ✔
+    Before splitCsv: /workspaces/training/hello-nextflow/data/greetings.csv
+    After splitCsv: [Hello, English, 123]
+    After splitCsv: [Bonjour, French, 456]
+    After splitCsv: [Holà, Spanish, 789]
+    After map: Hello
+    After map: Bonjour
+    After map: Holà
+    ```
+
+Desta vez deve executar sem erros.
+
+Olhando para a saída das instruções `view()`, você vê o seguinte:
+
+- Uma única instrução `Before splitCsv:`: nesse ponto o canal contém um item, o caminho do arquivo original.
+- Três instruções `After splitCsv:` separadas: uma para cada saudação, mas cada uma está contida dentro de um array que corresponde àquela linha no arquivo.
+- Três instruções `After map:` separadas: uma para cada saudação, que agora são elementos individuais no canal.
+
+Note que as linhas podem aparecer em uma ordem diferente na sua saída.
+
+Você também pode olhar os arquivos de saída para verificar que cada saudação foi corretamente extraída e processada através do fluxo de trabalho.
+
+Alcançamos o mesmo resultado de antes, mas agora temos muito mais flexibilidade para adicionar mais elementos ao canal de saudações que queremos processar modificando um arquivo de entrada, sem modificar nenhum código.
+Você aprenderá abordagens mais sofisticadas para lidar com entradas complexas em um treinamento posterior.
+
+### Conclusão
+
+Você sabe como usar o construtor de canal `.fromPath()` e os operadores `splitCsv()` e `map()` para ler um arquivo de valores de entrada e lidar com eles apropriadamente.
+
+De forma mais geral, você tem uma compreensão básica de como o Nextflow usa **canais** para gerenciar entradas para processos e **operadores** para transformar seu conteúdo.
+
+### O que vem a seguir?
+
+Faça uma grande pausa, você trabalhou duro nesta seção!
+
+Quando estiver pronto, prossiga para [**Parte 3: Olá Fluxo de Trabalho**](./03_hello_workflow.md) para aprender como adicionar mais etapas e conectá-las em um fluxo de trabalho adequado.
+
+---
+
+## Quiz
+
+<quiz>
+O que é um canal no Nextflow?
+- [ ] Uma especificação de caminho de arquivo
+- [ ] Uma definição de processo
+- [x] Uma estrutura tipo fila para passar dados entre processos
+- [ ] Uma configuração de definição
+
+Saiba mais: [1.1. Crie um canal de entrada](#11-crie-um-canal-de-entrada)
+</quiz>
+
+<quiz>
+O que este código produzirá como saída?
+
+```groovy
+channel.of('Hello', 'Bonjour', 'Hola')
+    .view()
+```
+
+- [ ] `['Hello', 'Bonjour', 'Hola']` (uma única lista)
+- [x] Cada elemento em uma linha separada: `Hello`, `Bonjour`, `Hola`
+- [ ] Nada (canais não imprimem por padrão)
+- [ ] Um erro (sintaxe inválida)
+
+Saiba mais: [1.1. Crie um canal de entrada](#11-crie-um-canal-de-entrada)
+</quiz>
+
+<quiz>
+Quando um canal contém múltiplos valores, como o Nextflow lida com a execução do processo?
+- [ ] O processo executa uma vez com todos os valores
+- [x] O processo executa uma vez para cada valor no canal
+- [ ] O processo executa apenas com o primeiro valor
+- [ ] O processo executa apenas com o último valor
+
+Saiba mais: [2. Modifique o fluxo de trabalho para executar em múltiplos valores de entrada](#2-modifique-o-fluxo-de-trabalho-para-executar-em-multiplos-valores-de-entrada)
+</quiz>
+
+<quiz>
+O que o operador `flatten()` faz?
+- [ ] Combina múltiplos canais em um
+- [ ] Ordena elementos do canal
+- [x] Desempacota arrays em elementos individuais
+- [ ] Remove elementos duplicados
+
+Saiba mais: [3.2.1. Adicione o operador `flatten()`](#321-adicione-o-operador-flatten)
+</quiz>
+
+<quiz>
+Qual é o propósito do operador `view()`?
+- [ ] Para filtrar o conteúdo do canal
+- [ ] Para transformar elementos do canal
+- [x] Para inspecionar e depurar o conteúdo do canal
+- [ ] Para salvar o conteúdo do canal em um arquivo
+
+Saiba mais: [1.4. Use `view()` para inspecionar o conteúdo do canal](#14-use-view-para-inspecionar-o-conteudo-do-canal)
+</quiz>
+
+<quiz>
+O que `splitCsv()` faz?
+- [ ] Cria um arquivo CSV a partir do conteúdo do canal
+- [ ] Divide uma string por vírgulas
+- [x] Analisa um arquivo CSV em arrays representando cada linha
+- [ ] Mescla múltiplos arquivos CSV
+
+Saiba mais: [4.2. Use o operador `splitCsv()` para analisar o arquivo](#42-use-o-operador-splitcsv-para-analisar-o-arquivo)
+</quiz>
+
+<quiz>
+Qual é o propósito do operador `map()`?
+- [ ] Para filtrar elementos de um canal
+- [ ] Para combinar múltiplos canais
+- [x] Para transformar cada elemento em um canal
+- [ ] Para contar elementos em um canal
+
+Saiba mais: [4.3. Use o operador `map()` para extrair as saudações](#43-use-o-operador-map-para-extrair-as-saudacoes)
+</quiz>
+
+<quiz>
+Por que é importante usar nomes de arquivo de saída dinâmicos ao processar múltiplas entradas?
+- [ ] Para melhorar o desempenho
+- [ ] Para reduzir o espaço em disco
+- [x] Para evitar que arquivos de saída se sobrescrevam
+- [ ] Para habilitar a funcionalidade de resume
+
+Saiba mais: [2.2. Garanta que os nomes dos arquivos de saída sejam únicos](#22-garanta-que-os-nomes-dos-arquivos-de-saida-sejam-unicos)
+</quiz>

--- a/docs/pt/docs/hello_nextflow/03_hello_workflow.md
+++ b/docs/pt/docs/hello_nextflow/03_hello_workflow.md
@@ -1,0 +1,1170 @@
+# Parte 3: Olá Fluxo de Trabalho
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/zJP7cUYPEbA?si=Irl9nAQniDyICp2b&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Veja [a playlist completa](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) no canal do Nextflow no YouTube.
+
+:green_book: A transcrição do vídeo está disponível [aqui](./transcripts/03_hello_workflow.md).
+///
+
+A maioria dos fluxos de trabalho do mundo real envolve mais de uma etapa.
+Neste módulo de treinamento, você aprenderá como conectar processos em um fluxo de trabalho de múltiplas etapas.
+
+Isso ensinará a você a maneira Nextflow de realizar o seguinte:
+
+1. Fazer os dados fluírem de um processo para o próximo
+2. Coletar saídas de múltiplas chamadas de processo em uma única chamada de processo
+3. Passar mais de uma entrada para um processo
+4. Gerenciar múltiplas saídas vindas de um processo
+
+Para demonstrar, continuaremos construindo sobre o exemplo Hello World agnóstico de domínio das Partes 1 e 2.
+Desta vez, faremos as seguintes alterações em nosso fluxo de trabalho para refletir melhor como as pessoas constroem fluxos de trabalho reais:
+
+1. Adicionar uma segunda etapa que converte a saudação para maiúsculas.
+2. Adicionar uma terceira etapa que coleta todas as saudações transformadas e as escreve em um único arquivo.
+3. Adicionar um parâmetro para nomear o arquivo de saída final e passá-lo como uma entrada secundária para a etapa de coleta.
+4. Fazer a etapa de coleta também relatar uma estatística simples sobre o que foi processado.
+
+??? info "Como começar a partir desta seção"
+
+    Esta seção do curso pressupõe que você completou as Partes 1-2 do curso [Hello Nextflow](./index.md), mas se você está confortável com os conceitos básicos cobertos nessas seções, pode começar a partir daqui sem fazer nada especial.
+
+---
+
+## 0. Aquecimento: Execute `hello-workflow.nf`
+
+Vamos usar o script de fluxo de trabalho `hello-workflow.nf` como ponto de partida.
+Ele é equivalente ao script produzido ao trabalhar na Parte 2 deste curso de treinamento, exceto que removemos as instruções `view()` e alteramos o destino de saída:
+
+```groovy title="hello-workflow.nf" linenums="37" hl_lines="3"
+output {
+    first_output {
+        path 'hello_workflow'
+        mode 'copy'
+    }
+}
+```
+
+Apenas para ter certeza de que tudo está funcionando, execute o script uma vez antes de fazer quaisquer alterações:
+
+```bash
+nextflow run hello-workflow.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [admiring_lamarr] DSL2 - revision: 4d4053520d
+
+    executor >  local (3)
+    [b1/5826b5] process > sayHello (2) [100%] 3 of 3 ✔
+    ```
+
+Como anteriormente, você encontrará os arquivos de saída no local especificado no bloco `output`.
+Para este capítulo, está em `results/hello_workflow/`.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    results/hello_workflow
+    ├── Bonjour-output.txt
+    ├── Hello-output.txt
+    └── Holà-output.txt
+    ```
+
+Se isso funcionou para você, você está pronto para aprender como montar um fluxo de trabalho de múltiplas etapas.
+
+---
+
+## 1. Adicione uma segunda etapa ao fluxo de trabalho
+
+Vamos adicionar uma etapa para converter cada saudação para maiúsculas.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-multistep.svg"
+</figure>
+
+Para isso, precisamos fazer três coisas:
+
+- Definir o comando que vamos usar para fazer a conversão para maiúsculas.
+- Escrever um novo processo que envolve o comando de conversão para maiúsculas.
+- Chamar o novo processo no bloco de fluxo de trabalho e configurá-lo para receber a saída do processo `sayHello()` como entrada.
+
+### 1.1. Defina o comando de conversão para maiúsculas e teste-o no terminal
+
+Para fazer a conversão das saudações para maiúsculas, vamos usar uma ferramenta UNIX clássica chamada `tr` para 'text replacement', com a seguinte sintaxe:
+
+```bash title="Sintaxe"
+tr '[a-z]' '[A-Z]'
+```
+
+Esta é uma substituição de texto muito simples que não leva em conta letras acentuadas, então por exemplo 'Holà' se tornará 'HOLà', mas fará um trabalho bom o suficiente para demonstrar os conceitos do Nextflow e isso é o que importa.
+
+Para testá-lo, podemos executar o comando `echo 'Hello World'` e direcionar sua saída para o comando `tr`:
+
+```bash
+echo 'Hello World' | tr '[a-z]' '[A-Z]' > UPPER-output.txt
+```
+
+A saída é um arquivo de texto chamado `UPPER-output.txt` que contém a versão em maiúsculas da string `Hello World`.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="UPPER-output.txt"
+    HELLO WORLD
+    ```
+
+Isso é basicamente o que vamos tentar fazer com nosso fluxo de trabalho.
+
+### 1.2. Escreva a etapa de conversão para maiúsculas como um processo Nextflow
+
+Podemos modelar nosso novo processo no primeiro, já que queremos usar todos os mesmos componentes.
+
+Adicione a seguinte definição de processo ao script de fluxo de trabalho, logo abaixo da primeira:
+
+```groovy title="hello-workflow.nf" linenums="20"
+/*
+ * Use uma ferramenta de substituição de texto para converter a saudação para maiúsculas
+ */
+process convertToUpper {
+
+    input:
+    path input_file
+
+    output:
+    path "UPPER-${input_file}"
+
+    script:
+    """
+    cat '$input_file' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    """
+}
+```
+
+Neste, compomos o segundo nome de arquivo de saída baseado no nome do arquivo de entrada, de forma similar ao que fizemos originalmente para a saída do primeiro processo.
+
+### 1.3. Adicione uma chamada ao novo processo no bloco de fluxo de trabalho
+
+Agora precisamos dizer ao Nextflow para realmente chamar o processo que acabamos de definir.
+
+No bloco de fluxo de trabalho, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="44" hl_lines="10-11"
+    workflow {
+
+        main:
+        // cria um canal para entradas de um arquivo CSV
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emite uma saudação
+        sayHello(greeting_ch)
+        // converte a saudação para maiúsculas
+        convertToUpper()
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="44"
+    workflow {
+
+        main:
+        // cria um canal para entradas de um arquivo CSV
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emite uma saudação
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Isso ainda não é funcional porque não especificamos o que deve ser entrada para o processo `convertToUpper()`.
+
+### 1.4. Passe a saída do primeiro processo para o segundo processo
+
+Agora precisamos fazer a saída do processo `sayHello()` fluir para o processo `convertToUpper()`.
+
+Convenientemente, o Nextflow empacota automaticamente a saída de um processo em um canal chamado `<process>.out`.
+Então a saída do processo `sayHello` é um canal chamado `sayHello.out`, que podemos conectar diretamente na chamada para `convertToUpper()`.
+
+No bloco de fluxo de trabalho, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="53" hl_lines="2"
+        // converte a saudação para maiúsculas
+        convertToUpper(sayHello.out)
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="53" hl_lines="2"
+        // converte a saudação para maiúsculas
+        convertToUpper()
+    ```
+
+Para um caso simples como este (uma saída para uma entrada), isso é tudo que precisamos fazer para conectar dois processos!
+
+### 1.5. Configure a publicação da saída do fluxo de trabalho
+
+Finalmente, vamos atualizar as saídas do fluxo de trabalho para publicar os resultados do segundo processo também.
+
+#### 1.5.1. Atualize a seção `publish:` do bloco `workflow`
+
+No bloco `workflow`, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="56" hl_lines="3"
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="56"
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+A lógica é a mesma de antes.
+
+#### 1.5.2. Atualize o bloco `output`
+
+No bloco `output`, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="61" hl_lines="6-9"
+    output {
+        first_output {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="61"
+    output {
+        first_output {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+    }
+    ```
+
+Mais uma vez, a lógica é a mesma de antes.
+
+Isso mostra que você pode controlar as configurações de saída em um nível muito granular, para cada saída individual.
+Sinta-se à vontade para tentar mudar os caminhos ou o modo de publicação para um dos processos para ver o que acontece.
+
+Claro, isso significa que estamos repetindo algumas informações aqui, o que pode se tornar inconveniente se quisermos atualizar a localização para todas as saídas da mesma forma.
+Mais tarde no curso, você aprenderá como configurar essas definições para múltiplas saídas de forma estruturada.
+
+### 1.6. Execute o fluxo de trabalho com `-resume`
+
+Vamos testar isso usando a flag `-resume`, já que já executamos a primeira etapa do fluxo de trabalho com sucesso.
+
+```bash
+nextflow run hello-workflow.nf -resume
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [high_cantor] DSL2 - revision: d746983511
+
+    executor >  local (3)
+    [ab/816321] process > sayHello (3)       [100%] 3 of 3, cached: 3 ✔
+    [e0/ecf81b] process > convertToUpper (3) [100%] 3 of 3 ✔
+    ```
+
+Agora há uma linha extra na saída do console que corresponde ao novo processo que acabamos de adicionar.
+
+Você encontrará as saídas no diretório `results/hello_workflow` conforme definido no bloco `output`.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    results/hello_workflow/
+    ├── Bonjour-output.txt
+    ├── Hello-output.txt
+    ├── Holà-output.txt
+    ├── UPPER-Bonjour-output.txt
+    ├── UPPER-Hello-output.txt
+    └── UPPER-Holà-output.txt
+    ```
+
+Isso é conveniente! Mas ainda vale a pena dar uma olhada dentro do diretório de trabalho de uma das chamadas ao segundo processo.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    work/e0/ecf81b4cacc648b9b994218d5b29d7/
+    ├── Holà-output.txt -> /workspaces/training/hello-nextflow/work/ab/81632178cd37e9e815959278808819/Holà-output.txt
+    └── UPPER-Holà-output.txt
+    ```
+
+Note que há dois arquivos `*-output`: a saída do primeiro processo assim como a saída do segundo.
+
+A saída do primeiro processo está lá porque o Nextflow a **preparou** (staged) ali para ter tudo o que é necessário para execução dentro do mesmo subdiretório.
+
+No entanto, é na verdade um link simbólico apontando para o arquivo original no subdiretório da primeira chamada de processo.
+Por padrão, ao executar em uma única máquina como estamos fazendo aqui, o Nextflow usa links simbólicos em vez de cópias para preparar arquivos de entrada e intermediários.
+
+Agora, antes de prosseguir, pense em como tudo o que fizemos foi conectar a saída de `sayHello` à entrada de `convertToUpper` e os dois processos puderam ser executados em série.
+O Nextflow fez o trabalho pesado de gerenciar arquivos individuais de entrada e saída e passá-los entre os dois comandos para nós.
+
+Esta é uma das razões pelas quais os canais do Nextflow são tão poderosos: eles cuidam do trabalho tedioso envolvido em conectar as etapas do fluxo de trabalho.
+
+### Conclusão
+
+Você sabe como encadear processos conectando a saída de uma etapa como entrada para a próxima etapa.
+
+### O que vem a seguir?
+
+Aprenda como coletar saídas de chamadas de processo em lote e alimentá-las em um único processo.
+
+---
+
+## 2. Adicione uma terceira etapa para coletar todas as saudações
+
+Quando usamos um processo para aplicar uma transformação a cada um dos elementos em um canal, como estamos fazendo aqui para as múltiplas saudações, às vezes queremos coletar elementos do canal de saída desse processo e alimentá-los em outro processo que realiza algum tipo de análise ou soma.
+
+Para demonstrar, adicionaremos uma nova etapa ao nosso pipeline que coleta todas as saudações em maiúsculas produzidas pelo processo `convertToUpper` e as escreve em um único arquivo.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-collect.svg"
+</figure>
+
+Sem estragar a surpresa, mas isso vai envolver um operador muito útil.
+
+### 2.1. Defina o comando de coleta e teste-o no terminal
+
+A etapa de coleta que queremos adicionar ao nosso fluxo de trabalho usará o comando `cat` para concatenar múltiplas saudações em maiúsculas em um único arquivo.
+
+Vamos executar o comando sozinho no terminal para verificar que funciona conforme esperado, assim como fizemos anteriormente.
+
+Execute o seguinte em seu terminal:
+
+```bash
+echo 'Hello' | tr '[a-z]' '[A-Z]' > UPPER-Hello-output.txt
+echo 'Bonjour' | tr '[a-z]' '[A-Z]' > UPPER-Bonjour-output.txt
+echo 'Holà' | tr '[a-z]' '[A-Z]' > UPPER-Holà-output.txt
+cat UPPER-Hello-output.txt UPPER-Bonjour-output.txt UPPER-Holà-output.txt > COLLECTED-output.txt
+```
+
+A saída é um arquivo de texto chamado `COLLECTED-output.txt` que contém as versões em maiúsculas das saudações originais.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="COLLECTED-output.txt"
+    HELLO
+    BONJOUR
+    HOLà
+    ```
+
+Esse é o resultado que queremos alcançar com nosso fluxo de trabalho.
+
+### 2.2. Crie um novo processo para fazer a etapa de coleta
+
+Vamos criar um novo processo e chamá-lo de `collectGreetings()`.
+Podemos começar a escrevê-lo com base no que já vimos antes.
+
+#### 2.2.1. Escreva as partes 'óbvias' do processo
+
+Adicione a seguinte definição de processo ao script de fluxo de trabalho:
+
+```groovy title="hello-workflow.nf" linenums="37"
+/*
+ * Coleta saudações em maiúsculas em um único arquivo de saída
+ */
+process collectGreetings {
+
+    input:
+    ???
+
+    output:
+    path "COLLECTED-output.txt"
+
+    script:
+    """
+    cat ??? > 'COLLECTED-output.txt'
+    """
+}
+```
+
+Isso é o que podemos escrever com confiança com base no que você aprendeu até agora.
+Mas isso não é funcional!
+Deixa de fora a(s) definição(ões) de entrada e a primeira metade do comando do script porque precisamos descobrir como escrever isso.
+
+#### 2.2.2. Defina as entradas para `collectGreetings()`
+
+Precisamos coletar as saudações de todas as chamadas ao processo `convertToUpper()`.
+O que sabemos que podemos obter da etapa anterior no fluxo de trabalho?
+
+O canal de saída de `convertToUpper()` conterá os caminhos para os arquivos individuais contendo as saudações em maiúsculas.
+Isso equivale a um slot de entrada; vamos chamá-lo de `input_files` por simplicidade.
+
+No bloco de processo, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="42" hl_lines="2"
+          input:
+          path input_files
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="42" hl_lines="2"
+          input:
+          ???
+    ```
+
+Note que usamos o prefixo `path` mesmo esperando que isso contenha múltiplos arquivos.
+
+#### 2.2.3. Componha o comando de concatenação
+
+É aqui que as coisas podem ficar um pouco complicadas, porque precisamos ser capazes de lidar com um número arbitrário de arquivos de entrada.
+Especificamente, não podemos escrever o comando antecipadamente, então precisamos dizer ao Nextflow como compô-lo em tempo de execução com base nas entradas que fluem para o processo.
+
+Em outras palavras, se tivermos um canal de entrada contendo o elemento `[file1.txt, file2.txt, file3.txt]`, precisamos que o Nextflow transforme isso em `cat file1.txt file2.txt file3.txt`.
+
+Felizmente, o Nextflow fica feliz em fazer isso por nós se simplesmente escrevermos `cat ${input_files}` no comando do script.
+
+No bloco de processo, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="54" hl_lines="3"
+        script:
+        """
+        cat ${input_files} > 'COLLECTED-output.txt'
+        """
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="54"
+        script:
+        """
+        cat ??? > 'COLLECTED-output.txt'
+        """
+    ```
+
+Em teoria, isso deve lidar com qualquer número arbitrário de arquivos de entrada.
+
+!!! tip
+
+    Algumas ferramentas de linha de comando exigem fornecer um argumento (como `-input`) para cada arquivo de entrada.
+    Nesse caso, teríamos que fazer um pouco de trabalho extra para compor o comando.
+    Você pode ver um exemplo disso no curso de treinamento [Nextflow for Genomics](../../nf4_science/genomics/).
+
+### 2.3. Adicione a etapa de coleta ao fluxo de trabalho
+
+Agora devemos apenas precisar chamar o processo de coleta na saída da etapa de conversão para maiúsculas.
+
+#### 2.3.1. Conecte as chamadas de processo
+
+No bloco de fluxo de trabalho, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="75" hl_lines="4 5"
+        // converte a saudação para maiúsculas
+        convertToUpper(sayHello.out)
+
+        // coleta todas as saudações em um arquivo
+        collectGreetings(convertToUpper.out)
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="75"
+        // converte a saudação para maiúsculas
+        convertToUpper(sayHello.out)
+    }
+    ```
+
+Isso conecta a saída de `convertToUpper()` à entrada de `collectGreetings()`.
+
+#### 2.3.2. Execute o fluxo de trabalho com `-resume`
+
+Vamos tentar.
+
+```bash
+nextflow run hello-workflow.nf -resume
+```
+
+??? success "Saída do comando"
+
+    ```console hl_lines="8"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [mad_gilbert] DSL2 - revision: 6acfd5e28d
+
+    executor >  local (3)
+    [79/33b2f0] sayHello (2)         | 3 of 3, cached: 3 ✔
+    [99/79394f] convertToUpper (3)   | 3 of 3, cached: 3 ✔
+    [47/50fe4a] collectGreetings (1) | 3 of 3 ✔
+    ```
+
+Ele é executado com sucesso, incluindo a terceira etapa.
+
+No entanto, olhe o número de chamadas para `collectGreetings()` na última linha.
+Estávamos esperando apenas uma, mas há três.
+
+Agora dê uma olhada no conteúdo do arquivo de saída final.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/COLLECTED-output.txt"
+    Holà
+    ```
+
+Oh não. A etapa de coleta foi executada individualmente em cada saudação, o que NÃO é o que queríamos.
+
+Precisamos fazer algo para dizer ao Nextflow explicitamente que queremos que a terceira etapa seja executada em todos os elementos no canal de saída de `convertToUpper()`.
+
+### 2.4. Use um operador para coletar as saudações em uma única entrada
+
+Sim, mais uma vez a resposta para nosso problema é um operador.
+
+Especificamente, vamos usar o operador apropriadamente chamado [`collect()`](https://www.nextflow.io/docs/latest/reference/operator.html#collect).
+
+#### 2.4.1. Adicione o operador `collect()`
+
+Desta vez vai parecer um pouco diferente porque não estamos adicionando o operador no contexto de uma fábrica de canal; estamos adicionando-o a um canal de saída.
+
+Pegamos o `convertToUpper.out` e acrescentamos o operador `collect()`, o que nos dá `convertToUpper.out.collect()`.
+Podemos conectar isso diretamente na chamada do processo `collectGreetings()`.
+
+No bloco de fluxo de trabalho, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="73" hl_lines="2"
+        // coleta todas as saudações em um arquivo
+        collectGreetings(convertToUpper.out.collect())
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="73" hl_lines="2"
+        // coleta todas as saudações em um arquivo
+        collectGreetings(convertToUpper.out)
+    }
+    ```
+
+#### 2.4.2. Adicione algumas instruções `view()`
+
+Vamos também incluir algumas instruções `view()` para visualizar os estados antes e depois do conteúdo do canal.
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="73" hl_lines="4-6"
+        // coleta todas as saudações em um arquivo
+        collectGreetings(convertToUpper.out.collect())
+
+        // instruções view opcionais
+        convertToUpper.out.view { contents -> "Antes do collect: $contents" }
+        convertToUpper.out.collect().view { contents -> "Depois do collect: $contents" }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="73"
+        // coleta todas as saudações em um arquivo
+        collectGreetings(convertToUpper.out.collect())
+    }
+    ```
+
+As instruções `view()` podem ir em qualquer lugar que você quiser; as colocamos logo após a chamada para legibilidade.
+
+#### 2.4.3. Execute o fluxo de trabalho novamente com `-resume`
+
+Vamos tentar:
+
+```bash
+nextflow run hello-workflow.nf -resume
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [soggy_franklin] DSL2 - revision: bc8e1b2726
+
+    [d6/cdf466] sayHello (1)       | 3 of 3, cached: 3 ✔
+    [99/79394f] convertToUpper (2) | 3 of 3, cached: 3 ✔
+    [1e/83586c] collectGreetings   | 1 of 1 ✔
+    Antes do collect: /workspaces/training/hello-nextflow/work/b3/d52708edba8b864024589285cb3445/UPPER-Bonjour-output.txt
+    Antes do collect: /workspaces/training/hello-nextflow/work/99/79394f549e3040dfc2440f69ede1fc/UPPER-Hello-output.txt
+    Antes do collect: /workspaces/training/hello-nextflow/work/aa/56bfe7cf00239dc5badc1d04b60ac4/UPPER-Holà-output.txt
+    Depois do collect: [/workspaces/training/hello-nextflow/work/b3/d52708edba8b864024589285cb3445/UPPER-Bonjour-output.txt, /workspaces/training/hello-nextflow/work/99/79394f549e3040dfc2440f69ede1fc/UPPER-Hello-output.txt, /workspaces/training/hello-nextflow/work/aa/56bfe7cf00239dc5badc1d04b60ac4/UPPER-Holà-output.txt]
+    ```
+
+Ele é executado com sucesso, embora a saída de log possa parecer um pouco mais bagunçada do que isso (nós a limpamos para legibilidade).
+
+Desta vez a terceira etapa foi chamada apenas uma vez!
+
+Olhando para a saída das instruções `view()`, vemos o seguinte:
+
+- Três instruções `Antes do collect:`, uma para cada saudação: nesse ponto os caminhos dos arquivos são itens individuais no canal.
+- Uma única instrução `Depois do collect:`: os três caminhos de arquivos agora estão empacotados em um único elemento.
+
+Dê uma olhada no conteúdo do arquivo de saída final.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/COLLECTED-output.txt"
+    BONJOUR
+    HELLO
+    HOLà
+    ```
+
+Desta vez temos todas as três saudações no arquivo de saída final. Sucesso!
+
+!!! note
+
+    Se você executar isso várias vezes sem `-resume`, verá que a ordem das saudações muda de uma execução para outra.
+    Isso mostra que a ordem na qual os elementos fluem através das chamadas de processo não é garantida ser consistente.
+
+#### 2.4.4. Remova as instruções `view()` para legibilidade
+
+Antes de passar para a próxima seção, recomendamos que você delete as instruções `view()` para evitar poluir a saída do console.
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="73"
+        // coleta todas as saudações em um arquivo
+        collectGreetings(convertToUpper.out.collect())
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="73" hl_lines="4-6"
+        // coleta todas as saudações em um arquivo
+        collectGreetings(convertToUpper.out.collect())
+
+        // instruções view opcionais
+        convertToUpper.out.view { contents -> "Antes do collect: $contents" }
+        convertToUpper.out.collect().view { contents -> "Depois do collect: $contents" }
+    ```
+
+Esta é basicamente a operação inversa do ponto 2.4.2.
+
+### Conclusão
+
+Você sabe como coletar saídas de um lote de chamadas de processo e alimentá-las em uma etapa de análise conjunta ou soma.
+
+### O que vem a seguir?
+
+Aprenda como passar mais de uma entrada para um processo.
+
+---
+
+## 3. Passe mais de uma entrada para um processo
+
+Queremos ser capazes de nomear o arquivo de saída final com algo específico para processar lotes subsequentes de saudações sem sobrescrever os resultados finais.
+
+Para isso, faremos os seguintes refinamentos no fluxo de trabalho:
+
+- Modificar o processo coletor para aceitar um nome definido pelo usuário para o arquivo de saída
+- Adicionar um parâmetro de linha de comando ao fluxo de trabalho e passá-lo ao processo coletor
+
+### 3.1. Modifique o processo coletor
+
+Vamos precisar declarar a entrada adicional e integrá-la ao nome do arquivo de saída.
+
+#### 3.1.1. Declare a entrada adicional
+
+Boas notícias: podemos declarar quantas variáveis de entrada quisermos na definição do processo.
+Vamos chamar esta de `batch_name`.
+
+No bloco de processo, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="42" hl_lines="3"
+        input:
+        path input_files
+        val batch_name
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="42"
+        input:
+        path input_files
+    ```
+
+Você pode configurar seus processos para esperar quantas entradas quiser.
+Agora, todas estas estão configuradas para serem entradas obrigatórias; você _deve_ fornecer um valor para o fluxo de trabalho funcionar.
+
+Você aprenderá como gerenciar entradas obrigatórias versus opcionais mais tarde em sua jornada Nextflow.
+
+#### 3.1.2. Use a variável `batch_name` no nome do arquivo de saída
+
+Podemos inserir a variável no nome do arquivo de saída da mesma forma que compusemos nomes de arquivos dinâmicos antes.
+
+No bloco de processo, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="46" hl_lines="2 6"
+        output:
+        path "COLLECTED-${batch_name}-output.txt"
+
+        script:
+        """
+        cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+        """
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="46" hl_lines="2 6"
+        output:
+        path "COLLECTED-output.txt"
+
+        script:
+        """
+        cat ${input_files} > 'COLLECTED-output.txt'
+        """
+    ```
+
+Isso configura o processo para usar o valor `batch_name` para gerar um nome de arquivo específico para a saída final do fluxo de trabalho.
+
+### 3.2. Adicione um parâmetro de linha de comando `batch`
+
+Agora precisamos de uma forma de fornecer o valor para `batch_name` e alimentá-lo à chamada do processo.
+
+#### 3.2.1. Use `params` para configurar o parâmetro
+
+Você já sabe como usar o sistema `params` para declarar parâmetros CLI.
+Vamos usar isso para declarar um parâmetro `batch` (com um valor padrão porque somos preguiçosos).
+
+Na seção de parâmetros do pipeline, faça as seguintes alterações de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="55" hl_lines="6"
+    /*
+     * Parâmetros do pipeline
+     */
+    params {
+        input: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="55"
+    /*
+     * Parâmetros do pipeline
+     */
+    params {
+        input: Path = 'data/greetings.csv'
+    }
+    ```
+
+Assim como demonstramos para `--input`, você pode sobrescrever esse valor padrão especificando um valor com `--batch` na linha de comando.
+
+#### 3.2.2. Passe o parâmetro `batch` para o processo
+
+Para fornecer o valor do parâmetro ao processo, precisamos adicioná-lo na chamada do processo.
+
+No bloco de fluxo de trabalho, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="74" hl_lines="2"
+        // coleta todas as saudações em um arquivo
+        collectGreetings(convertToUpper.out.collect(), params.batch)
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="74" hl_lines="2"
+        // coleta todas as saudações em um arquivo
+        collectGreetings(convertToUpper.out.collect())
+    ```
+
+Você vê que para fornecer múltiplas entradas a um processo, você simplesmente as lista nos parênteses da chamada, separadas por vírgulas.
+
+!!! warning
+
+    Você DEVE fornecer as entradas ao processo na MESMA ORDEM EXATA em que estão listadas no bloco de definição de entrada do processo.
+
+### 3.3. Execute o fluxo de trabalho
+
+Vamos tentar executar isso com um nome de lote na linha de comando.
+
+```bash
+nextflow run hello-workflow.nf -resume --batch trio
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [confident_rutherford] DSL2 - revision: bc58af409c
+
+    executor >  local (1)
+    [79/33b2f0] sayHello (2)       | 3 of 3, cached: 3 ✔
+    [99/79394f] convertToUpper (2) | 3 of 3, cached: 3 ✔
+    [b5/f19efe] collectGreetings   | 1 of 1 ✔
+    ```
+
+Ele é executado com sucesso e produz a saída desejada:
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/COLLECTED-trio-output.txt"
+    HELLO
+    BONJOUR
+    HOLà
+    ```
+
+Agora, contanto que especifiquemos o parâmetro apropriadamente, execuções subsequentes em outros lotes de entradas não destruirão os resultados anteriores.
+
+### Conclusão
+
+Você sabe como passar mais de uma entrada para um processo.
+
+### O que vem a seguir?
+
+Aprenda como emitir múltiplas saídas e manuseá-las convenientemente.
+
+---
+
+## 4. Adicione uma saída à etapa coletora
+
+Até agora estivemos usando processos que produziam apenas uma saída cada.
+Conseguimos acessar suas respectivas saídas muito convenientemente usando a sintaxe `<process>.out`, que usamos tanto no contexto de passar uma saída para o próximo processo (por exemplo, `convertToUpper(sayHello.out)`) quanto no contexto da seção `publish:` (por exemplo, `first_output = sayHello.out`).
+
+O que acontece quando um processo produz mais de uma?
+Como lidamos com as múltiplas saídas?
+Podemos selecionar e usar uma saída específica?
+
+Todas excelentes perguntas, e a resposta curta é sim, podemos!
+
+Múltiplas saídas serão empacotadas em canais separados.
+Podemos escolher dar nomes a esses canais de saída, o que torna fácil referenciá-los individualmente mais tarde, ou podemos referenciá-los por índice.
+
+Vamos nos aprofundar com um exemplo.
+
+Para fins de demonstração, digamos que queremos contar o número de saudações que estão sendo coletadas para um determinado lote de entradas e relatá-lo em um arquivo.
+
+### 4.1. Modifique o processo para contar e gerar o número de saudações
+
+Isso exigirá duas mudanças-chave na definição do processo: precisamos de uma forma de contar as saudações e escrever um arquivo de relatório, então precisamos adicionar esse arquivo de relatório ao bloco `output` do processo.
+
+#### 4.1.1. Conte o número de saudações coletadas
+
+Convenientemente, o Nextflow nos permite adicionar código arbitrário no bloco `script:` da definição do processo, o que é muito útil para fazer coisas como essa.
+
+Isso significa que podemos usar a função integrada `size()` do Nextflow para obter o número de arquivos no array `input_files`, e escrever o resultado em arquivo com um comando `echo`.
+
+No bloco de processo `collectGreetings`, faça as seguintes alterações de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="55" hl_lines="2 5"
+        script:
+        count_greetings = input_files.size()
+        """
+        cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+        echo 'Havia ${count_greetings} saudações neste lote.' > '${batch_name}-report.txt'
+        """
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="55"
+        script:
+        """
+        cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+        """
+    ```
+
+A variável `count_greetings` será computada em tempo de execução.
+
+#### 4.1.2. Emita o arquivo de relatório e nomeie as saídas
+
+Em princípio, tudo o que precisamos fazer é adicionar o arquivo de relatório ao bloco `output:`.
+
+No entanto, enquanto estamos fazendo isso, também vamos adicionar algumas tags `emit:` às nossas declarações de saída. Estas nos permitirão selecionar as saídas por nome em vez de ter que usar índices posicionais.
+
+No bloco de processo, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="46" hl_lines="2 3"
+        output:
+        path "COLLECTED-${batch_name}-output.txt", emit: outfile
+        path "${batch_name}-report.txt", emit: report
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="46"
+        output:
+        path "COLLECTED-${batch_name}-output.txt"
+    ```
+
+As tags `emit:` são opcionais, e poderíamos ter adicionado uma tag a apenas uma das saídas.
+Mas como dizem, por que não ambos?
+
+!!! tip
+
+    Se você não nomear as saídas de um processo usando `emit:`, ainda pode acessá-las individualmente usando seu respectivo índice (baseado em zero).
+    Por exemplo, você usaria `<process>.out[0]` para obter a primeira saída, `<process>.out[1]` para obter a segunda saída, e assim por diante.
+
+    Preferimos nomear saídas porque caso contrário, é muito fácil pegar o índice errado por erro, especialmente quando o processo produz muitas saídas.
+
+### 4.2. Atualize as saídas do fluxo de trabalho
+
+Agora que temos duas saídas saindo do processo `collectGreetings`, a saída `collectGreetings.out` contém dois canais:
+
+- `collectGreetings.out.outfile` contém o arquivo de saída final
+- `collectGreetings.out.report` contém o arquivo de relatório
+
+Precisamos atualizar as saídas do fluxo de trabalho adequadamente.
+
+#### 4.2.1. Atualize a seção `publish:`
+
+No bloco `workflow`, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="80" hl_lines="4 5"
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out.outfile
+        batch_report = collectGreetings.out.report
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="80" hl_lines="4"
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out
+    ```
+
+Como você pode ver, referir-se a saídas específicas de processos agora é trivial.
+Quando formos adicionar mais um passo ao nosso pipeline na Parte 5 (Contêineres), poderemos facilmente nos referir a `collectGreetings.out.outfile` e passá-lo ao novo processo (spoiler: o novo processo se chama `cowpy`).
+
+Mas por enquanto, vamos terminar de atualizar as saídas no nível do fluxo de trabalho.
+
+#### 4.2.2. Atualize o bloco `output`
+
+No bloco `output`, faça a seguinte alteração de código:
+
+=== "Depois"
+
+    ```groovy title="hello-workflow.nf" linenums="86" hl_lines="14-17"
+    output {
+        first_output {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        collected {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        batch_report {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-workflow.nf" linenums="80"
+    output {
+        first_output {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        collected {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+    }
+    ```
+
+Não precisamos atualizar a definição de saída `collected` já que esse nome não mudou.
+Só precisamos adicionar a nova saída.
+
+### 4.3. Execute o fluxo de trabalho
+
+Vamos tentar executar isso com o lote atual de saudações.
+
+```bash
+nextflow run hello-workflow.nf -resume --batch trio
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [ecstatic_wilson] DSL2 - revision: c80285f8c8
+
+    executor >  local (1)
+    [c5/4c6ca9] sayHello (3)       [100%] 3 of 3, cached: 3 ✔
+    [0e/6cbc59] convertToUpper (3) [100%] 3 of 3, cached: 3 ✔
+    [02/61ead2] collectGreetings   [100%] 1 of 1 ✔
+    ```
+
+Se você olhar no diretório `results/hello_workflow/`, encontrará o novo arquivo de relatório, `trio-report.txt`.
+Abra-o para verificar que o fluxo de trabalho relatou corretamente a contagem de saudações que foram processadas.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```txt title="trio-report.txt"
+    Havia 3 saudações neste lote.
+    ```
+
+Sinta-se à vontade para adicionar mais saudações ao CSV e testar o que acontece.
+
+### Conclusão
+
+Você sabe como fazer um processo emitir múltiplas saídas nomeadas e como manuseá-las apropriadamente no nível do fluxo de trabalho.
+
+De forma mais geral, você entende os princípios-chave envolvidos em conectar processos de formas comuns.
+
+### O que vem a seguir?
+
+Faça uma pausa extra longa, você a merece.
+
+Quando estiver pronto, passe para [**Parte 4: Olá Módulos**](./04_hello_modules.md) para aprender como modularizar seu código para melhor manutenibilidade e eficiência de código.
+
+---
+
+## Quiz
+
+<quiz>
+Como você acessa a saída de um processo no bloco de fluxo de trabalho?
+- [ ] `process.output`
+- [ ] `output.processName`
+- [x] `processName.out`
+- [ ] `get(processName)`
+
+Saiba mais: [1.4. Passe a saída do primeiro processo para o segundo processo](#14-passe-a-saída-do-primeiro-processo-para-o-segundo-processo)
+</quiz>
+
+<quiz>
+O que determina a ordem de execução de processos no Nextflow?
+- [ ] A ordem em que os processos são escritos no bloco de fluxo de trabalho
+- [ ] Ordem alfabética pelo nome do processo
+- [x] Dependências de dados entre processos
+- [ ] Ordem aleatória para execução paralela
+
+Saiba mais: [1.4. Passe a saída do primeiro processo para o segundo processo](#14-passe-a-saída-do-primeiro-processo-para-o-segundo-processo)
+</quiz>
+
+<quiz>
+Qual operador deve substituir `???` para reunir todas as saídas em uma única lista para o processo downstream?
+
+```groovy hl_lines="4"
+workflow {
+    greetings_ch = Channel.of('Hello', 'Bonjour', 'Hola')
+    SAYHELLO(greetings_ch)
+    GATHER_ALL(SAYHELLO.out.???)
+}
+```
+
+- [ ] `flatten()`
+- [x] `collect()`
+- [ ] `mix()`
+- [ ] `join()`
+
+Saiba mais: [2.4. Use um operador para coletar as saudações em uma única entrada](#24-use-um-operador-para-coletar-as-saudações-em-uma-única-entrada)
+</quiz>
+
+<quiz>
+Quando você deve usar o operador `collect()`?
+- [ ] Quando você quer processar itens em paralelo
+- [ ] Quando você precisa filtrar conteúdo do canal
+- [x] Quando um processo downstream precisa de todos os itens de um processo upstream
+- [ ] Quando você quer dividir dados entre múltiplos processos
+
+Saiba mais: [2.4. Use um operador para coletar as saudações em uma única entrada](#24-use-um-operador-para-coletar-as-saudações-em-uma-única-entrada)
+</quiz>
+
+<quiz>
+Como você acessa uma saída nomeada de um processo?
+- [ ] `processName.outputName`
+- [ ] `processName.get(outputName)`
+- [x] `processName.out.outputName`
+- [ ] `output.processName.outputName`
+
+Saiba mais: [4.1.2. Emita o arquivo de relatório e nomeie as saídas](#412-emita-o-arquivo-de-relatório-e-nomeie-as-saídas)
+</quiz>
+
+<quiz>
+Qual é a sintaxe correta para nomear uma saída em um processo?
+- [ ] `name: outputName`
+- [ ] `output: outputName`
+- [x] `emit: outputName`
+- [ ] `label: outputName`
+
+Saiba mais: [4.1.2. Emita o arquivo de relatório e nomeie as saídas](#412-emita-o-arquivo-de-relatório-e-nomeie-as-saídas)
+</quiz>
+
+<quiz>
+Ao fornecer múltiplas entradas a um processo, o que deve ser verdadeiro?
+- [ ] Todas as entradas devem ser do mesmo tipo
+- [ ] As entradas devem ser fornecidas em ordem alfabética
+- [x] A ordem das entradas deve corresponder à ordem definida no bloco de entrada
+- [ ] Apenas duas entradas podem ser fornecidas por vez
+
+Saiba mais: [3. Passe mais de uma entrada para um processo](#3-passe-mais-de-uma-entrada-para-um-processo)
+</quiz>

--- a/docs/pt/docs/hello_nextflow/04_hello_modules.md
+++ b/docs/pt/docs/hello_nextflow/04_hello_modules.md
@@ -1,0 +1,510 @@
+# Parte 4: Olá Módulos
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/Xxp_menS0E8?si=0AWnXB7xqHAzJdJV&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Veja [a playlist completa](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) no canal do Nextflow no YouTube.
+
+:green_book: A transcrição do vídeo está disponível [aqui](./transcripts/04_hello_modules.md).
+///
+
+Esta seção aborda como organizar o código do seu fluxo de trabalho para tornar o desenvolvimento e a manutenção do seu pipeline mais eficientes e sustentáveis.
+Especificamente, vamos demonstrar como usar **módulos**.
+
+No Nextflow, um **módulo** é uma única definição de processo que é encapsulada por si só em um arquivo de código independente.
+Para usar um módulo em um fluxo de trabalho, você apenas adiciona uma única linha de declaração de importação ao seu arquivo de código do fluxo de trabalho; então você pode integrar o processo no fluxo de trabalho da mesma forma que normalmente faria.
+Isso torna possível reutilizar definições de processos em múltiplos fluxos de trabalho sem produzir múltiplas cópias do código.
+
+Quando começamos a desenvolver nosso fluxo de trabalho, escrevemos tudo em um único arquivo de código.
+Agora vamos mover os processos para módulos individuais.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/modules.svg"
+</figure>
+
+Isso tornará nosso código mais compartilhável, flexível e de fácil manutenção.
+
+??? info "Como começar a partir desta seção"
+
+    Esta seção do curso pressupõe que você completou as Partes 1-3 do curso [Olá Nextflow](./index.md), mas se você está confortável com os conceitos básicos abordados nessas seções, pode começar a partir daqui sem fazer nada especial.
+
+---
+
+## 0. Aquecimento: Execute `hello-modules.nf`
+
+Vamos usar o script de fluxo de trabalho `hello-modules.nf` como ponto de partida.
+Ele é equivalente ao script produzido ao trabalhar na Parte 3 deste curso de treinamento, exceto que mudamos os destinos de saída:
+
+```groovy title="hello-modules.nf" linenums="37" hl_lines="3 7 11 15"
+output {
+    first_output {
+        path 'hello_modules'
+        mode 'copy'
+    }
+    uppercased {
+        path 'hello_modules'
+        mode 'copy'
+    }
+    collected {
+        path 'hello_modules'
+        mode 'copy'
+    }
+    batch_report {
+        path 'hello_modules'
+        mode 'copy'
+    }
+}
+```
+
+Apenas para ter certeza de que tudo está funcionando, execute o script uma vez antes de fazer quaisquer alterações:
+
+```bash
+nextflow run hello-modules.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-modules.nf` [hopeful_avogadro] DSL2 - revision: b09af1237d
+
+    executor >  local (7)
+    [0f/8795c9] sayHello (3)       [100%] 3 of 3 ✔
+    [6a/eb2510] convertToUpper (3) [100%] 3 of 3 ✔
+    [af/479117] collectGreetings   [100%] 1 of 1 ✔
+    ```
+
+Como anteriormente, você encontrará os arquivos de saída no diretório especificado no bloco `output` (aqui, `results/hello_modules/`).
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    results/hello_modules/
+    ├── Bonjour-output.txt
+    ├── COLLECTED-batch-output.txt
+    ├── Hello-output.txt
+    ├── Holà-output.txt
+    ├── batch-report.txt
+    ├── UPPER-Bonjour-output.txt
+    ├── UPPER-Hello-output.txt
+    └── UPPER-Holà-output.txt
+    ```
+
+Se funcionou para você, você está pronto para aprender como modularizar o código do seu fluxo de trabalho.
+
+---
+
+## 1. Crie um diretório para armazenar módulos
+
+É uma boa prática armazenar seus módulos em um diretório específico.
+Você pode chamar esse diretório de qualquer nome, mas a convenção é chamá-lo de `modules/`.
+
+```bash
+mkdir modules
+```
+
+!!! tip "Dica"
+
+    Aqui estamos mostrando como usar **módulos locais**, ou seja, módulos armazenados localmente no mesmo repositório que o restante do código do fluxo de trabalho, em contraste com módulos remotos, que são armazenados em outros repositórios (remotos).
+    Para mais informações sobre **módulos remotos**, veja a [documentação](https://www.nextflow.io/docs/latest/module.html).
+
+---
+
+## 2. Crie um módulo para `sayHello()`
+
+Na sua forma mais simples, transformar um processo existente em um módulo é pouco mais do que uma operação de copiar e colar.
+Vamos criar um esboço de arquivo para o módulo, copiar o código relevante e então excluí-lo do arquivo principal do fluxo de trabalho.
+
+Então tudo o que precisaremos fazer é adicionar uma declaração de importação para que o Nextflow saiba trazer o código relevante em tempo de execução.
+
+### 2.1. Crie um esboço de arquivo para o novo módulo
+
+Vamos criar um arquivo vazio para o módulo chamado `sayHello.nf`.
+
+```bash
+touch modules/sayHello.nf
+```
+
+Isso nos dá um lugar para colocar o código do processo.
+
+### 2.2. Mova o código do processo `sayHello` para o arquivo do módulo
+
+Copie toda a definição do processo do arquivo de fluxo de trabalho para o arquivo do módulo, certificando-se de copiar também o shebang `#!/usr/bin/env nextflow`.
+
+```groovy title="modules/sayHello.nf" linenums="1"
+#!/usr/bin/env nextflow
+
+/*
+ * Use echo to print 'Hello World!' to a file
+ */
+process sayHello {
+
+    input:
+    val greeting
+
+    output:
+    path "${greeting}-output.txt"
+
+    script:
+    """
+    echo '${greeting}' > '${greeting}-output.txt'
+    """
+}
+```
+
+Uma vez feito isso, exclua a definição do processo do arquivo de fluxo de trabalho, mas certifique-se de deixar o shebang no lugar.
+
+### 2.3. Adicione uma declaração de importação antes do bloco de fluxo de trabalho
+
+A sintaxe para importar um módulo local é bastante direta:
+
+```groovy title="Sintaxe: Declaração de importação"
+include { <NOME_DO_MÓDULO> } from '<caminho_para_o_módulo>'
+```
+
+Vamos inserir isso acima do bloco `params` e preenchê-lo adequadamente.
+
+=== "Depois"
+
+    ```groovy title="hello-modules.nf" linenums="44" hl_lines="1 2"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-modules.nf" linenums="44"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+Você vê que preenchemos o nome do módulo, `sayHello`, e o caminho para o arquivo contendo o código do módulo, `./modules/sayHello.nf`.
+
+### 2.4. Execute o fluxo de trabalho
+
+Estamos executando o fluxo de trabalho com essencialmente o mesmo código e entradas de antes, então vamos executar com a flag `-resume` e ver o que acontece.
+
+```bash
+nextflow run hello-modules.nf -resume
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-modules.nf` [romantic_poisson] DSL2 - revision: 96edfa9ad3
+
+    [f6/cc0107] sayHello (1)       | 3 of 3, cached: 3 ✔
+    [3c/4058ba] convertToUpper (2) | 3 of 3, cached: 3 ✔
+    [1a/bc5901] collectGreetings   | 1 of 1, cached: 1 ✔
+    ```
+
+Isso deve ser executado muito rapidamente porque tudo está em cache.
+Sinta-se à vontade para verificar as saídas publicadas.
+
+O Nextflow reconheceu que ainda é todo o mesmo trabalho a ser feito, mesmo que o código esteja dividido em múltiplos arquivos.
+
+### Conclusão
+
+Você sabe como extrair um processo para um módulo local e você sabe que fazer isso não quebra a capacidade de retomada do fluxo de trabalho.
+
+### Qual é o próximo passo?
+
+Pratique criando mais módulos.
+Uma vez que você fez um, você pode fazer um milhão mais...
+Mas vamos fazer apenas mais dois por enquanto.
+
+---
+
+## 3. Modularize o processo `convertToUpper()`
+
+### 3.1. Crie um esboço de arquivo para o novo módulo
+
+Crie um arquivo vazio para o módulo chamado `convertToUpper.nf`.
+
+```bash
+touch modules/convertToUpper.nf
+```
+
+### 3.2. Mova o código do processo `convertToUpper` para o arquivo do módulo
+
+Copie toda a definição do processo do arquivo de fluxo de trabalho para o arquivo do módulo, certificando-se de copiar também o shebang `#!/usr/bin/env nextflow`.
+
+```groovy title="modules/convertToUpper.nf" linenums="1"
+#!/usr/bin/env nextflow
+
+/*
+ * Use a text replacement tool to convert the greeting to uppercase
+ */
+process convertToUpper {
+
+    input:
+    path input_file
+
+    output:
+    path "UPPER-${input_file}"
+
+    script:
+    """
+    cat '${input_file}' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    """
+}
+```
+
+Uma vez feito isso, exclua a definição do processo do arquivo de fluxo de trabalho, mas certifique-se de deixar o shebang no lugar.
+
+### 3.3. Adicione uma declaração de importação antes do bloco `params`
+
+Insira a declaração de importação acima do bloco `params` e preencha-a adequadamente.
+
+=== "Depois"
+
+    ```groovy title="hello-modules.nf" linenums="23" hl_lines="3"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-modules.nf" linenums="23"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+Isso deve começar a parecer muito familiar.
+
+### 3.4. Execute o fluxo de trabalho novamente
+
+Execute isso com a flag `-resume`.
+
+```bash
+nextflow run hello-modules.nf -resume
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-modules.nf` [nauseous_heisenberg] DSL2 - revision: a04a9f2da0
+
+    [c9/763d42] sayHello (3)       | 3 of 3, cached: 3 ✔
+    [60/bc6831] convertToUpper (3) | 3 of 3, cached: 3 ✔
+    [1a/bc5901] collectGreetings   | 1 of 1, cached: 1 ✔
+    ```
+
+Isso ainda deve produzir a mesma saída de antes.
+
+Dois feitos, mais um para fazer!
+
+---
+
+## 4. Modularize o processo `collectGreetings()`
+
+### 4.1. Crie um esboço de arquivo para o novo módulo
+
+Crie um arquivo vazio para o módulo chamado `collectGreetings.nf`.
+
+```bash
+touch modules/collectGreetings.nf
+```
+
+### 4.2. Mova o código do processo `collectGreetings` para o arquivo do módulo
+
+Copie toda a definição do processo do arquivo de fluxo de trabalho para o arquivo do módulo, certificando-se de copiar também o shebang `#!/usr/bin/env nextflow`.
+
+```groovy title="modules/collectGreetings.nf" linenums="1"
+#!/usr/bin/env nextflow
+
+/*
+ * Collect uppercase greetings into a single output file
+ */
+process collectGreetings {
+
+    input:
+    path input_files
+    val batch_name
+
+    output:
+    path "COLLECTED-${batch_name}-output.txt", emit: outfile
+    path "${batch_name}-report.txt", emit: report
+
+    script:
+    count_greetings = input_files.size()
+    """
+    cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+    echo 'There were ${count_greetings} greetings in this batch.' > '${batch_name}-report.txt'
+    """
+}
+```
+
+Uma vez feito isso, exclua a definição do processo do arquivo de fluxo de trabalho, mas certifique-se de deixar o shebang no lugar.
+
+### 4.3. Adicione uma declaração de importação antes do bloco `params`
+
+Insira a declaração de importação acima do bloco `params` e preencha-a adequadamente.
+
+=== "Depois"
+
+    ```groovy title="hello-modules.nf" linenums="3" hl_lines="4"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+    include { collectGreetings } from './modules/collectGreetings.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-modules.nf" linenums="3"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+Último!
+
+### 4.4. Execute o fluxo de trabalho
+
+Execute isso com a flag `-resume`.
+
+```bash
+nextflow run hello-modules.nf -resume
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-modules.nf` [friendly_coulomb] DSL2 - revision: 7aa2b9bc0f
+
+    [f6/cc0107] sayHello (1)       | 3 of 3, cached: 3 ✔
+    [3c/4058ba] convertToUpper (2) | 3 of 3, cached: 3 ✔
+    [1a/bc5901] collectGreetings   | 1 of 1, cached: 1 ✔
+    ```
+
+Isso ainda deve produzir a mesma saída de antes.
+
+### Conclusão
+
+Você sabe como modularizar múltiplos processos em um fluxo de trabalho.
+
+Parabéns, você fez todo esse trabalho e absolutamente nada mudou na forma como o pipeline funciona!
+
+Brincadeiras à parte, agora seu código é mais modular, e se você decidir escrever outro pipeline que chame um desses processos, você só precisa digitar uma curta declaração de importação para usar o módulo relevante.
+Isso é melhor do que copiar e colar o código, porque se mais tarde você decidir melhorar o módulo, todos os seus pipelines herdarão as melhorias.
+
+### Qual é o próximo passo?
+
+Faça uma pequena pausa se quiser.
+
+Quando estiver pronto, passe para a [**Parte 5: Olá Contêineres**](./05_hello_containers.md) para aprender como usar contêineres para gerenciar dependências de software de forma mais conveniente e reproduzível.
+
+---
+
+## Quiz
+
+<quiz>
+O que é um módulo no Nextflow?
+- [ ] Um arquivo de configuração
+- [x] Um arquivo independente contendo uma única definição de processo
+- [ ] Uma definição de fluxo de trabalho
+- [ ] Um operador de canal
+
+Saiba mais: [2. Crie um módulo para `sayHello()`](#2-crie-um-modulo-para-sayhello)
+</quiz>
+
+<quiz>
+Qual é a convenção de nomenclatura recomendada para arquivos de módulo?
+- [ ] `module_processName.nf`
+- [ ] `processName_module.nf`
+- [x] `processName.nf`
+- [ ] `mod_processName.nf`
+</quiz>
+
+<quiz>
+Onde os arquivos de módulo devem ser armazenados?
+- [ ] No mesmo diretório que o fluxo de trabalho
+- [ ] Em um diretório `bin/`
+- [x] Em um diretório `modules/`
+- [ ] Em um diretório `lib/`
+
+Saiba mais: [1. Crie um diretório para armazenar módulos](#1-crie-um-diretorio-para-armazenar-modulos)
+</quiz>
+
+<quiz>
+Qual é a sintaxe correta para importar um módulo?
+
+- [ ] `#!groovy import { SAYHELLO } from './modules/sayhello.nf'`
+- [ ] `#!groovy require { SAYHELLO } from './modules/sayhello.nf'`
+- [x] `#!groovy include { SAYHELLO } from './modules/sayhello.nf'`
+- [ ] `#!groovy load { SAYHELLO } from './modules/sayhello.nf'`
+
+Saiba mais: [2.3. Adicione uma declaração de importação](#23-adicione-uma-declaracao-de-importacao-antes-do-bloco-de-fluxo-de-trabalho)
+</quiz>
+
+<quiz>
+O que acontece com a funcionalidade `-resume` ao usar módulos?
+- [ ] Ela não funciona mais
+- [ ] Ela requer configuração adicional
+- [x] Ela funciona da mesma forma que antes
+- [ ] Ela funciona apenas para módulos locais
+</quiz>
+
+<quiz>
+Quais são os benefícios de usar módulos? (Selecione todas as opções aplicáveis)
+- [x] Reutilização de código entre fluxos de trabalho
+- [x] Manutenção mais fácil
+- [x] Melhor organização do código do fluxo de trabalho
+- [ ] Velocidade de execução mais rápida
+</quiz>

--- a/docs/pt/docs/hello_nextflow/05_hello_containers.md
+++ b/docs/pt/docs/hello_nextflow/05_hello_containers.md
@@ -1,0 +1,1160 @@
+# Parte 5: Olá Contêineres
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/5PyOWjKnNmg?si=QinuAnFwFj-Z8CrO&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Veja [a playlist completa](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) no canal do Nextflow no YouTube.
+
+:green_book: A transcrição do vídeo está disponível [aqui](./transcripts/05_hello_containers.md).
+///
+
+Nas Partes 1-4 deste curso de treinamento, você aprendeu como usar os blocos de construção básicos do Nextflow para montar um fluxo de trabalho simples capaz de processar algum texto, paralelizar a execução se houvesse múltiplas entradas e coletar os resultados para processamento adicional.
+
+No entanto, você estava limitado às ferramentas básicas do UNIX disponíveis no seu ambiente.
+Tarefas do mundo real frequentemente requerem várias ferramentas e pacotes não incluídos por padrão.
+Tipicamente, você precisaria instalar essas ferramentas, gerenciar suas dependências e resolver quaisquer conflitos.
+
+Tudo isso é muito tedioso e irritante, então vamos mostrar como usar **contêineres** para resolver este problema de forma muito mais conveniente.
+
+Um **contêiner** é uma unidade leve, autônoma e executável de software criada a partir de uma **imagem** de contêiner que inclui tudo o que é necessário para executar uma aplicação, incluindo código, bibliotecas do sistema e configurações.
+Como você pode imaginar, isso será muito útil para tornar seus pipelines mais reproduzíveis.
+
+Note que ensinaremos isso usando [Docker](https://www.docker.com/get-started/), mas tenha em mente que o Nextflow suporta [várias outras tecnologias de contêiner](https://www.nextflow.io/docs/latest/container.html#) também.
+
+??? info "Como começar a partir desta seção"
+
+    Esta seção do curso assume que você completou as Partes 1-4 do curso [Hello Nextflow](./index.md) e tem um pipeline completo funcionando.
+
+    Se você está começando o curso a partir deste ponto, você precisará copiar o diretório `modules` das soluções:
+
+    ```bash
+    cp -r solutions/4-hello-modules/modules .
+    ```
+
+---
+
+## 0. Aquecimento: Execute `hello-containers.nf`
+
+Vamos usar o script de fluxo de trabalho `hello-containers.nf` como ponto de partida.
+Ele é equivalente ao script produzido ao trabalhar na Parte 4 deste curso de treinamento, exceto que mudamos os destinos de saída:
+
+```groovy title="hello-containers.nf" linenums="37" hl_lines="3 7 11 15"
+output {
+    first_output {
+        path 'hello_containers'
+        mode 'copy'
+    }
+    uppercased {
+        path 'hello_containers'
+        mode 'copy'
+    }
+    collected {
+        path 'hello_containers'
+        mode 'copy'
+    }
+    batch_report {
+        path 'hello_containers'
+        mode 'copy'
+    }
+}
+```
+
+Apenas para garantir que tudo está funcionando, execute o script uma vez antes de fazer qualquer alteração:
+
+```bash
+nextflow run hello-containers.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-containers.nf` [nice_escher] DSL2 - revision: d5dfdc9872
+
+    executor > local (7)
+    [5a/ec1fa1] sayHello (2) [100%] 3 of 3 ✔
+    [30/32b5b8] convertToUpper (3) [100%] 3 of 3 ✔
+    [d3/be01bc] collectGreetings [100%] 1 of 1 ✔
+
+    ```
+
+Como anteriormente, você encontrará os arquivos de saída no diretório especificado no bloco `output` (`results/hello_containers/`).
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    results/hello_containers/
+    ├── Bonjour-output.txt
+    ├── COLLECTED-batch-output.txt
+    ├── Hello-output.txt
+    ├── Holà-output.txt
+    ├── batch-report.txt
+    ├── UPPER-Bonjour-output.txt
+    ├── UPPER-Hello-output.txt
+    └── UPPER-Holà-output.txt
+    ```
+
+Se funcionou para você, você está pronto para aprender como usar contêineres.
+
+---
+
+## 1. Use um contêiner 'manualmente'
+
+O que queremos fazer é adicionar uma etapa ao nosso fluxo de trabalho que usará um contêiner para execução.
+
+No entanto, primeiro vamos revisar alguns conceitos básicos e operações para solidificar sua compreensão do que são contêineres antes de começarmos a usá-los no Nextflow.
+
+### 1.1. Baixe a imagem do contêiner
+
+Para usar um contêiner, você normalmente baixa ou _puxa_ uma imagem de contêiner de um registro de contêineres e então executa a imagem de contêiner para criar uma instância de contêiner.
+
+A sintaxe geral é a seguinte:
+
+```bash title="Sintaxe"
+docker pull '<container>'
+```
+
+A parte `docker pull` é a instrução ao sistema de contêiner para puxar uma imagem de contêiner de um repositório.
+
+A parte `'<container>'` é o endereço URI da imagem de contêiner.
+
+Como exemplo, vamos puxar uma imagem de contêiner que contém [cowpy](https://github.com/jeffbuttars/cowpy), uma implementação em Python de uma ferramenta chamada `cowsay` que gera arte ASCII para exibir entradas de texto arbitrárias de forma divertida.
+
+```txt title="Exemplo"
+ ________________________
+< Are we having fun yet? >
+ ------------------------
+    \                                  ___-------___
+     \                             _-~~             ~~-_
+      \                         _-~                    /~-_
+             /^\__/^\         /~  \                   /    \
+           /|  O|| O|        /      \_______________/        \
+          | |___||__|      /       /                \          \
+          |          \    /      /                    \          \
+          |   (_______) /______/                        \_________ \
+          |         / /         \                      /            \
+           \         \^\\         \                  /               \     /
+             \         ||           \______________/      _-_       //\__//
+               \       ||------_-~~-_ ------------- \ --/~   ~\    || __/
+                 ~-----||====/~     |==================|       |/~~~~~
+                  (_(__/  ./     /                    \_\      \.
+                         (_(___/                         \_____)_)
+```
+
+Existem vários repositórios onde você pode encontrar contêineres publicados.
+Usamos o serviço [Seqera Containers](https://seqera.io/containers/) para gerar esta imagem de contêiner Docker a partir do pacote Conda `cowpy`: `'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'`.
+
+Execute o comando pull completo:
+
+```bash
+docker pull 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+```
+
+??? success "Saída do comando"
+
+    ```console
+    1.1.5--3db457ae1977a273: Pulling from library/cowpy
+    dafa2b0c44d2: Pull complete
+    dec6b097362e: Pull complete
+    f88da01cff0b: Pull complete
+    4f4fb700ef54: Pull complete
+    92dc97a3ef36: Pull complete
+    403f74b0f85e: Pull complete
+    10b8c00c10a5: Pull complete
+    17dc7ea432cc: Pull complete
+    bb36d6c3110d: Pull complete
+    0ea1a16bbe82: Pull complete
+    030a47592a0a: Pull complete
+    c23bdb422167: Pull complete
+    e1686ff32a11: Pull complete
+    Digest: sha256:1ebc0043e8cafa61203bf42d29fd05bd14e7b4298e5e8cf986504c15f5aa4160
+    Status: Downloaded newer image for community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273
+    community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273
+    ```
+
+Se você nunca baixou a imagem antes, isso pode levar um minuto para completar.
+Uma vez concluído, você tem uma cópia local da imagem de contêiner.
+
+### 1.2. Use o contêiner para executar `cowpy` como um comando único
+
+Uma maneira muito comum de as pessoas usarem contêineres é executá-los diretamente, _ou seja_, de forma não interativa.
+Isso é ótimo para executar comandos únicos.
+
+A sintaxe geral é a seguinte:
+
+```bash title="Sintaxe"
+docker run --rm '<container>' [tool command]
+```
+
+A parte `docker run --rm '<container>'` é a instrução ao sistema de contêiner para iniciar uma instância de contêiner a partir de uma imagem de contêiner e executar um comando nela.
+A flag `--rm` diz ao sistema para desligar a instância de contêiner após o comando ter sido completado.
+
+A sintaxe `[tool command]` depende da ferramenta que você está usando e de como o contêiner está configurado.
+Vamos começar apenas com `cowpy`.
+
+Totalmente montado, o comando de execução do contêiner fica assim; vá em frente e execute-o.
+
+```bash
+docker run --rm 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273' cowpy
+```
+
+??? success "Saída do comando"
+
+    ```console
+    ______________________________________________________
+    < Cowacter, eyes:default, tongue:False, thoughts:False >
+    ------------------------------------------------------
+        \   ^__^
+          \  (oo)\_______
+            (__)\       )\/\
+              ||----w |
+              ||     ||
+    ```
+
+O sistema iniciou o contêiner, executou o comando `cowpy` com seus parâmetros, enviou a saída para o console e finalmente desligou a instância de contêiner.
+
+### 1.3. Use o contêiner para executar `cowpy` interativamente
+
+Você também pode executar um contêiner interativamente, o que lhe dá um prompt de shell dentro do contêiner e permite que você brinque com o comando.
+
+#### 1.3.1. Inicie o contêiner
+
+Para executar interativamente, apenas adicionamos `-it` ao comando `docker run`.
+Opcionalmente, podemos especificar o shell que queremos usar dentro do contêiner anexando _por exemplo_ `/bin/bash` ao comando.
+
+```bash
+docker run --rm -it 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273' /bin/bash
+```
+
+Note que seu prompt muda para algo como `(base) root@b645838b3314:/tmp#`, o que indica que você está agora dentro do contêiner.
+
+Você pode verificar isso executando `ls /` para listar o conteúdo do diretório a partir da raiz do sistema de arquivos:
+
+```bash
+ls /
+```
+
+??? abstract "Saída do comando"
+
+    ```console
+    bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
+    ```
+
+Usamos `ls` aqui em vez de `tree` porque o utilitário `tree` não está disponível neste contêiner.
+Você pode ver que o sistema de arquivos dentro do contêiner é diferente do sistema de arquivos no seu sistema hospedeiro.
+
+Uma limitação do que acabamos de fazer é que o contêiner está completamente isolado do sistema hospedeiro por padrão.
+Isso significa que o contêiner não pode acessar nenhum arquivo no sistema hospedeiro a menos que você permita explicitamente que ele o faça.
+
+Vamos mostrar como fazer isso em um minuto.
+
+#### 1.3.2. Execute o(s) comando(s) da ferramenta desejada
+
+Agora que você está dentro do contêiner, você pode executar o comando `cowpy` diretamente e dar alguns parâmetros a ele.
+Por exemplo, a documentação da ferramenta diz que podemos mudar o personagem ('cowacter') com `-c`.
+
+```bash
+cowpy "Hello Containers" -c tux
+```
+
+??? success "Saída do comando"
+
+    ```console
+    __________________
+    < Hello Containers >
+    ------------------
+      \
+        \
+            .--.
+          |o_o |
+          |:_/ |
+          //   \ \
+        (|     | )
+        /'\_   _/`\
+        \___)=(___/
+    ```
+
+Agora a saída mostra o pinguim do Linux, Tux, em vez da vaca padrão, porque especificamos o parâmetro `-c tux`.
+
+Como você está dentro do contêiner, você pode executar o comando `cowpy` quantas vezes quiser, variando os parâmetros de entrada, sem ter que se preocupar com comandos Docker.
+
+!!! Tip "Dica"
+
+    Use a flag '-c' para escolher um personagem diferente, incluindo:
+    `beavis`, `cheese`, `daemon`, `dragonandcow`, `ghostbusters`, `kitty`, `moose`, `milk`, `stegosaurus`, `turkey`, `turtle`, `tux`
+
+Isso é legal. O que seria ainda mais legal é se pudéssemos alimentar nosso `greetings.csv` como entrada nisso.
+Mas como não temos acesso ao sistema de arquivos, não podemos.
+
+Vamos consertar isso.
+
+#### 1.3.3. Saia do contêiner
+
+Para sair do contêiner, você pode digitar `exit` no prompt ou usar o atalho de teclado ++ctrl+d++.
+
+```bash
+exit
+```
+
+Seu prompt agora deve estar de volta ao que era antes de você iniciar o contêiner.
+
+#### 1.3.4. Monte dados no contêiner
+
+Como notado anteriormente, o contêiner está isolado do sistema hospedeiro por padrão.
+
+Para permitir que o contêiner acesse o sistema de arquivos do hospedeiro, você pode **montar** um **volume** do sistema hospedeiro no contêiner usando a seguinte sintaxe:
+
+```bash title="Sintaxe"
+-v <outside_path>:<inside_path>
+```
+
+No nosso caso `<outside_path>` será o diretório de trabalho atual, então podemos apenas usar um ponto (`.`), e `<inside_path>` é apenas um alias que inventamos; vamos chamá-lo de `/my_project` (o caminho interno deve ser absoluto).
+
+Para montar um volume, substituímos os caminhos e adicionamos o argumento de montagem de volume ao comando docker run da seguinte forma:
+
+```bash
+docker run --rm -it -v .:/my_project 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273' /bin/bash
+```
+
+Isso monta o diretório de trabalho atual como um volume que estará acessível em `/my_project` dentro do contêiner.
+
+Você pode verificar que funciona listando o conteúdo de `/my_project`:
+
+```bash
+ls /my_project
+```
+
+??? success "Saída do comando"
+
+    ```console
+    data               hello-config.nf      hello-modules.nf   hello-world.nf  nextflow.config  solutions         work
+    hello-channels.nf  hello-containers.nf  hello-workflow.nf  modules         results          test-params.json
+    ```
+
+Agora você pode ver o conteúdo do diretório de trabalho de dentro do contêiner, incluindo o arquivo `greetings.csv` em `data/`.
+
+Isso efetivamente estabeleceu um túnel através da parede do contêiner que você pode usar para acessar aquela parte do seu sistema de arquivos.
+
+#### 1.3.5. Use os dados montados
+
+Agora que montamos o diretório de trabalho no contêiner, podemos usar o comando `cowpy` para exibir o conteúdo do arquivo `greetings.csv`.
+
+Para fazer isso, usaremos `cat /my_project/data/greetings.csv | ` para canalizar o conteúdo do arquivo CSV para o comando `cowpy`.
+
+```bash
+cat /my_project/data/greetings.csv | cowpy -c turkey
+```
+
+??? success "Saída do comando"
+
+    ```console title="data/greetings.csv"
+     ____________________
+    / Hello,English,123  \
+    | Bonjour,French,456 |
+    \ Holà,Spanish,789   /
+    --------------------
+      \                                  ,+*^^*+___+++_
+      \                           ,*^^^^              )
+        \                       _+*                     ^**+_
+        \                    +^       _ _++*+_+++_,         )
+                  _+^^*+_    (     ,+*^ ^          \+_        )
+                {       )  (    ,(    ,_+--+--,      ^)      ^\
+                { (\@)    } f   ,(  ,+-^ __*_*_  ^^\_   ^\       )
+              {:;-/    (_+*-+^^^^^+*+*<_ _++_)_    )    )      /
+              ( /  (    (        ,___    ^*+_+* )   <    <      \
+              U _/     )    *--<  ) ^\-----++__)   )    )       )
+                (      )  _(^)^^))  )  )\^^^^^))^*+/    /       /
+              (      /  (_))_^)) )  )  ))^^^^^))^^^)__/     +^^
+            (     ,/    (^))^))  )  ) ))^^^^^^^))^^)       _)
+              *+__+*       (_))^)  ) ) ))^^^^^^))^^^^^)____*^
+              \             \_)^)_)) ))^^^^^^^^^^))^^^^)
+              (_             ^\__^^^^^^^^^^^^))^^^^^^^)
+                ^\___            ^\__^^^^^^))^^^^^^^^)\\
+                      ^^^^^\uuu/^^\uuu/^^^^\^\^\^\^\^\^\^\
+                        ___) >____) >___   ^\_\_\_\_\_\_\)
+                        ^^^//\\_^^//\\_^       ^(\_\_\_\)
+                          ^^^ ^^ ^^^ ^
+    ```
+
+Isso produz a arte ASCII desejada de um peru recitando nossas saudações de exemplo!
+Exceto que aqui o peru está repetindo as linhas completas em vez de apenas as saudações.
+Já sabemos que nosso fluxo de trabalho Nextflow fará um trabalho melhor!
+
+Sinta-se à vontade para brincar com este comando.
+Quando terminar, saia do contêiner como anteriormente:
+
+```bash
+exit
+```
+
+Você se encontrará de volta ao seu shell normal.
+
+### Resumo
+
+Você sabe como puxar um contêiner e executá-lo como um comando único ou interativamente. Você também sabe como tornar seus dados acessíveis de dentro do seu contêiner, o que permite que você experimente qualquer ferramenta na qual esteja interessado com dados reais sem ter que instalar nenhum software no seu sistema.
+
+### O que vem a seguir?
+
+Aprenda como usar contêineres para a execução de processos Nextflow.
+
+---
+
+## 2. Use contêineres no Nextflow
+
+O Nextflow tem suporte integrado para executar processos dentro de contêineres para permitir que você execute ferramentas que você não tem instaladas no seu ambiente de computação.
+Isso significa que você pode usar qualquer imagem de contêiner que desejar para executar seus processos, e o Nextflow cuidará de puxar a imagem, montar os dados e executar o processo dentro dela.
+
+Para demonstrar isso, vamos adicionar uma etapa `cowpy` ao pipeline que estamos desenvolvendo, após a etapa `collectGreetings`.
+
+<figure class="excalidraw">
+--8<-- "docs/nextflow_run/img/hello-pipeline-cowpy.svg"
+</figure>
+
+Muu se você está pronto para mergulhar!
+
+### 2.1. Escreva um módulo `cowpy`
+
+Primeiro, vamos criar o módulo do processo `cowpy`.
+
+#### 2.1.1. Crie um arquivo stub para o novo módulo
+
+Crie um arquivo vazio para o módulo chamado `cowpy.nf`.
+
+```bash
+touch modules/cowpy.nf
+```
+
+Isso nos dá um lugar para colocar o código do processo.
+
+#### 2.1.2. Copie o código do processo `cowpy` no arquivo do módulo
+
+Podemos modelar nosso processo `cowpy` nos outros processos que escrevemos anteriormente.
+
+```groovy title="modules/cowpy.nf" linenums="1"
+#!/usr/bin/env nextflow
+
+// Generate ASCII art with cowpy
+process cowpy {
+
+    input:
+    path input_file
+    val character
+
+    output:
+    path "cowpy-${input_file}"
+
+    script:
+    """
+    cat ${input_file} | cowpy -c "${character}" > cowpy-${input_file}
+    """
+
+}
+```
+
+O processo espera um `input_file` contendo as saudações, bem como um valor `character`.
+
+A saída será um novo arquivo de texto contendo a arte ASCII gerada pela ferramenta `cowpy`.
+
+### 2.2. Adicione cowpy ao fluxo de trabalho
+
+Agora precisamos importar o módulo e chamar o processo.
+
+#### 2.2.1. Importe o processo `cowpy` para `hello-containers.nf`
+
+Insira a declaração de importação acima do bloco de fluxo de trabalho e preencha-a adequadamente.
+
+=== "Depois"
+
+    ```groovy title="hello-containers.nf" linenums="3" hl_lines="5"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+    include { collectGreetings } from './modules/collectGreetings.nf'
+    include { cowpy } from './modules/cowpy.nf'
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-containers.nf" linenums="3"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+    include { collectGreetings } from './modules/collectGreetings.nf'
+    ```
+
+Agora o módulo `cowpy` está disponível para uso no fluxo de trabalho.
+
+#### 2.2.2. Adicione uma chamada ao processo `cowpy` no fluxo de trabalho
+
+Vamos conectar o processo `cowpy()` à saída do processo `collectGreetings()`, que como você deve se lembrar produz duas saídas:
+
+- `collectGreetings.out.outfile` contém o arquivo de saída <--_o que queremos_
+- `collectGreetings.out.report` contém o arquivo de relatório com a contagem de saudações por lote
+
+No bloco de fluxo de trabalho, faça a seguinte mudança de código:
+
+=== "Depois"
+
+    ```groovy title="hello-containers.nf" linenums="19" hl_lines="12-13"
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emit a greeting
+        sayHello(greeting_ch)
+        // convert the greeting to uppercase
+        convertToUpper(sayHello.out)
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect(), params.batch)
+        // generate ASCII art of the greetings with cowpy
+        cowpy(collectGreetings.out.outfile, params.character)
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-containers.nf" linenums="19"
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emit a greeting
+        sayHello(greeting_ch)
+        // convert the greeting to uppercase
+        convertToUpper(sayHello.out)
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect(), params.batch)
+    ```
+
+Note que declaramos um novo parâmetro CLI, `params.character`, para especificar qual personagem queremos que diga as saudações.
+
+#### 2.2.3. Adicione o parâmetro `character` ao bloco `params`
+
+Isso é tecnicamente opcional, mas é a prática recomendada e é uma oportunidade de definir um valor padrão para o personagem enquanto estamos nisso.
+
+=== "Depois"
+
+    ```groovy title="hello-containers.nf" linenums="9" hl_lines="7"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+        character: String = 'turkey'
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-containers.nf" linenums="9"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+Agora podemos ser preguiçosos e pular a digitação do parâmetro de personagem em nossas linhas de comando.
+
+#### 2.2.4. Atualize as saídas do fluxo de trabalho
+
+Precisamos atualizar as saídas do fluxo de trabalho para publicar a saída do processo `cowpy`.
+
+##### 2.2.4.1. Atualize a seção `publish:`
+
+No bloco de `workflow`, faça a seguinte mudança de código:
+
+=== "Depois"
+
+    ```groovy title="hello-containers.nf" linenums="34" hl_lines="6"
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out.outfile
+        batch_report = collectGreetings.out.report
+        cowpy_art = cowpy.out
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-containers.nf" linenums="34"
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out.outfile
+        batch_report = collectGreetings.out.report
+    ```
+
+O processo `cowpy` produz apenas uma saída, então podemos referenciá-la da maneira usual anexando `.out`.
+
+Mas por enquanto, vamos terminar de atualizar as saídas no nível do fluxo de trabalho.
+
+##### 2.2.4.2. Atualize o bloco `output`
+
+Precisamos adicionar a saída final `cowpy_art` ao bloco `output`. Enquanto estamos nisso, vamos também editar os destinos de publicação, já que agora nosso pipeline está completo e sabemos quais saídas realmente nos interessam.
+
+No bloco `output`, faça as seguintes mudanças de código:
+
+=== "Depois"
+
+    ```groovy title="hello-containers.nf" linenums="42" hl_lines="3 7 11 15 18-21"
+    output {
+        first_output {
+            path 'hello_containers/intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_containers/intermediates'
+            mode 'copy'
+        }
+        collected {
+            path 'hello_containers/intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path 'hello_containers'
+            mode 'copy'
+        }
+        cowpy_art {
+            path 'hello_containers'
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-containers.nf" linenums="42" hl_lines="3 7 11 15"
+    output {
+        first_output {
+            path 'hello_containers'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_containers'
+            mode 'copy'
+        }
+        collected {
+            path 'hello_containers'
+            mode 'copy'
+        }
+        batch_report {
+            path 'hello_containers'
+            mode 'copy'
+        }
+    }
+    ```
+
+Agora as saídas publicadas estarão um pouco mais organizadas.
+
+#### 2.2.5. Execute o fluxo de trabalho
+
+Apenas para recapitular, isso é o que estamos buscando:
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_pipeline_complete.svg"
+</figure>
+
+Você acha que vai funcionar?
+
+Vamos deletar as saídas publicadas anteriores para ter um slate limpo, e executar o fluxo de trabalho com a flag `-resume`.
+
+```bash
+rm -r hello_containers/
+nextflow run hello-containers.nf -resume
+```
+
+??? failure "Saída do comando (editada para clareza)"
+
+    ```console hl_lines="10 13 20-21 26-27"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-containers.nf` [lonely_woese] DSL2 - revision: abf1dccf7f
+
+    executor >  local (1)
+    [c9/f5c686] sayHello (3)       [100%] 3 of 3, cached: 3 ✔
+    [ef/3135a8] convertToUpper (3) [100%] 3 of 3, cached: 3 ✔
+    [7f/f435e3] collectGreetings   [100%] 1 of 1, cached: 1 ✔
+    [9b/02e776] cowpy              [  0%] 0 of 1 ✘
+    ERROR ~ Error executing process > 'cowpy'
+
+    Caused by:
+      Process `cowpy` terminated with an error exit status (127)
+
+
+    Command executed:
+
+      cat COLLECTED-batch-output.txt | cowpy -c "turkey" > cowpy-COLLECTED-batch-output.txt
+
+    Command exit status:
+      127
+
+    Command output:
+      (empty)
+
+    Command error:
+      .command.sh: line 2: cowpy: command not found
+
+    Work dir:
+      /workspaces/training/hello-nextflow/work/9b/02e7761db848f82db3c3e59ff3a9b6
+
+    Tip: when you have fixed the problem you can continue the execution adding the option `-resume` to the run command line
+
+    -- Check '.nextflow.log' file for details
+    ERROR ~ Cannot access first() element from an empty List
+
+    -- Check '.nextflow.log' file for details
+    ```
+
+Oh não, há um erro!
+O código de erro dado por `error exit status (127)` significa que o executável que pedimos não foi encontrado.
+
+Isso faz sentido, já que estamos chamando a ferramenta `cowpy` mas não especificamos um contêiner ainda (ops).
+
+### 2.3. Use um contêiner para executar o processo `cowpy`
+
+Precisamos especificar um contêiner e dizer ao Nextflow para usá-lo no processo `cowpy()`.
+
+#### 2.3.1. Especifique um contêiner para `cowpy`
+
+Podemos usar a mesma imagem que estávamos usando diretamente na primeira seção deste tutorial.
+
+Edite o módulo `cowpy.nf` para adicionar a diretiva `container` à definição do processo da seguinte forma:
+
+=== "Depois"
+
+    ```groovy title="modules/cowpy.nf" linenums="4" hl_lines="3"
+    process cowpy {
+
+        container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+
+        input:
+        path input_file
+        val character
+
+        output:
+        path "cowpy-${input_file}"
+
+        script:
+        """
+        cat ${input_file} | cowpy -c "${character}" > cowpy-${input_file}
+        """
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="modules/cowpy.nf" linenums="4"
+    process cowpy {
+
+        input:
+        path input_file
+        val character
+
+        output:
+        path "cowpy-${input_file}"
+
+        script:
+        """
+        cat ${input_file} | cowpy -c "${character}" > cowpy-${input_file}
+        """
+    }
+    ```
+
+Isso diz ao Nextflow que _se o uso de Docker estiver habilitado_, ele deve usar a imagem de contêiner especificada aqui para executar o processo.
+
+#### 2.3.2. Habilite o uso de Docker através do arquivo `nextflow.config`
+
+Note que dissemos _'se o uso de Docker estiver habilitado'_. Por padrão, não está, então precisamos dizer ao Nextflow que ele tem permissão para usar Docker.
+Para esse fim, vamos antecipar um pouco o tópico da próxima e última parte deste curso (Parte 6), que cobre configuração.
+
+Uma das principais maneiras que o Nextflow oferece para configurar a execução do fluxo de trabalho é usar um arquivo `nextflow.config`.
+Quando tal arquivo está presente no diretório atual, o Nextflow irá carregá-lo automaticamente e aplicar qualquer configuração que ele contém.
+
+Fornecemos um arquivo `nextflow.config` com uma única linha de código que desabilita explicitamente o Docker: `docker.enabled = false`.
+
+Agora, vamos mudar isso para `true` para habilitar o Docker:
+
+=== "Depois"
+
+    ```console title="nextflow.config" linenums="1" hl_lines="1"
+    docker.enabled = true
+    ```
+
+=== "Antes"
+
+    ```console title="nextflow.config" linenums="1" hl_lines="1"
+    docker.enabled = false
+    ```
+
+!!! tip "Dica"
+
+    É possível habilitar a execução Docker a partir da linha de comando, por execução, usando o parâmetro `-with-docker <container>`.
+    No entanto, isso só nos permite especificar um contêiner para todo o fluxo de trabalho, enquanto a abordagem que acabamos de mostrar permite especificar um contêiner diferente por processo.
+    Isso é melhor para modularidade, manutenção de código e reprodutibilidade.
+
+#### 2.3.3. Execute o fluxo de trabalho com Docker habilitado
+
+Execute o fluxo de trabalho com a flag `-resume`:
+
+```bash
+nextflow run hello-containers.nf -resume
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-containers.nf` [drunk_perlman] DSL2 - revision: abf1dccf7f
+
+    executor >  local (1)
+    [c9/f5c686] sayHello (3)       [100%] 3 of 3, cached: 3 ✔
+    [ef/3135a8] convertToUpper (3) [100%] 3 of 3, cached: 3 ✔
+    [7f/f435e3] collectGreetings   [100%] 1 of 1, cached: 1 ✔
+    [98/656c6c] cowpy              [100%] 1 of 1 ✔
+    ```
+
+Desta vez realmente funciona!
+Como de costume, você pode encontrar as saídas do fluxo de trabalho no diretório de resultados correspondente, embora desta vez elas estejam um pouco mais organizadas, com apenas o relatório e a saída final no nível superior, e todos os arquivos intermediários empurrados para fora do caminho em um subdiretório.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    results/hello_containers/
+    ├── cowpy-COLLECTED-batch-output.txt
+    ├── intermediates
+    │   ├── Bonjour-output.txt
+    │   ├── COLLECTED-batch-output.txt
+    │   ├── Hello-output.txt
+    │   ├── Holà-output.txt
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    └── batch-report.txt
+    ```
+
+A saída final de arte ASCII está no diretório `results/hello_containers/`, com o nome `cowpy-COLLECTED-batch-output.txt`.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/hello_containers/cowpy-COLLECTED-batch-output.txt"
+    _________
+    / HOLà    \
+    | HELLO   |
+    \ BONJOUR /
+    ---------
+      \                                  ,+*^^*+___+++_
+      \                           ,*^^^^              )
+        \                       _+*                     ^**+_
+        \                    +^       _ _++*+_+++_,         )
+                  _+^^*+_    (     ,+*^ ^          \+_        )
+                {       )  (    ,(    ,_+--+--,      ^)      ^\
+                { (\@)    } f   ,(  ,+-^ __*_*_  ^^\_   ^\       )
+              {:;-/    (_+*-+^^^^^+*+*<_ _++_)_    )    )      /
+              ( /  (    (        ,___    ^*+_+* )   <    <      \
+              U _/     )    *--<  ) ^\-----++__)   )    )       )
+                (      )  _(^)^^))  )  )\^^^^^))^*+/    /       /
+              (      /  (_))_^)) )  )  ))^^^^^))^^^)__/     +^^
+            (     ,/    (^))^))  )  ) ))^^^^^^^))^^)       _)
+              *+__+*       (_))^)  ) ) ))^^^^^^))^^^^^)____*^
+              \             \_)^)_)) ))^^^^^^^^^^))^^^^)
+              (_             ^\__^^^^^^^^^^^^))^^^^^^^)
+                ^\___            ^\__^^^^^^))^^^^^^^^)\\
+                      ^^^^^\uuu/^^\uuu/^^^^\^\^\^\^\^\^\^\
+                        ___) >____) >___   ^\_\_\_\_\_\_\)
+                        ^^^//\\_^^//\\_^       ^(\_\_\_\)
+                          ^^^ ^^ ^^^ ^
+    ```
+
+E aí está, nosso lindo peru dizendo as saudações conforme desejado.
+
+#### 2.3.4. Inspecione como o Nextflow lançou a tarefa em contêiner
+
+Como um coda final para esta seção, vamos dar uma olhada no subdiretório de trabalho de uma das chamadas do processo `cowpy` para obter um pouco mais de insight sobre como o Nextflow trabalha com contêineres nos bastidores.
+
+Verifique a saída do seu comando `nextflow run` para encontrar o caminho para o subdiretório de trabalho do processo `cowpy`.
+Olhando para o que obtivemos para a execução mostrada acima, a linha de log do console para o processo `cowpy` começa com `[98/656c6c]`.
+Isso corresponde ao seguinte caminho de diretório truncado: `work/98/656c6c`.
+
+Nesse diretório, você encontrará o arquivo `.command.run` que contém todos os comandos que o Nextflow executou em seu nome no curso da execução do pipeline.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="work/98/656c6c90cce1667c094d880f4b6dcc/.command.run"
+    #!/bin/bash
+    ### ---
+    ### name: 'cowpy'
+    ### container: 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+    ### outputs:
+    ### - 'cowpy-COLLECTED-batch-output.txt'
+    ### ...
+    set -e
+    set -u
+    NXF_DEBUG=${NXF_DEBUG:=0}; [[ $NXF_DEBUG > 1 ]] && set -x
+    NXF_ENTRY=${1:-nxf_main}
+
+
+    nxf_sleep() {
+      sleep $1 2>/dev/null || sleep 1;
+    }
+
+    nxf_date() {
+        local ts=$(date +%s%3N);
+        if [[ ${#ts} == 10 ]]; then echo ${ts}000
+        elif [[ $ts == *%3N ]]; then echo ${ts/\%3N/000}
+        elif [[ $ts == *3N ]]; then echo ${ts/3N/000}
+        elif [[ ${#ts} == 13 ]]; then echo $ts
+        else echo "Unexpected timestamp value: $ts"; exit 1
+        fi
+    }
+
+    nxf_env() {
+        echo '============= task environment ============='
+        env | sort | sed "s/\(.*\)AWS\(.*\)=\(.\{6\}\).*/\1AWS\2=\3xxxxxxxxxxxxx/"
+        echo '============= task output =================='
+    }
+
+    nxf_kill() {
+        declare -a children
+        while read P PP;do
+            children[$PP]+=" $P"
+        done < <(ps -e -o pid= -o ppid=)
+
+        kill_all() {
+            [[ $1 != $$ ]] && kill $1 2>/dev/null || true
+            for i in ${children[$1]:=}; do kill_all $i; done
+        }
+
+        kill_all $1
+    }
+
+    nxf_mktemp() {
+        local base=${1:-/tmp}
+        mkdir -p "$base"
+        if [[ $(uname) = Darwin ]]; then mktemp -d $base/nxf.XXXXXXXXXX
+        else TMPDIR="$base" mktemp -d -t nxf.XXXXXXXXXX
+        fi
+    }
+
+    nxf_fs_copy() {
+      local source=$1
+      local target=$2
+      local basedir=$(dirname $1)
+      mkdir -p $target/$basedir
+      cp -fRL $source $target/$basedir
+    }
+
+    nxf_fs_move() {
+      local source=$1
+      local target=$2
+      local basedir=$(dirname $1)
+      mkdir -p $target/$basedir
+      mv -f $source $target/$basedir
+    }
+
+    nxf_fs_rsync() {
+      rsync -rRl $1 $2
+    }
+
+    nxf_fs_rclone() {
+      rclone copyto $1 $2/$1
+    }
+
+    nxf_fs_fcp() {
+      fcp $1 $2/$1
+    }
+
+    on_exit() {
+        local last_err=$?
+        local exit_status=${nxf_main_ret:=0}
+        [[ ${exit_status} -eq 0 && ${nxf_unstage_ret:=0} -ne 0 ]] && exit_status=${nxf_unstage_ret:=0}
+        [[ ${exit_status} -eq 0 && ${last_err} -ne 0 ]] && exit_status=${last_err}
+        printf -- $exit_status > /workspaces/training/hello-nextflow/work/98/656c6c90cce1667c094d880f4b6dcc/.exitcode
+        set +u
+        docker rm $NXF_BOXID &>/dev/null || true
+        exit $exit_status
+    }
+
+    on_term() {
+        set +e
+        docker stop $NXF_BOXID
+    }
+
+    nxf_launch() {
+        docker run -i --cpu-shares 1024 -e "NXF_TASK_WORKDIR" -v /workspaces/training/hello-nextflow/work:/workspaces/training/hello-nextflow/work -w "$NXF_TASK_WORKDIR" --name $NXF_BOXID community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273 /bin/bash -ue /workspaces/training/hello-nextflow/work/98/656c6c90cce1667c094d880f4b6dcc/.command.sh
+    }
+
+    nxf_stage() {
+        true
+        # stage input files
+        rm -f COLLECTED-batch-output.txt
+        ln -s /workspaces/training/hello-nextflow/work/7f/f435e3f2cf95979b5f3d7647ae6696/COLLECTED-batch-output.txt COLLECTED-batch-output.txt
+    }
+
+    nxf_unstage_outputs() {
+        true
+    }
+
+    nxf_unstage_controls() {
+        true
+    }
+
+    nxf_unstage() {
+        if [[ ${nxf_main_ret:=0} == 0 ]]; then
+            (set -e -o pipefail; (nxf_unstage_outputs | tee -a .command.out) 3>&1 1>&2 2>&3 | tee -a .command.err)
+            nxf_unstage_ret=$?
+        fi
+        nxf_unstage_controls
+    }
+
+    nxf_main() {
+        trap on_exit EXIT
+        trap on_term TERM INT USR2
+        trap '' USR1
+
+        [[ "${NXF_CHDIR:-}" ]] && cd "$NXF_CHDIR"
+        export NXF_BOXID="nxf-$(dd bs=18 count=1 if=/dev/urandom 2>/dev/null | base64 | tr +/ 0A | tr -d '\r\n')"
+        NXF_SCRATCH=''
+        [[ $NXF_DEBUG > 0 ]] && nxf_env
+        touch /workspaces/training/hello-nextflow/work/98/656c6c90cce1667c094d880f4b6dcc/.command.begin
+        set +u
+        set -u
+        [[ $NXF_SCRATCH ]] && cd $NXF_SCRATCH
+        export NXF_TASK_WORKDIR="$PWD"
+        nxf_stage
+
+        set +e
+        (set -o pipefail; (nxf_launch | tee .command.out) 3>&1 1>&2 2>&3 | tee .command.err) &
+        pid=$!
+        wait $pid || nxf_main_ret=$?
+        nxf_unstage
+    }
+
+    $NXF_ENTRY
+
+    ```
+
+Se você procurar por `nxf_launch` neste arquivo, você deve ver algo assim:
+
+```console
+nxf_launch() {
+    docker run -i --cpu-shares 1024 -e "NXF_TASK_WORKDIR" -v /workspaces/training/hello-nextflow/work:/workspaces/training/hello-nextflow/work -w "$NXF_TASK_WORKDIR" --name $NXF_BOXID community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273 /bin/bash -ue /workspaces/training/hello-nextflow/work/98/656c6c90cce1667c094d880f4b6dcc/.command.sh
+}
+```
+
+Como você pode ver, o Nextflow está usando o comando `docker run` para lançar a chamada do processo.
+Ele também monta o subdiretório de trabalho correspondente no contêiner, define o diretório de trabalho dentro do contêiner adequadamente e executa nosso script bash modelado no arquivo `.command.sh`.
+
+Todo o trabalho duro que tivemos que fazer manualmente na primeira seção? O Nextflow faz por nós nos bastidores!
+
+```txt
+ _______________________
+< Viva os robôs...! >
+ -----------------------
+                                   ,-----.
+                                   |     |
+                                ,--|     |-.
+                         __,----|  |     | |
+                       ,;::     |  `_____' |
+                       `._______|    i^i   |
+                                `----| |---'| .
+                           ,-------._| |== ||//
+                           |       |_|P`.  /'/
+                           `-------' 'Y Y/'/'
+                                     .==\ /_\
+   ^__^                             /   /'|  `i
+   (oo)\_______                   /'   /  |   |
+   (__)\       )\/\             /'    /   |   `i
+       ||----w |           ___,;`----'.___L_,-'`\__
+       ||     ||          i_____;----\.____i""\____\
+```
+
+### Resumo
+
+Você sabe como usar contêineres no Nextflow para executar processos.
+
+### O que vem a seguir?
+
+Faça uma pausa!
+
+Quando estiver pronto, siga para [**Parte 6: Olá Configuração**](./06_hello_config.md) para aprender como configurar a execução do seu pipeline para se adequar à sua infraestrutura, bem como gerenciar configuração de entradas e parâmetros.
+
+É a última parte, e então você terá terminado este curso!
+
+---
+
+## Quiz
+
+<quiz>
+O que é um contêiner?
+- [ ] Um tipo de máquina virtual
+- [ ] Um formato de compressão de arquivo
+- [x] Uma unidade leve, autônoma e executável que inclui tudo o que é necessário para executar uma aplicação
+- [ ] Um protocolo de rede
+</quiz>
+
+<quiz>
+Qual é a diferença entre uma imagem de contêiner e uma instância de contêiner?
+- [ ] São a mesma coisa
+- [x] Uma imagem é um template; uma instância é um contêiner em execução criado a partir dessa imagem
+- [ ] Uma instância é um template; uma imagem é um contêiner em execução
+- [ ] Imagens são para Docker; instâncias são para Singularity
+</quiz>
+
+<quiz>
+O que a flag `-v` faz em um comando `docker run`?
+- [ ] Habilita saída detalhada
+- [ ] Valida o contêiner
+- [x] Monta um volume do sistema hospedeiro no contêiner
+- [ ] Especifica a versão do contêiner
+
+Saiba mais: [1.3.4. Monte dados no contêiner](#134-monte-dados-no-conteiner)
+</quiz>
+
+<quiz>
+Por que você precisa montar volumes ao usar contêineres?
+- [ ] Para melhorar o desempenho do contêiner
+- [ ] Para economizar espaço em disco
+- [x] Porque contêineres estão isolados do sistema de arquivos do hospedeiro por padrão
+- [ ] Para habilitar rede
+
+Saiba mais: [1.3.4. Monte dados no contêiner](#134-monte-dados-no-conteiner)
+</quiz>
+
+<quiz>
+Como você especifica um contêiner para um processo Nextflow?
+- [ ] `docker 'container-uri'`
+- [ ] `image 'container-uri'`
+- [x] `container 'container-uri'`
+- [ ] `use 'container-uri'`
+
+Saiba mais: [2.3.1. Especifique um contêiner para cowpy](#231-especifique-um-conteiner-para-cowpy)
+</quiz>
+
+<quiz>
+Qual configuração do `nextflow.config` habilita Docker para seu fluxo de trabalho?
+- [ ] `#!groovy process.docker = true`
+- [x] `#!groovy docker.enabled = true`
+- [ ] `#!groovy container.engine = 'docker'`
+- [ ] `#!groovy docker.activate = true`
+
+Saiba mais: [2.3.2. Habilite o uso de Docker através do arquivo `nextflow.config`](#232-habilite-o-uso-de-docker-atraves-do-arquivo-nextflowconfig)
+</quiz>
+
+<quiz>
+O que o Nextflow lida automaticamente ao executar um processo em um contêiner? (Selecione todas as opções que se aplicam)
+- [x] Puxar a imagem do contêiner se necessário
+- [x] Montar o diretório de trabalho
+- [x] Executar o script do processo dentro do contêiner
+- [x] Limpar a instância do contêiner após a execução
+
+Saiba mais: [2.3.4. Inspecione como o Nextflow lançou a tarefa em contêiner](#234-inspecione-como-o-nextflow-lancou-a-tarefa-em-conteiner)
+</quiz>

--- a/docs/pt/docs/hello_nextflow/06_hello_config.md
+++ b/docs/pt/docs/hello_nextflow/06_hello_config.md
@@ -1,0 +1,1365 @@
+# Parte 6: Hello Config
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/IuDO2HeKvXk?si=tnXTi6mRkITY0zW_&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Veja [a playlist completa](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) no canal do YouTube do Nextflow.
+
+:green_book: A transcrição do vídeo está disponível [aqui](./transcripts/06_hello_config.md).
+///
+
+Esta seção explorará como configurar e gerenciar a configuração do seu pipeline Nextflow para que você possa personalizar seu comportamento, adaptá-lo a diferentes ambientes e otimizar o uso de recursos _sem alterar uma única linha do código do fluxo de trabalho_.
+
+Existem várias maneiras de fazer isso, que podem ser usadas em combinação e são interpretadas de acordo com a ordem de precedência descrita [aqui](https://www.nextflow.io/docs/latest/config.html).
+
+Nesta parte do curso, vamos mostrar o mecanismo de arquivo de configuração mais simples e comum, o arquivo `nextflow.config`, que você já encontrou na Parte 5: Hello Containers.
+
+Vamos abordar componentes essenciais da configuração do Nextflow, como diretivas de processos, executores, perfis e arquivos de parâmetros.
+Ao aprender a utilizar essas opções de configuração de forma eficaz, você pode melhorar a flexibilidade, escalabilidade e desempenho dos seus pipelines.
+
+??? info "Como começar a partir desta seção"
+
+    Esta seção do curso assume que você completou as Partes 1-5 do curso [Hello Nextflow](./index.md) e tem um pipeline completo funcionando.
+
+    Se você está começando o curso a partir deste ponto, precisará copiar o diretório `modules` e o arquivo `nextflow.config` das soluções:
+
+    ```bash
+    cp -r solutions/5-hello-containers/modules .
+    cp solutions/5-hello-containers/nextflow.config .
+    ```
+
+    O arquivo `nextflow.config` contém a linha `docker.enabled = true` que habilita o uso de contêineres Docker.
+
+    Se você não está familiarizado com o pipeline Hello ou precisa relembrar, veja [esta página de informações](../info/hello_pipeline.md).
+
+---
+
+## 0. Aquecimento: Execute `hello-config.nf`
+
+Vamos usar o script do fluxo de trabalho `hello-config.nf` como ponto de partida.
+Ele é equivalente ao script produzido ao trabalhar na Parte 5 deste curso de treinamento, exceto que mudamos os destinos de saída:
+
+```groovy title="hello-config.nf" linenums="37" hl_lines="3 7 11 15"
+output {
+    first_output {
+        path 'hello_config/intermediates'
+        mode 'copy'
+    }
+    uppercased {
+        path 'hello_config/intermediates'
+        mode 'copy'
+    }
+    collected {
+        path 'hello_config/intermediates'
+        mode 'copy'
+    }
+    batch_report {
+        path 'hello_config'
+        mode 'copy'
+    }
+    cowpy_art {
+        path 'hello_config'
+        mode 'copy'
+    }
+}
+```
+
+Apenas para garantir que tudo está funcionando, execute o script uma vez antes de fazer qualquer alteração:
+
+```bash
+nextflow run hello-config.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [nice_escher] DSL2 - revision: d5dfdc9872
+
+    executor > local (7)
+    [6a/bc46a6] sayHello (2) [100%] 3 of 3 ✔
+    [33/67bc48] convertToUpper (3) [100%] 3 of 3 ✔
+    [b5/de03ba] collectGreetings [100%] 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Como anteriormente, você encontrará os arquivos de saída no diretório especificado no bloco `output` (`results/hello_config/`).
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    results/hello_config/
+    ├── cowpy-COLLECTED-batch-output.txt
+    ├── intermediates
+    │   ├── Bonjour-output.txt
+    │   ├── COLLECTED-batch-output.txt
+    │   ├── Hello-output.txt
+    │   ├── Holà-output.txt
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    └── batch-report.txt
+    ```
+
+A saída final em arte ASCII está no diretório `results/hello_config/`, com o nome `cowpy-COLLECTED-batch-output.txt`.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/hello_config/cowpy-COLLECTED-batch-output.txt"
+    _________
+    / HOLà    \
+    | HELLO   |
+    \ BONJOUR /
+    ---------
+      \                                  ,+*^^*+___+++_
+      \                           ,*^^^^              )
+        \                       _+*                     ^**+_
+        \                    +^       _ _++*+_+++_,         )
+                  _+^^*+_    (     ,+*^ ^          \+_        )
+                {       )  (    ,(    ,_+--+--,      ^)      ^\
+                { (\@)    } f   ,(  ,+-^ __*_*_  ^^\_   ^\       )
+              {:;-/    (_+*-+^^^^^+*+*<_ _++_)_    )    )      /
+              ( /  (    (        ,___    ^*+_+* )   <    <      \
+              U _/     )    *--<  ) ^\-----++__)   )    )       )
+                (      )  _(^)^^))  )  )\^^^^^))^*+/    /       /
+              (      /  (_))_^)) )  )  ))^^^^^))^^^)__/     +^^
+            (     ,/    (^))^))  )  ) ))^^^^^^^))^^)       _)
+              *+__+*       (_))^)  ) ) ))^^^^^^))^^^^^)____*^
+              \             \_)^)_)) ))^^^^^^^^^^))^^^^)
+              (_             ^\__^^^^^^^^^^^^))^^^^^^^)
+                ^\___            ^\__^^^^^^))^^^^^^^^)\\
+                      ^^^^^\uuu/^^\uuu/^^^^\^\^\^\^\^\^\^\
+                        ___) >____) >___   ^\_\_\_\_\_\_\)
+                        ^^^//\\_^^//\\_^       ^(\_\_\_\)
+                          ^^^ ^^ ^^^ ^
+    ```
+
+Se isso funcionou para você, está pronto para aprender como configurar seus pipelines.
+
+---
+
+## 1. Gerencie parâmetros de entrada do fluxo de trabalho
+
+Vamos começar com um aspecto da configuração que é simplesmente uma extensão do que temos trabalhado até agora: o gerenciamento de parâmetros de entrada.
+
+Atualmente, nosso fluxo de trabalho está configurado para aceitar vários valores de parâmetros via linha de comando, com valores padrão definidos em um bloco `params` no próprio script do fluxo de trabalho.
+No entanto, você pode querer substituir esses padrões sem ter que especificar parâmetros na linha de comando ou modificar o arquivo de script original.
+
+Existem várias maneiras de fazer isso; vamos mostrar três formas básicas que são muito comumente usadas.
+
+### 1.1. Mova os valores padrão para o `nextflow.config`
+
+Esta é a abordagem mais simples, embora seja possivelmente a menos flexível, já que o arquivo `nextflow.config` principal não é algo que você quer estar editando para cada execução.
+Mas tem a vantagem de separar as preocupações de _declarar_ os parâmetros no fluxo de trabalho (que definitivamente pertence lá) versus fornecer _valores padrão_, que estão mais em casa em um arquivo de configuração.
+
+Vamos fazer isso em dois passos.
+
+#### 1.1.1. Crie um bloco `params` no arquivo de configuração
+
+Faça as seguintes alterações de código no arquivo `nextflow.config`:
+
+=== "Depois"
+
+    ```groovy title="nextflow.config" linenums="1" hl_lines="3-10"
+    docker.enabled = true
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input = 'data/greetings.csv'
+        batch = 'batch'
+        character = 'turkey'
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="nextflow.config" linenums="1"
+    docker.enabled = true
+    ```
+
+Note que não simplesmente copiamos o bloco `params` do fluxo de trabalho para o arquivo de configuração.
+A sintaxe é um pouco diferente.
+No arquivo de fluxo de trabalho, essas são declarações tipadas.
+Na configuração, essas são atribuições de valores.
+
+Tecnicamente, isso é suficiente para substituir os valores padrão ainda especificados no arquivo de fluxo de trabalho.
+Você poderia modificar o caractere, por exemplo, e executar o fluxo de trabalho para se convencer de que o valor definido no arquivo de configuração substitui o definido no arquivo de fluxo de trabalho.
+
+Mas no espírito de mover a configuração completamente para o arquivo de configuração, vamos remover esses valores do arquivo de fluxo de trabalho inteiramente.
+
+#### 1.1.2. Remova os valores do bloco `params` no arquivo de fluxo de trabalho
+
+Faça as seguintes alterações de código no arquivo de fluxo de trabalho `hello-config.nf`:
+
+=== "Depois"
+
+    ```groovy title="hello-config.nf" linenums="9" hl_lines="5-7"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path
+        batch: String
+        character: String
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-config.nf" linenums="9" hl_lines="5-7"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+        character: String = 'turkey'
+    }
+    ```
+
+Agora o arquivo de fluxo de trabalho em si não define nenhum valor padrão para esses parâmetros.
+
+#### 1.1.3. Execute o pipeline
+
+Vamos testar se funciona corretamente.
+
+```bash
+nextflow run hello-config.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [disturbed_einstein] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Isso ainda produz a mesma saída de antes.
+
+A saída final em arte ASCII está no diretório `results/hello_config/`, com o nome `cowpy-COLLECTED-batch-output.txt`, igual a antes.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/hello_config/cowpy-COLLECTED-batch-output.txt"
+    _________
+    / HOLà    \
+    | HELLO   |
+    \ BONJOUR /
+    ---------
+      \                                  ,+*^^*+___+++_
+      \                           ,*^^^^              )
+        \                       _+*                     ^**+_
+        \                    +^       _ _++*+_+++_,         )
+                  _+^^*+_    (     ,+*^ ^          \+_        )
+                {       )  (    ,(    ,_+--+--,      ^)      ^\
+                { (\@)    } f   ,(  ,+-^ __*_*_  ^^\_   ^\       )
+              {:;-/    (_+*-+^^^^^+*+*<_ _++_)_    )    )      /
+              ( /  (    (        ,___    ^*+_+* )   <    <      \
+              U _/     )    *--<  ) ^\-----++__)   )    )       )
+                (      )  _(^)^^))  )  )\^^^^^))^*+/    /       /
+              (      /  (_))_^)) )  )  ))^^^^^))^^^)__/     +^^
+            (     ,/    (^))^))  )  ) ))^^^^^^^))^^)       _)
+              *+__+*       (_))^)  ) ) ))^^^^^^))^^^^^)____*^
+              \             \_)^)_)) ))^^^^^^^^^^))^^^^)
+              (_             ^\__^^^^^^^^^^^^))^^^^^^^)
+                ^\___            ^\__^^^^^^))^^^^^^^^)\\
+                      ^^^^^\uuu/^^\uuu/^^^^\^\^\^\^\^\^\^\
+                        ___) >____) >___   ^\_\_\_\_\_\_\)
+                        ^^^//\\_^^//\\_^       ^(\_\_\_\)
+                          ^^^ ^^ ^^^ ^
+    ```
+
+Funcionalmente, essa mudança não alterou nada, mas conceitualmente é um pouco mais limpo ter os valores padrão definidos no arquivo de configuração.
+
+### 1.2. Use um arquivo de configuração específico para a execução
+
+Isso é ótimo, mas às vezes você pode querer executar alguns experimentos temporários com diferentes valores padrão sem mexer no arquivo de configuração principal.
+Você pode fazer isso criando um novo arquivo `nextflow.config` em um subdiretório que você usará como diretório de trabalho para seus experimentos.
+
+#### 1.2.1. Crie o diretório de trabalho com uma configuração em branco
+
+Vamos começar criando um novo diretório e entrando nele:
+
+```bash
+mkdir -p tux-run
+cd tux-run
+```
+
+Em seguida, crie um arquivo de configuração em branco nesse diretório:
+
+```bash
+touch nextflow.config
+```
+
+Isso produz um arquivo vazio.
+
+#### 1.2.2. Configure a configuração experimental
+
+Agora abra o novo arquivo e adicione os parâmetros que você deseja personalizar:
+
+```groovy title="tux-run/nextflow.config" linenums="1"
+params {
+    input = '../data/greetings.csv'
+    batch = 'experiment'
+    character = 'tux'
+}
+```
+
+Note que o caminho para o arquivo de entrada deve refletir a estrutura de diretórios.
+
+#### 1.2.3. Execute o pipeline
+
+Agora podemos executar nosso pipeline de dentro do nosso novo diretório de trabalho.
+Certifique-se de adaptar o caminho adequadamente!
+
+```bash
+nextflow run ../hello-config.nf
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `../hello-config.nf` [trusting_escher] DSL2 - revision: 356df0818d
+
+    executor >  local (8)
+    [59/b66913] sayHello (2)       [100%] 3 of 3 ✔
+    [ad/f06364] convertToUpper (3) [100%] 3 of 3 ✔
+    [10/714895] collectGreetings   [100%] 1 of 1 ✔
+    [88/3ece98] cowpy              [100%] 1 of 1 ✔
+    ```
+
+Isso criará um novo conjunto de diretórios em `tux-run/` incluindo `tux-run/work/` e `tux-run/results/`.
+
+Nesta execução, o Nextflow combina o `nextflow.config` no nosso diretório atual com o `nextflow.config` no diretório raiz do pipeline, e assim substitui o caractere padrão (turkey) pelo caractere tux.
+
+O arquivo de saída final deve conter o caractere tux dizendo as saudações.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="tux-run/results/hello_config/cowpy-COLLECTED-experiment-output.txt"
+    _________
+    / HELLO   \
+    | BONJOUR |
+    \ HOLà    /
+    ---------
+      \
+        \
+            .--.
+          |o_o |
+          |:_/ |
+          //   \ \
+        (|     | )
+        /'\_   _/`\
+        \___)=(___/
+
+    ```
+
+É isso; agora você tem um espaço para experimentar sem modificar sua configuração 'normal'.
+
+!!! warning
+
+    Certifique-se de voltar ao diretório anterior antes de passar para a próxima seção!
+
+    ```bash
+    cd ..
+    ```
+
+Agora vamos ver outra maneira útil de definir valores de parâmetros.
+
+### 1.3. Use um arquivo de parâmetros
+
+A abordagem de subdiretório funciona muito bem para experimentar, mas envolve um pouco de configuração e requer que você adapte os caminhos adequadamente.
+Existe uma abordagem mais simples para quando você quer executar seu pipeline com um conjunto específico de valores, ou permitir que outra pessoa faça isso com o mínimo de esforço.
+
+O Nextflow nos permite especificar parâmetros via um arquivo de parâmetros no formato YAML ou JSON, o que torna muito conveniente gerenciar e distribuir conjuntos alternativos de valores padrão, por exemplo, assim como valores de parâmetros específicos da execução.
+
+#### 1.3.1. Examine o arquivo de parâmetros de exemplo
+
+Para demonstrar isso, fornecemos um arquivo de parâmetros de exemplo no diretório atual, chamado `test-params.yaml`:
+
+```yaml title="test-params.yaml" linenums="1"
+{
+  input: "greetings.csv"
+  batch: "yaml"
+  character: "stegosaurus"
+}
+```
+
+Este arquivo de parâmetros contém um par chave-valor para cada uma das entradas que queremos especificar.
+Note o uso de dois pontos (`:`) em vez de sinais de igual (`=`) se você comparar a sintaxe com o arquivo de configuração.
+O arquivo de configuração é escrito em Groovy, enquanto o arquivo de parâmetros é escrito em YAML.
+
+!!! info
+
+    Também fornecemos uma versão JSON do arquivo de parâmetros como exemplo, mas não vamos executar com ela aqui.
+    Sinta-se livre para tentar essa por conta própria.
+
+#### 1.3.2. Execute o pipeline
+
+Para executar o fluxo de trabalho com este arquivo de parâmetros, simplesmente adicione `-params-file <filename>` ao comando base.
+
+```bash
+nextflow run hello-config.nf -params-file test-params.yaml
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [disturbed_sammet] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+O arquivo de saída final deve conter o caractere stegosaurus dizendo as saudações.
+
+??? abstract "Conteúdo do arquivo"
+
+    ```console title="results/hello_config/cowpy-COLLECTED-yaml-output.txt"
+    _________
+    / HELLO   \
+    | HOLà    |
+    \ BONJOUR /
+    ---------
+    \                             .       .
+    \                           / `.   .' "
+      \                  .---.  <    > <    >  .---.
+      \                 |    \  \ - ~ ~ - /  /    |
+            _____          ..-~             ~-..-~
+            |     |   \~~~\.'                    `./~~~/
+          ---------   \__/                        \__/
+          .'  O    \     /               /       \  "
+        (_____,    `._.'               |         }  \/~~~/
+          `----.          /       }     |        /    \__/
+                `-.      |       /      |       /      `. ,~~|
+                    ~-.__|      /_ - ~ ^|      /- _      `..-'
+                        |     /        |     /     ~-.     `-. _  _  _
+                        |_____|        |_____|         ~ - . _ _ _ _ _>
+    ```
+
+Usar um arquivo de parâmetros pode parecer exagero quando você tem apenas alguns parâmetros para especificar, mas alguns pipelines esperam dezenas de parâmetros.
+Nesses casos, usar um arquivo de parâmetros nos permitirá fornecer valores de parâmetros no tempo de execução sem ter que digitar linhas de comando enormes e sem modificar o script do fluxo de trabalho.
+
+Também torna mais fácil distribuir conjuntos de parâmetros para colaboradores, ou como informação de apoio para uma publicação, por exemplo.
+Isso torna seu trabalho mais reproduzível por outros.
+
+### Conclusão
+
+Você sabe como aproveitar as principais opções de configuração para gerenciar entradas do fluxo de trabalho.
+
+### O que vem a seguir?
+
+Aprenda como gerenciar onde e como as saídas do seu fluxo de trabalho são publicadas.
+
+---
+
+## 2. Gerencie saídas do fluxo de trabalho
+
+Até agora temos codificado todos os caminhos para declarações de saída no nível do fluxo de trabalho, e como notamos quando começamos a adicionar múltiplas saídas, pode haver um pouco de repetição envolvida.
+
+Vamos ver algumas maneiras comuns de configurar isso para ser mais flexível.
+
+### 2.1. Personalize o nome do diretório `outputDir`
+
+Para cada capítulo deste curso, temos publicado saídas em um subdiretório diferente codificado nas definições de saída.
+
+Vamos mudar isso para usar um parâmetro configurável pelo usuário.
+Poderíamos criar um parâmetro totalmente novo para isso, mas vamos usar o parâmetro `batch` já que está bem ali.
+
+#### 2.1.1. Defina um valor para `outputDir` no arquivo de configuração
+
+O caminho que o Nextflow usa para publicar saídas é controlado pela opção `outputDir`.
+Para mudar o caminho para todas as saídas, você pode definir um valor para esta opção no arquivo de configuração `nextflow.config`.
+
+Adicione o seguinte código ao arquivo `nextflow.config`:
+
+=== "Depois"
+
+    ```groovy title="nextflow.config" linenums="9" hl_lines="10-13"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input = 'data/greetings.csv'
+        batch = 'batch'
+        character = 'turkey'
+    }
+
+    /*
+    * Output settings
+    */
+    outputDir = "results/${params.batch}"
+    ```
+
+=== "Antes"
+
+    ```groovy title="nextflow.config" linenums="9"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input = 'data/greetings.csv'
+        batch = 'batch'
+        character = 'turkey'
+    }
+    ```
+
+Isso substituirá o caminho padrão integrado, `results/`, por `results/` mais o valor do parâmetro `batch` como subdiretório.
+Você também poderia mudar a parte `results` se quisesse.
+
+Para uma mudança temporária, você poderia definir esta opção da linha de comando usando o parâmetro `-output-dir` no seu comando (mas então você não poderia usar o valor do parâmetro `batch`).
+
+#### 2.1.2. Remova a parte repetida do caminho codificado
+
+Ainda temos um subdiretório codificado nas opções de saída, então vamos nos livrar disso agora.
+
+Faça as seguintes alterações de código no arquivo de fluxo de trabalho:
+
+=== "Depois"
+
+    ```groovy title="hello-config.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path 'intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path 'intermediates'
+            mode 'copy'
+        }
+        collected {
+            path 'intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path ''
+            mode 'copy'
+        }
+        cowpy_art {
+            path ''
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-config.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path 'hello_config/intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_config/intermediates'
+            mode 'copy'
+        }
+        collected {
+            path 'hello_config/intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path 'hello_config'
+            mode 'copy'
+        }
+        cowpy_art {
+            path 'hello_config'
+            mode 'copy'
+        }
+    }
+    ```
+
+Também poderíamos ter apenas adicionado `${params.batch}` a cada caminho em vez de modificar o padrão `outputDir`, mas isso é mais conciso.
+
+#### 2.1.3. Execute o pipeline
+
+Vamos testar se funciona corretamente, definindo o nome do lote como `outdir` a partir da linha de comando.
+
+```bash
+nextflow run hello-config.nf --batch outdir
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [disturbed_einstein] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Isso ainda produz a mesma saída de antes, exceto que desta vez encontramos nossas saídas em `results/outdir/`.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    results/outdir/
+    ├── cowpy-COLLECTED-outdir-output.txt
+    ├── intermediates
+    │   ├── Bonjour-output.txt
+    │   ├── COLLECTED-outdir-output.txt
+    │   ├── Hello-output.txt
+    │   ├── Holà-output.txt
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    └── outdir-report.txt
+    ```
+
+Você pode combinar esta abordagem com definições de caminho personalizadas para construir qualquer hierarquia de diretórios que desejar.
+
+### 2.2. Organize saídas por processo
+
+Uma maneira popular de organizar ainda mais as saídas é fazer isso por processo, _ou seja_, criar subdiretórios para cada processo executado no pipeline.
+
+#### 2.2.1. Substitua os caminhos de saída por uma referência aos nomes dos processos
+
+Tudo o que você precisa fazer é referenciar o nome do processo como `<task>.name` na declaração do caminho de saída.
+
+Faça as seguintes alterações no arquivo de fluxo de trabalho:
+
+=== "Depois"
+
+    ```groovy title="hello-config.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path { sayHello.name }
+            mode 'copy'
+        }
+        uppercased {
+            path { convertToUpper.name }
+            mode 'copy'
+        }
+        collected {
+            path { collectGreetings.name }
+            mode 'copy'
+        }
+        batch_report {
+            path { collectGreetings.name }
+            mode 'copy'
+        }
+        cowpy_art {
+            path { cowpy.name }
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-config.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path 'intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path 'intermediates'
+            mode 'copy'
+        }
+        collected {
+            path 'intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path ''
+            mode 'copy'
+        }
+        cowpy_art {
+            path ''
+            mode 'copy'
+        }
+    }
+    ```
+
+Isso remove os elementos codificados restantes da configuração do caminho de saída.
+
+#### 2.2.2. Execute o pipeline
+
+Vamos testar se funciona corretamente, definindo o nome do lote como `pnames` a partir da linha de comando.
+
+```bash
+nextflow run hello-config.nf --batch pnames
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [jovial_mcclintock] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Isso ainda produz a mesma saída de antes, exceto que desta vez encontramos nossas saídas em `results/pnames/`, e elas estão agrupadas por processo.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    results/pnames/
+    ├── collectGreetings
+    │   ├── COLLECTED-pnames-output.txt
+    │   └── pnames-report.txt
+    ├── convertToUpper
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    ├── cowpy
+    │   └── cowpy-COLLECTED-pnames-output.txt
+    └── sayHello
+        ├── Bonjour-output.txt
+        ├── Hello-output.txt
+        └── Holà-output.txt
+    ```
+
+Note que aqui apagamos a distinção entre `intermediates` versus saídas finais estando no nível superior.
+Você poderia, é claro, misturar e combinar essas abordagens, por exemplo, definindo o caminho da primeira saída como `intermediates/${sayHello.process}`
+
+### 2.3. Defina o modo de publicação no nível do fluxo de trabalho
+
+Finalmente, no espírito de reduzir a quantidade de código repetitivo, podemos substituir as declarações `mode` por saída com uma única linha na configuração.
+
+#### 2.3.1. Adicione `workflow.output.mode` ao arquivo de configuração
+
+Adicione o seguinte código ao arquivo `nextflow.config`:
+
+=== "Depois"
+
+    ```groovy title="nextflow.config" linenums="2" hl_lines="5"
+    /*
+    * Output settings
+    */
+    outputDir = "results/${params.batch}"
+    workflow.output.mode = 'copy'
+    ```
+
+=== "Antes"
+
+    ```groovy title="nextflow.config" linenums="12"
+    /*
+    * Output settings
+    */
+    outputDir = "results/${params.batch}"
+    ```
+
+Assim como a opção `outputDir`, dar a `workflow.output.mode` um valor no arquivo de configuração seria suficiente para substituir o que está definido no arquivo de fluxo de trabalho, mas vamos remover o código desnecessário de qualquer forma.
+
+#### 2.3.2. Remova o modo de saída do arquivo de fluxo de trabalho
+
+Faça as seguintes alterações no arquivo de fluxo de trabalho:
+
+=== "Depois"
+
+    ```groovy title="hello-config.nf" linenums="42"
+    output {
+        first_output {
+            path { sayHello.process }
+        }
+        uppercased {
+            path { convertToUpper.process }
+        }
+        collected {
+            path { collectGreetings.process }
+        }
+        batch_report {
+            path { collectGreetings.process }
+        }
+        cowpy_art {
+            path { cowpy.process }
+        }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="hello-config.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path { sayHello.process }
+            mode 'copy'
+        }
+        uppercased {
+            path { convertToUpper.process }
+            mode 'copy'
+        }
+        collected {
+            path { collectGreetings.process }
+            mode 'copy'
+        }
+        batch_report {
+            path { collectGreetings.process }
+            mode 'copy'
+        }
+        cowpy_art {
+            path { cowpy.process }
+            mode 'copy'
+        }
+    }
+    ```
+
+Isso é mais conciso, não é?
+
+#### 2.3.3. Execute o pipeline
+
+Vamos testar se funciona corretamente, definindo o nome do lote como `outmode` a partir da linha de comando.
+
+```bash
+nextflow run hello-config.nf --batch outmode
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [rowdy_sagan] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Isso ainda produz a mesma saída de antes, exceto que desta vez encontramos nossas saídas em `results/outmode/`.
+Todas ainda são cópias adequadas, não symlinks.
+
+??? abstract "Conteúdo do diretório"
+
+    ```console
+    results/outmode/
+    ├── collectGreetings
+    │   ├── COLLECTED-outmode-output.txt
+    │   └── outmode-report.txt
+    ├── convertToUpper
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    ├── cowpy
+    │   └── cowpy-COLLECTED-outmode-output.txt
+    └── sayHello
+        ├── Bonjour-output.txt
+        ├── Hello-output.txt
+        └── Holà-output.txt
+    ```
+
+A principal razão pela qual você ainda pode querer usar a maneira por saída de definir o modo é se você quiser misturar e combinar dentro do mesmo fluxo de trabalho, _ou seja_, ter algumas saídas sendo copiadas e algumas sendo symlinkadas.
+
+Existem muitas outras opções que você pode personalizar dessa maneira, mas esperamos que isso lhe dê uma noção da gama de opções e como utilizá-las efetivamente para atender às suas preferências.
+
+### Conclusão
+
+Você sabe como controlar a nomenclatura e estrutura dos diretórios onde suas saídas são publicadas, bem como o modo de publicação de saída do fluxo de trabalho.
+
+### O que vem a seguir?
+
+Aprenda como adaptar a configuração do seu fluxo de trabalho ao seu ambiente de computação, começando com a tecnologia de empacotamento de software.
+
+---
+
+## 3. Selecione uma tecnologia de empacotamento de software
+
+Até agora temos visto elementos de configuração que controlam como as entradas entram e onde as saídas saem. Agora é hora de focar mais especificamente em adaptar a configuração do seu fluxo de trabalho ao seu ambiente de computação.
+
+O primeiro passo nesse caminho é especificar de onde virão os pacotes de software que serão executados em cada etapa.
+Eles já estão instalados no ambiente de computação local?
+Precisamos recuperar imagens e executá-las via um sistema de contêineres?
+Ou precisamos recuperar pacotes Conda e construir um ambiente Conda local?
+
+Na primeira parte deste curso de treinamento (Partes 1-4) apenas usamos software instalado localmente em nosso fluxo de trabalho.
+Então na Parte 5, introduzimos contêineres Docker e o arquivo `nextflow.config`, que usamos para habilitar o uso de contêineres Docker.
+
+Agora vamos ver como podemos configurar uma opção alternativa de empacotamento de software via o arquivo `nextflow.config`.
+
+### 3.1. Desabilite o Docker e habilite o Conda no arquivo de configuração
+
+Vamos fingir que estamos trabalhando em um cluster HPC e o administrador não permite o uso do Docker por razões de segurança.
+Felizmente para nós, o Nextflow suporta múltiplas outras tecnologias de contêineres, incluindo Singularity (que é mais amplamente usado em HPC), e gerenciadores de pacotes de software como Conda.
+
+Podemos mudar nosso arquivo de configuração para usar Conda em vez de Docker.
+Para fazer isso, vamos mudar o valor de `docker.enabled` para `false`, e adicionar uma diretiva habilitando o uso do Conda:
+
+=== "Depois"
+
+    ```groovy title="nextflow.config" linenums="1" hl_lines="1-2"
+    docker.enabled = false
+    conda.enabled = true
+    ```
+
+=== "Antes"
+
+    ```groovy title="nextflow.config" linenums="1" hl_lines="1"
+    docker.enabled = true
+    ```
+
+Isso permitirá que o Nextflow crie e utilize ambientes Conda para processos que têm pacotes Conda especificados.
+O que significa que agora precisamos adicionar um desses ao nosso processo `cowpy`!
+
+### 3.2. Especifique um pacote Conda na definição do processo
+
+Já recuperamos o URI para um pacote Conda contendo a ferramenta `cowpy`: `conda-forge::cowpy==1.1.5`
+
+Agora adicionamos o URI à definição do processo `cowpy` usando a diretiva `conda`:
+
+=== "Depois"
+
+    ```groovy title="modules/cowpy.nf" linenums="4" hl_lines="4"
+    process cowpy {
+
+        container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+        conda 'conda-forge::cowpy==1.1.5'
+
+        input:
+    ```
+
+=== "Antes"
+
+    ```groovy title="modules/cowpy.nf" linenums="4"
+    process cowpy {
+
+        container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+
+        input:
+    ```
+
+Para ser claro, não estamos _substituindo_ a diretiva `docker`, estamos _adicionando_ uma opção alternativa.
+
+!!! tip
+
+    Existem algumas maneiras diferentes de obter o URI para um determinado pacote conda.
+    Recomendamos usar a consulta de busca [Seqera Containers](https://seqera.io/containers/), que lhe dará um URI que você pode copiar e colar, mesmo que você não esteja planejando criar um contêiner a partir dele.
+
+### 3.3. Execute o fluxo de trabalho para verificar que ele pode usar Conda
+
+Vamos experimentar.
+
+```bash
+nextflow run hello-config.nf --batch conda
+```
+
+??? success "Saída do comando"
+
+    ```console title="Output"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [trusting_lovelace] DSL2 - revision: 028a841db1
+
+    executor >  local (8)
+    [ee/4ca1f2] sayHello (3)       | 3 of 3 ✔
+    [20/2596a7] convertToUpper (1) | 3 of 3 ✔
+    [b3/e15de5] collectGreetings   | 1 of 1 ✔
+    [c5/af5f88] cowpy              | 1 of 1 ✔
+    ```
+
+Isso deve funcionar sem problemas e produzir as mesmas saídas de antes em `results/conda`.
+
+Nos bastidores, o Nextflow recuperou os pacotes Conda e criou o ambiente, o que normalmente requer um pouco de trabalho; então é bom que não tenhamos que fazer nada disso nós mesmos!
+
+!!! note
+
+    Isso executa rapidamente porque o pacote `cowpy` é bastante pequeno, mas se você estiver trabalhando com pacotes grandes, pode levar um pouco mais de tempo do que o normal na primeira vez, e você pode ver a saída do console ficar 'presa' por um minuto ou mais antes de completar.
+    Isso é normal e se deve ao trabalho extra que o Nextflow faz na primeira vez que você usa um novo pacote.
+
+Do nosso ponto de vista, parece que funciona exatamente da mesma forma que executar com Docker, embora no backend a mecânica seja um pouco diferente.
+
+Isso significa que estamos todos prontos para executar com ambientes Conda se necessário.
+
+??? info "Misturando e combinando Docker e Conda"
+
+    Como essas diretivas são atribuídas por processo, é possível 'misturar e combinar', _ou seja_, configurar alguns dos processos em seu fluxo de trabalho para executar com Docker e outros com Conda, por exemplo, se a infraestrutura de computação que você está usando suporta ambos.
+    Nesse caso, você habilitaria tanto Docker quanto Conda no seu arquivo de configuração.
+    Se ambos estiverem disponíveis para um determinado processo, o Nextflow priorizará contêineres.
+
+    E como observado anteriormente, o Nextflow suporta múltiplas outras tecnologias de empacotamento de software e contêineres, então você não está limitado a apenas essas duas.
+
+### Conclusão
+
+Você sabe como configurar qual pacote de software cada processo deve usar, e como alternar entre tecnologias.
+
+### O que vem a seguir?
+
+Aprenda como mudar a plataforma de execução usada pelo Nextflow para realmente fazer o trabalho.
+
+---
+
+## 4. Selecione uma plataforma de execução
+
+Até agora, temos executado nosso pipeline com o executor local.
+Isso executa cada tarefa na máquina em que o Nextflow está sendo executado.
+Quando o Nextflow começa, ele verifica as CPUs e memória disponíveis.
+Se os recursos das tarefas prontas para executar excedem os recursos disponíveis, o Nextflow manterá as últimas tarefas de volta da execução até que uma ou mais das tarefas anteriores tenham terminado, liberando os recursos necessários.
+
+O executor local é conveniente e eficiente, mas é limitado àquela única máquina. Para cargas de trabalho muito grandes, você pode descobrir que sua máquina local é um gargalo, seja porque você tem uma única tarefa que requer mais recursos do que você tem disponíveis, ou porque você tem tantas tarefas que esperar por uma única máquina para executá-las levaria muito tempo.
+
+O Nextflow suporta [muitos backends de execução diferentes](https://www.nextflow.io/docs/latest/executor.html), incluindo agendadores HPC (Slurm, LSF, SGE, PBS, Moab, OAR, Bridge, HTCondor e outros), bem como backends de execução em nuvem (AWS Batch, Google Cloud Batch, Azure Batch, Kubernetes e mais).
+
+### 4.1. Direcionando um backend diferente
+
+A escolha do executor é definida por uma diretiva de processo chamada `executor`.
+Por padrão, é definido como `local`, então a seguinte configuração está implícita:
+
+```groovy title="Configuração integrada"
+process {
+    executor = 'local'
+}
+```
+
+Para definir o executor para direcionar um backend diferente, você simplesmente especificaria o executor que deseja usando sintaxe similar à descrita acima para alocações de recursos (veja a [documentação](https://www.nextflow.io/docs/latest/executor.html) para todas as opções).
+
+```groovy title="nextflow.config"
+process {
+    executor = 'slurm'
+}
+```
+
+!!! warning
+
+    Não podemos realmente testar isso no ambiente de treinamento porque não está configurado para se conectar a um HPC.
+
+### 4.2. Lidando com sintaxe específica do backend para parâmetros de execução
+
+A maioria das plataformas de computação de alto desempenho permite (e às vezes exige) que você especifique certos parâmetros, como solicitações e limitações de alocação de recursos (por exemplo, número de CPUs e memória) e nome da fila de trabalhos a ser usada.
+
+Infelizmente, cada um desses sistemas usa tecnologias, sintaxes e configurações diferentes para definir como um trabalho deve ser definido e submetido ao agendador relevante.
+
+??? abstract "Exemplos"
+
+    Por exemplo, o mesmo trabalho requerendo 8 CPUs e 4GB de RAM para ser executado na fila "my-science-work" precisa ser expresso das seguintes maneiras diferentes dependendo do backend.
+
+    ```bash title="Config para SLURM / submeter usando sbatch"
+    #SBATCH -o /path/to/my/task/directory/my-task-1.log
+    #SBATCH --no-requeue
+    #SBATCH -c 8
+    #SBATCH --mem 4096M
+    #SBATCH -p my-science-work
+    ```
+
+    ```bash title="Config para PBS / submeter usando qsub"
+    #PBS -o /path/to/my/task/directory/my-task-1.log
+    #PBS -j oe
+    #PBS -q my-science-work
+    #PBS -l nodes=1:ppn=5
+    #PBS -l mem=4gb
+    ```
+
+    ```bash title="Config para SGE / submeter usando qsub"
+    #$ -o /path/to/my/task/directory/my-task-1.log
+    #$ -j y
+    #$ -terse
+    #$ -notify
+    #$ -q my-science-work
+    #$ -l slots=5
+    #$ -l h_rss=4096M,mem_free=4096M
+    ```
+
+Felizmente, o Nextflow simplifica tudo isso.
+Ele fornece uma sintaxe padronizada para que você possa especificar as propriedades relevantes como `cpus`, `memory` e `queue` (veja a documentação para outras propriedades) apenas uma vez.
+Então, no tempo de execução, o Nextflow usará essas configurações para gerar os scripts específicos do backend apropriados com base na configuração do executor.
+
+Vamos cobrir essa sintaxe padronizada na próxima seção.
+
+### Conclusão
+
+Você agora sabe como mudar o executor para usar diferentes tipos de infraestrutura de computação.
+
+### O que vem a seguir?
+
+Aprenda como avaliar e expressar alocações e limitações de recursos no Nextflow.
+
+---
+
+## 5. Controle alocações de recursos de computação
+
+A maioria das plataformas de computação de alto desempenho permite (e às vezes exige) que você especifique certos parâmetros de alocação de recursos, como número de CPUs e memória.
+
+Por padrão, o Nextflow usará uma única CPU e 2GB de memória para cada processo.
+As diretivas de processo correspondentes são chamadas `cpus` e `memory`, então a seguinte configuração está implícita:
+
+```groovy title="Configuração integrada" linenums="1"
+process {
+    cpus = 1
+    memory = 2.GB
+}
+```
+
+Você pode modificar esses valores, seja para todos os processos ou para processos nomeados específicos, usando diretivas de processo adicionais no seu arquivo de configuração.
+O Nextflow os traduzirá nas instruções apropriadas para o executor escolhido.
+
+Mas como você sabe quais valores usar?
+
+### 5.1. Execute o fluxo de trabalho para gerar um relatório de utilização de recursos
+
+Se você não sabe de antemão quanta CPU e memória seus processos provavelmente precisarão, você pode fazer algum perfil de recursos, o que significa que você executa o fluxo de trabalho com algumas alocações padrão, registra quanto cada processo usou e, a partir daí, estima como ajustar as alocações base.
+
+Convenientemente, o Nextflow inclui ferramentas integradas para fazer isso, e irá gerar alegremente um relatório para você mediante solicitação.
+
+Para fazer isso, adicione `-with-report <filename>.html` à sua linha de comando.
+
+```bash
+nextflow run hello-config.nf -with-report report-config-1.html
+```
+
+O relatório é um arquivo html, que você pode baixar e abrir no seu navegador. Você também pode clicar com o botão direito nele no explorador de arquivos à esquerda e clicar em `Show preview` para visualizá-lo no ambiente de treinamento.
+
+Reserve alguns minutos para examinar o relatório e ver se você consegue identificar algumas oportunidades para ajustar recursos.
+Certifique-se de clicar nas abas que mostram os resultados de utilização como uma porcentagem do que foi alocado.
+Há alguma [documentação](https://www.nextflow.io/docs/latest/reports.html) descrevendo todos os recursos disponíveis.
+
+### 5.2. Defina alocações de recursos para todos os processos
+
+O perfil mostra que os processos em nosso fluxo de trabalho de treinamento são muito leves, então vamos reduzir a alocação de memória padrão para 1GB por processo.
+
+Adicione o seguinte ao seu arquivo `nextflow.config`, antes da seção de parâmetros do pipeline:
+
+```groovy title="nextflow.config" linenums="4"
+/*
+* Process settings
+*/
+process {
+    memory = 1.GB
+}
+```
+
+Isso ajudará a reduzir a quantidade de computação que consumimos.
+
+### 5.3. Defina alocações de recursos para um processo específico
+
+Ao mesmo tempo, vamos fingir que o processo `cowpy` requer mais recursos do que os outros, apenas para que possamos demonstrar como ajustar alocações para um processo individual.
+
+=== "Depois"
+
+    ```groovy title="nextflow.config" linenums="4" hl_lines="6-9"
+    /*
+    * Process settings
+    */
+    process {
+        memory = 1.GB
+        withName: 'cowpy' {
+            memory = 2.GB
+            cpus = 2
+        }
+    }
+    ```
+
+=== "Antes"
+
+    ```groovy title="nextflow.config" linenums="4"
+    /*
+    * Process settings
+    */
+    process {
+        memory = 1.GB
+    }
+    ```
+
+Com esta configuração, todos os processos solicitarão 1GB de memória e uma única CPU (o padrão implícito), exceto o processo `cowpy`, que solicitará 2GB e 2 CPUs.
+
+!!! tip
+
+    Se você tiver uma máquina com poucas CPUs e alocar um número alto por processo, poderá ver chamadas de processo sendo enfileiradas uma atrás da outra.
+    Isso ocorre porque o Nextflow garante que não solicitemos mais CPUs do que as disponíveis.
+
+### 5.4. Execute o fluxo de trabalho com a configuração atualizada
+
+Vamos experimentar isso, fornecendo um nome de arquivo diferente para o relatório de perfil para que possamos comparar o desempenho antes e depois das mudanças de configuração.
+
+```bash
+nextflow run hello-config.nf -with-report report-config-2.html
+```
+
+Você provavelmente não notará nenhuma diferença real, pois esta é uma carga de trabalho tão pequena, mas esta é a abordagem que você usaria para analisar o desempenho e os requisitos de recursos de um fluxo de trabalho do mundo real.
+
+É muito útil quando seus processos têm requisitos de recursos diferentes. Ele o capacita a dimensionar corretamente as alocações de recursos que você configura para cada processo com base em dados reais, não em suposições.
+
+!!! tip
+
+    Este é apenas um pequeno aperitivo do que você pode fazer para otimizar seu uso de recursos.
+    O próprio Nextflow tem uma [lógica de repetição dinâmica](https://www.nextflow.io/docs/latest/process.html#dynamic-task-resources) realmente interessante embutida para repetir trabalhos que falham devido a limitações de recursos.
+    Além disso, a Seqera Platform oferece ferramentas orientadas por IA para otimizar suas alocações de recursos automaticamente também.
+
+### 5.5. Adicione limites de recursos
+
+Dependendo de qual executor de computação e infraestrutura de computação você está usando, pode haver algumas restrições sobre o que você pode (ou deve) alocar.
+Por exemplo, seu cluster pode exigir que você permaneça dentro de certos limites.
+
+Você pode usar a diretiva `resourceLimits` para definir as limitações relevantes. A sintaxe se parece com isso quando está sozinha em um bloco de processo:
+
+```groovy title="Exemplo de sintaxe"
+process {
+    resourceLimits = [
+        memory: 750.GB,
+        cpus: 200,
+        time: 30.d
+    ]
+}
+```
+
+O Nextflow traduzirá esses valores nas instruções apropriadas dependendo do executor que você especificou.
+
+Não vamos executar isso, pois não temos acesso à infraestrutura relevante no ambiente de treinamento.
+No entanto, se você tentasse executar o fluxo de trabalho com alocações de recursos que excedem esses limites, então procurasse o comando `sbatch` no arquivo de script `.command.run`, você veria que as solicitações que realmente são enviadas ao executor são limitadas aos valores especificados por `resourceLimits`.
+
+??? info "Configurações de referência institucionais"
+
+    O projeto nf-core compilou uma [coleção de arquivos de configuração](https://nf-co.re/configs/) compartilhados por várias instituições ao redor do mundo, cobrindo uma ampla gama de executores HPC e nuvem.
+
+    Essas configurações compartilhadas são valiosas tanto para pessoas que trabalham lá e, portanto, podem simplesmente utilizar a configuração de sua instituição pronta para uso, quanto como modelo para pessoas que estão procurando desenvolver uma configuração para sua própria infraestrutura.
+
+### Conclusão
+
+Você sabe como gerar um relatório de perfil para avaliar a utilização de recursos e como modificar alocações de recursos para todos os processos e/ou para processos individuais, bem como definir limitações de recursos para executar em HPC.
+
+### O que vem a seguir?
+
+Aprenda como configurar perfis de configuração predefinidos e alternar entre eles no tempo de execução.
+
+---
+
+## 6. Use perfis para alternar entre configurações predefinidas
+
+Mostramos a você várias maneiras de personalizar a configuração do seu pipeline dependendo do projeto em que você está trabalhando ou do ambiente de computação que está usando.
+
+Você pode querer alternar entre configurações alternativas dependendo de qual infraestrutura de computação está usando. Por exemplo, você pode querer desenvolver e executar testes em pequena escala localmente no seu laptop, depois executar cargas de trabalho em escala completa em HPC ou nuvem.
+
+O Nextflow permite que você configure qualquer número de perfis que descrevem diferentes configurações, que você pode então selecionar no tempo de execução usando um argumento de linha de comando, em vez de ter que modificar o arquivo de configuração em si.
+
+### 6.1. Crie perfis para alternar entre desenvolvimento local e execução em HPC
+
+Vamos configurar dois perfis alternativos; um para executar cargas em pequena escala em um computador normal, onde usaremos contêineres Docker, e outro para executar em um HPC universitário com um agendador Slurm, onde usaremos pacotes Conda.
+
+#### 6.1.1. Configure os perfis
+
+Adicione o seguinte ao seu arquivo `nextflow.config`, após a seção de parâmetros do pipeline, mas antes das configurações de saída:
+
+```groovy title="nextflow.config" linenums="24"
+/*
+* Profiles
+*/
+profiles {
+    my_laptop {
+        process.executor = 'local'
+        docker.enabled = true
+    }
+    univ_hpc {
+        process.executor = 'slurm'
+        conda.enabled = true
+        process.resourceLimits = [
+            memory: 750.GB,
+            cpus: 200,
+            time: 30.d
+        ]
+    }
+}
+```
+
+Você vê que para o HPC universitário, também estamos especificando limitações de recursos.
+
+#### 6.1.2. Execute o fluxo de trabalho com um perfil
+
+Para especificar um perfil na nossa linha de comando do Nextflow, usamos o argumento `-profile`.
+
+Vamos tentar executar o fluxo de trabalho com a configuração `my_laptop`.
+
+```bash
+nextflow run hello-config.nf -profile my_laptop
+```
+
+??? success "Saída do comando"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [gigantic_brazil] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [58/da9437] sayHello (3)       | 3 of 3 ✔
+    [35/9cbe77] convertToUpper (2) | 3 of 3 ✔
+    [67/857d05] collectGreetings   | 1 of 1 ✔
+    [37/7b51b5] cowpy              | 1 of 1 ✔
+    ```
+
+Como você pode ver, isso nos permite alternar entre configurações muito convenientemente no tempo de execução.
+
+!!! warning
+
+    O perfil `univ_hpc` não será executado corretamente no ambiente de treinamento, pois não temos acesso a um agendador Slurm.
+
+Se no futuro encontrarmos outros elementos de configuração que estão sempre co-ocorrendo com esses, podemos simplesmente adicioná-los ao(s) perfil(is) correspondente(s).
+Também podemos criar perfis adicionais se houver outros elementos de configuração que queremos agrupar.
+
+### 6.2. Crie um perfil de parâmetros de teste
+
+Perfis não são apenas para configuração de infraestrutura.
+Também podemos usá-los para definir valores padrão para parâmetros de fluxo de trabalho, para facilitar que outros experimentem o fluxo de trabalho sem ter que reunir valores de entrada apropriados por conta própria.
+Você pode considerar isso uma alternativa ao uso de um arquivo de parâmetros.
+
+#### 6.2.1. Configure o perfil
+
+A sintaxe para expressar valores padrão neste contexto se parece com isso, para um perfil que nomeamos `test`:
+
+```groovy title="Exemplo de sintaxe"
+    test {
+        params.<parameter1>
+        params.<parameter2>
+        ...
+    }
+```
+
+Se adicionarmos um perfil de teste para nosso fluxo de trabalho, o bloco `profiles` se torna:
+
+```groovy title="nextflow.config" linenums="24"
+/*
+* Profiles
+*/
+profiles {
+    my_laptop {
+        process.executor = 'local'
+        docker.enabled = true
+    }
+    univ_hpc {
+        process.executor = 'slurm'
+        conda.enabled = true
+        process.resourceLimits = [
+            memory: 750.GB,
+            cpus: 200,
+            time: 30.d
+        ]
+    }
+    test {
+        params.greeting = 'greetings.csv'
+        params.batch = 'test'
+        params.character = 'dragonandcow'
+    }
+}
+```
+
+Assim como para perfis de configuração técnica, você pode configurar vários perfis diferentes especificando parâmetros sob qualquer

--- a/docs/pt/docs/hello_nextflow/index.md
+++ b/docs/pt/docs/hello_nextflow/index.md
@@ -1,0 +1,60 @@
+---
+title: Hello Nextflow
+hide:
+    - toc
+page_type: index_page
+index_type: course
+additional_information:
+    technical_requirements: true
+    learning_objectives:
+        - Iniciar e gerenciar a execução de fluxos de trabalho Nextflow
+        - Encontrar e interpretar saídas (resultados) e arquivos de log gerados pelo Nextflow
+        - Solucionar problemas básicos
+        - Construir um fluxo de trabalho simples de múltiplas etapas a partir de componentes principais do Nextflow
+        - Distinguir entre tipos essenciais de fábricas de canais e operadores e utilizá-los efetivamente em um fluxo de trabalho simples
+        - Configurar a execução de pipelines para rodar em plataformas de computação comuns, incluindo HPC e nuvem
+        - Aplicar boas práticas para reprodutibilidade, portabilidade e reutilização de código que tornam pipelines FAIR, incluindo modularidade de código e contêineres de software
+    audience_prerequisites:
+        - "**Público:** Este curso é destinado a pessoas que são completamente novas no Nextflow e desejam desenvolver seus próprios pipelines."
+        - "**Habilidades:** Presume-se alguma familiaridade com a linha de comando, conceitos básicos de script e formatos de arquivo comuns."
+        - "**Domínio:** Os exercícios são todos agnósticos de domínio, portanto não é necessário conhecimento científico prévio."
+    videos_playlist: https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik
+---
+
+# Hello Nextflow
+
+**Hello Nextflow é uma introdução prática à construção de fluxos de trabalho de análise de dados reproduzíveis e escaláveis.**
+
+Trabalhando através de exemplos práticos e exercícios guiados, você aprenderá os fundamentos do desenvolvimento de pipelines com Nextflow, incluindo como definir processos, conectá-los em pipelines, gerenciar arquivos e dependências de software, paralelizar a execução sem esforço e executar fluxos de trabalho em diferentes ambientes computacionais.
+
+Você sairá com as habilidades e a confiança para começar a desenvolver e executar seus próprios fluxos de trabalho com Nextflow.
+
+<!-- additional_information -->
+
+## Visão geral do curso
+
+Este curso é projetado para ser prático, com exercícios orientados a objetivos estruturados para introduzir informações gradualmente.
+
+Você desenvolverá um pipeline simples do Nextflow que recebe algumas entradas de texto, executa algumas etapas de transformação e gera um único arquivo de texto contendo uma figura ASCII de um personagem dizendo o texto transformado.
+
+### Plano de aula
+
+Para evitar sobrecarregá-lo com conceitos e código, dividimos isso em seis partes que focarão em aspectos específicos do desenvolvimento de pipelines com Nextflow.
+
+| Capítulo do curso                                    | Resumo                                                                                                             | Duração estimada |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| [Parte 1: Hello World](./01_hello_world.md)          | Componentes básicos e princípios envolvidos na montagem e execução de um fluxo de trabalho Nextflow               | 30 mins          |
+| [Parte 2: Hello Channels](./02_hello_channels.md)    | Usando canais e operadores para processar entradas e paralelizar a execução sem esforço                            | 45 mins          |
+| [Parte 3: Hello Workflow](./03_hello_workflow.md)    | Usando canais para encadear múltiplas etapas juntas e lidar com a transferência de dados entre etapas             | 60 mins          |
+| [Parte 4: Hello Modules](./04_hello_modules.md)      | Aplicando princípios de modularidade de código para aumentar a reutilização e diminuir a carga de manutenção      | 20 mins          |
+| [Parte 5: Hello Containers](./05_hello_containers.md)| Usando contêineres como um mecanismo para gerenciar dependências de software e aumentar a reprodutibilidade       | 60 mins          |
+| [Parte 6: Hello Config](./06_hello_config.md)        | Personalizando o comportamento do pipeline e otimizando o uso em diferentes ambientes computacionais              | 60 mins          |
+
+Ao final deste curso, você estará bem preparado para enfrentar os próximos passos em sua jornada para desenvolver fluxos de trabalho reproduzíveis para suas necessidades de computação científica.
+
+Pronto para fazer o curso?
+
+[Começar :material-arrow-right:](00_orientation.md){ .md-button .md-button--primary }
+
+<!-- Clearfix for float -->
+<div style="content: ''; clear: both; display: table;"></div>

--- a/docs/pt/docs/hello_nextflow/next_steps.md
+++ b/docs/pt/docs/hello_nextflow/next_steps.md
@@ -1,0 +1,64 @@
+# Resumo do curso
+
+Parabéns por concluir o curso de treinamento Hello Nextflow! 🎉
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/xHOcx_4Ancg?si=Lp8hS8RdaMwbp5j5&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Veja a [playlist completa no canal do YouTube do Nextflow](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik).
+
+:green_book: Você pode ler a [transcrição do vídeo](./transcripts/07_next_steps.md) junto com o vídeo.
+///
+
+## Sua jornada
+
+Você começou com um fluxo de trabalho muito básico que executava um comando hardcoded.
+Ao longo de seis partes, você transformou esse fluxo de trabalho básico em um pipeline modular de múltiplas etapas que exercita recursos-chave do Nextflow, incluindo canais, operadores, suporte integrado para contêineres e opções de configuração.
+
+### O que você construiu
+
+- A forma final do fluxo de trabalho Hello recebe como entrada um arquivo CSV contendo saudações em texto.
+- As quatro etapas são implementadas como processos Nextflow (`sayHello`, `convertToUpper`, `collectGreetings` e `cowpy`) armazenados em arquivos de módulo separados.
+- Os resultados são publicados em um diretório chamado `results/`.
+- A saída final do pipeline é um arquivo de texto simples contendo arte ASCII de um personagem dizendo as saudações em maiúsculas.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_pipeline_complete.svg"
+</figure>
+
+1. **`sayHello`:** Escreve cada saudação em seu próprio arquivo de saída (_ex._ "Hello-output.txt")
+2. **`convertToUpper`:** Converte cada saudação para maiúsculas (_ex._ "HELLO")
+3. **`collectGreetings`:** Coleta todas as saudações em maiúsculas em um único arquivo em lote
+4. **`cowpy`:** Gera arte ASCII usando a ferramenta `cowpy`
+
+A configuração do fluxo de trabalho suporta fornecer entradas e parâmetros de forma flexível e reproduzível.
+
+### Habilidades adquiridas
+
+Através deste curso prático, você aprendeu como:
+
+- Descrever e utilizar componentes principais do Nextflow suficientes para construir um fluxo de trabalho simples de múltiplas etapas
+- Descrever conceitos de próximo nível, como operadores e fábricas de canais
+- Lançar um fluxo de trabalho Nextflow localmente
+- Encontrar e interpretar saídas (resultados) e arquivos de log gerados pelo Nextflow
+- Solucionar problemas básicos
+
+Você está agora equipado com o conhecimento fundamental para começar a desenvolver seus próprios pipelines no Nextflow.
+
+## Próximos passos para desenvolver suas habilidades
+
+Aqui estão nossas 3 principais sugestões do que fazer em seguida:
+
+- Aplique Nextflow a um caso de uso de análise científica com [Nextflow for Science](../nf4_science/index.md)
+- Comece com nf-core através do [Hello nf-core](../../hello_nf-core/index.md)
+- Explore recursos mais avançados do Nextflow com as [Side Quests](../side_quests/index.md)
+
+Finalmente, recomendamos que você dê uma olhada no [**Seqera Platform**](https://seqera.io/), uma plataforma baseada em nuvem desenvolvida pelos criadores do Nextflow que torna ainda mais fácil lançar e gerenciar seus fluxos de trabalho, bem como gerenciar seus dados e executar análises interativamente em qualquer ambiente.
+
+## Pesquisa de feedback
+
+Antes de prosseguir, por favor reserve um minuto para completar a pesquisa do curso! Seu feedback nos ajuda a melhorar nossos materiais de treinamento para todos.
+
+[Responder a pesquisa :material-arrow-right:](survey.md){ .md-button .md-button--primary }

--- a/docs/pt/docs/hello_nextflow/survey.md
+++ b/docs/pt/docs/hello_nextflow/survey.md
@@ -1,0 +1,7 @@
+# Pesquisa de feedback
+
+Antes de prosseguir, por favor complete esta breve pesquisa de 5 perguntas para avaliar o treinamento, compartilhar qualquer feedback que você possa ter sobre sua experiência e nos informar o que mais poderíamos fazer para ajudá-lo em sua jornada com Nextflow.
+
+Isso deve levar menos de um minuto para completar. Obrigado por nos ajudar a melhorar nossos materiais de treinamento para todos!
+
+<div data-tf-live="01JMHYE82Z92J2Q6Q3Z7QJ1BFW"></div><script src="//embed.typeform.com/next/embed.js"></script>

--- a/docs/pt/docs/help.md
+++ b/docs/pt/docs/help.md
@@ -1,0 +1,76 @@
+---
+title: Obtendo ajuda
+description: Recursos úteis quando você tiver um problema com o treinamento do Nextflow
+hide:
+  - toc
+  - footer
+---
+
+# Obtendo ajuda
+
+Se você está tendo dificuldades para começar, ficou travado no meio do caminho ou tem perguntas adicionais, não hesite em entrar em contato!
+Nossa equipe da comunidade está aqui para ajudar, e a comunidade Nextflow em geral é muito ativa, inclusiva e sempre disposta a ajudar.
+
+Aqui estão as principais opções disponíveis, dependendo do que você está procurando.
+
+<div class="grid cards" markdown>
+
+-   :material-forum-outline:{ .lg .middle } __Fórum da comunidade__
+
+    ---
+
+    Nosso fórum da comunidade tem uma categoria dedicada ao treinamento, que é um ótimo lugar para postar perguntas ou relatar quaisquer problemas que você possa estar tendo com o treinamento. Você pode até encontrar sua pergunta já feita --e respondida!
+
+    [Acesse o fórum de treinamento:material-arrow-right:](https://community.seqera.io/c/training/39){ .md-button .md-button--primary .mt-1 }
+
+-   :material-slack:{ .lg .middle } __Canal no Slack__
+
+    ---
+
+    Se você usa Slack, seja bem-vindo para entrar em contato conosco no canal de treinamento no workspace do Nextflow no Slack. O Slack do Nextflow é um ótimo lugar para conversar com outros desenvolvedores e interagir com a comunidade Nextflow em geral.
+
+    [Acesse o Slack do Nextflow :material-arrow-right:](https://www.nextflow.io/slack-invite.html){ .md-button .md-button--primary .mt-1 }
+
+-   :material-github:{ .lg .middle } __Issues no Github__
+
+    ---
+
+    Se você identificar um erro nos materiais de treinamento, por favor, reporte abrindo uma issue no repositório do Github. Seja um erro de digitação, um problema de formatação ou um bug real que afeta o código, nos avise para que possamos corrigir! Também aceitamos PRs diretamente.
+
+    [Reporte um problema:material-arrow-right:](https://github.com/nextflow-io/training/issues){ .md-button .md-button--primary .mt-1 }
+
+-   :octicons-comment-ai-16:{ .lg .middle } __Assistente de IA da Seqera__
+
+    ---
+
+    O Seqera AI é um assistente de IA treinado com recursos do Nextflow e nf-core. Ele pode ajudá-lo a fazer debug do seu código, esclarecer conceitos do Nextflow e buscar documentação mais rapidamente. Pense nele como ter um tutor disponível 24 horas por dia, 7 dias por semana, enquanto você trabalha nos cursos.
+
+    [Pergunte ao Seqera AI:material-arrow-right:](https://github.com/nextflow-io/training/issues){ .md-button .md-button--primary .mt-1 }
+
+-   :material-book-open-variant:{ .lg .middle } __Documentação do Nextflow__
+
+    ---
+
+    A documentação oficial é o guia definitivo para todos os recursos da linguagem e opções de configuração. Use-a junto com este treinamento para se aprofundar em tópicos específicos, explorar recursos avançados e encontrar referências detalhadas de sintaxe.
+
+    [Navegue pela documentação:material-arrow-right:](https://www.nextflow.io/docs/latest){ .md-button .md-button--primary .mt-1 }
+
+-   :material-account-hard-hat:{ .lg .middle } __Suporte profissional__
+
+    ---
+
+    Nextflow é um software gratuito e de código aberto desenvolvido pela [Seqera](https://seqera.io/), uma empresa com sede na Espanha e escritórios satélites no Reino Unido e nos EUA. Oferecemos serviços de suporte profissional para Nextflow, incluindo treinamento personalizado.
+
+    [Entre em contato:material-arrow-right:](https://seqera.io/demo/){ .md-button .md-button--primary .mt-1 }
+
+</div>
+
+---
+
+<div markdown class="homepage_logos">
+
+![Seqera](assets/img/seqera_logo.png#only-light)
+
+![Seqera](assets/img/seqera_logo_dark.png#only-dark)
+
+</div>

--- a/docs/pt/docs/index.md
+++ b/docs/pt/docs/index.md
@@ -1,0 +1,168 @@
+---
+title: Treinamento em Nextflow
+description: Bem-vindo ao portal de treinamento da comunidade Nextflow!
+hide:
+  - toc
+  - footer
+---
+
+# Treinamento em Nextflow
+
+<div class="grid cards" markdown>
+
+-   :material-book-open-variant:{ .lg .middle } __Cursos de autoaprendizado__
+
+    ---
+
+    **Bem-vindo ao portal de treinamento da comunidade Nextflow!**
+
+    Os cursos de treinamento listados abaixo foram projetados para serem usados como um recurso de autoaprendizado.
+    Você pode trabalhar neles por conta própria a qualquer momento, seja no ambiente baseado na web que fornecemos via Github Codespaces ou em seu próprio ambiente.
+
+    [Explore os cursos :material-arrow-right:](#catalogo-de-cursos-de-treinamento-em-nextflow){ .md-button .md-button--primary .mt-1 }
+
+-   :material-information-outline:{ .lg .middle } __Informações adicionais__
+
+    ---
+
+    ??? warning "Compatibilidade de versões"
+
+        <!-- Any update to this content needs to be copied to the local installation page -->
+        **A partir de janeiro de 2026, todos os nossos cursos de treinamento em Nextflow requerem a versão 25.10.2 ou posterior do Nextflow, com sintaxe estrita ativada, salvo indicação em contrário.**
+
+        Para mais informações sobre requisitos de versão e sintaxe estrita, consulte o [guia de migração da documentação do Nextflow](https://nextflow.io/docs/latest/strict-syntax.html).
+
+        Versões mais antigas do material de treinamento correspondentes à sintaxe anterior estão disponíveis através do seletor de versão na barra de menu desta página web.
+
+    ??? terminal "Opções de ambiente"
+
+        Fornecemos um ambiente de treinamento baseado na web onde tudo o que você precisa para fazer o treinamento está pré-instalado, disponível através do Github Codespaces (requer uma conta gratuita no GitHub).
+
+        [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
+
+        Se isso não atender às suas necessidades, consulte as outras [Opções de ambiente](./envsetup/index.md).
+
+    ??? learning "Eventos de treinamento"
+
+        Se você prefere fazer o treinamento em Nextflow como parte de um evento estruturado, há muitas oportunidades para fazê-lo. Recomendamos verificar as seguintes opções:
+
+        - **[Semanas de Treinamento]()** organizadas trimestralmente pela equipe da Comunidade
+        - **[Eventos Seqera](https://seqera.io/events/)** incluem eventos de treinamento presenciais organizados pela Seqera (procure por 'Seqera Sessions' e 'Nextflow Summit')
+        - **[Embaixadores Nextflow]()** organizam eventos para sua comunidade local
+        - **[eventos nf-core](https://nf-co.re/events)** incluem hackathons da comunidade
+
+    ??? people "Informações para instrutores"
+
+        Se você é um instrutor realizando seus próprios treinamentos, pode usar nossos materiais diretamente do portal de treinamento, desde que atribua os créditos apropriados. Veja 'Créditos e contribuições' abaixo para detalhes.
+
+        Além disso, adoraríamos ouvir de você sobre como poderíamos apoiar melhor seus esforços de treinamento! Entre em contato conosco em [community@seqera.io](mailto:community@seqera.io) ou no fórum da comunidade (veja a página de [Ajuda](help.md)).
+
+    ??? licensing "Licença de código aberto e política de contribuição"
+
+        [![Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)](assets/img/cc_by-nc-sa.svg){ align=right }](https://creativecommons.org/licenses/by-nc-sa/4.0/)
+
+        Este material de treinamento é desenvolvido e mantido pela [Seqera](https://seqera.io) e lançado sob uma licença de código aberto ([CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/)) para o benefício da comunidade. Se você deseja usar este material de uma forma que esteja fora do escopo da licença (observe as limitações sobre uso comercial e redistribuição), entre em contato conosco em [community@seqera.io](mailto:community@seqera.io) para discutir sua solicitação.
+
+        Damos as boas-vindas a melhorias, correções e relatórios de bugs da comunidade. Cada página tem um ícone :material-file-edit-outline: no canto superior direito da página que leva ao repositório de código, onde você pode relatar problemas ou propor mudanças no material de treinamento através de um pull request. Veja o `README.md` no repositório para mais detalhes.
+
+</div>
+
+## Catálogo de cursos de treinamento em Nextflow
+
+<div class="grid cards" markdown>
+
+-   :material-walk:{ .lg .middle } __Trilha introdutória__
+
+    ---
+
+    ### :material-compass:{.nextflow-primary} Nextflow para Iniciantes {.mt-1}
+
+    Cursos independentes de domínio destinados àqueles que são completamente novos no Nextflow. Cada curso consiste em uma série de módulos de treinamento projetados para ajudar os aprendizes a desenvolver suas habilidades progressivamente.
+
+    ??? courses "**Hello Nextflow:** Aprenda a desenvolver seus próprios pipelines"
+
+        Este curso cobre os componentes principais da linguagem Nextflow com detalhes suficientes para permitir o desenvolvimento de pipelines simples, mas totalmente funcionais, além de elementos-chave de práticas de design, desenvolvimento e configuração de pipelines.
+
+        [Comece o treinamento Hello Nextflow :material-arrow-right:](hello_nextflow/index.md){ .md-button .md-button--secondary }
+
+    ??? courses "**Nextflow Run:** Aprenda a executar pipelines existentes"
+
+        Uma introdução concisa para executar e configurar pipelines Nextflow, baseada no curso para desenvolvedores Hello Nextflow, mas com menos foco em código. Cobre execução, saídas, estrutura básica de código e configuração para diferentes ambientes computacionais.
+
+        [Comece o treinamento Nextflow Run :material-arrow-right:](nextflow_run/index.md){ .md-button .md-button--secondary }
+
+    ---
+
+    ### :material-microscope:{.nextflow-primary} Nextflow para Ciência {.mt-1}
+
+    Aprenda a aplicar os conceitos e componentes apresentados em 'Hello Nextflow' a casos de uso científicos específicos.
+
+    ??? courses "**Nextflow para Genômica** (chamada de variantes)"
+
+        Para pesquisadores que desejam aprender como desenvolver seus próprios pipelines de genômica. O curso usa um caso de uso de chamada de variantes para demonstrar como desenvolver um pipeline de genômica simples, mas funcional.
+
+        [Comece o treinamento Nextflow para Genômica :material-arrow-right:](nf4_science/genomics/){ .md-button .md-button--secondary }
+
+    ??? courses "**Nextflow para RNAseq** (RNAseq bulk)"
+
+        Para pesquisadores que desejam aprender como desenvolver seus próprios pipelines de RNAseq. O curso usa um caso de uso de processamento de RNAseq bulk para demonstrar como desenvolver um pipeline de RNAseq simples, mas funcional.
+
+        [Comece o treinamento Nextflow para RNAseq :material-arrow-right:](nf4_science/rnaseq/){ .md-button .md-button--secondary }
+
+    ??? courses "**Nextflow para Imagens** (ômica espacial)"
+
+        Para pesquisadores em imagens e ômica espacial que desejam aprender como executar e personalizar pipelines de análise. O curso usa o pipeline nf-core/molkart para fornecer um pipeline biologicamente relevante que demonstra como executar, configurar e gerenciar entradas para fluxos de trabalho de pipelines Nextflow.
+
+        [Comece o treinamento Nextflow para Imagens :material-arrow-right:](nf4_science/imaging/){ .md-button .md-button--secondary }
+
+-   :material-run:{ .lg .middle } __Trilha avançada__
+
+    ---
+
+    ### :material-bridge:{.nextflow-primary} De Nextflow para nf-core {.mt-1}
+
+    Aprenda a utilizar código e melhores práticas do projeto comunitário [nf-core](https://nf-co.re/).
+
+    Esses cursos ajudam você a ir dos fundamentos do Nextflow às melhores práticas do nf-core.
+    Entenda como e por que a comunidade nf-core constrói pipelines, e como você pode contribuir e reutilizar essas técnicas.
+
+    ??? courses "**Hello nf-core:** Comece com nf-core"
+
+        Para desenvolvedores que desejam aprender a executar e desenvolver pipelines compatíveis com [nf-core](https://nf-co.re/). O curso cobre a estrutura de pipelines nf-core com detalhes suficientes para permitir o desenvolvimento de pipelines simples, mas totalmente funcionais, que seguem o template nf-core e as melhores práticas de desenvolvimento, além de usar módulos nf-core existentes.
+
+        [Comece o treinamento Hello nf-core :material-arrow-right:](hello_nf-core/index.md){ .md-button .md-button--secondary }
+
+    ---
+
+    ### :material-rocket-launch:{.nextflow-primary} Treinamento Avançado em Nextflow {.mt-1}
+
+    Aprenda conceitos e mecanismos avançados para desenvolver e implantar pipelines Nextflow para lidar com casos de uso do mundo real.
+
+    ??? courses "**Side Quests:** Mergulhos profundos em tópicos independentes"
+
+        Mini-cursos independentes destinados a desenvolvedores Nextflow que desejam ampliar seu alcance e/ou aprofundar suas habilidades em tópicos específicos. Eles são apresentados linearmente, mas podem ser realizados em qualquer ordem (veja as dependências na visão geral de cada mini-curso).
+
+        [Navegue pelos Side Quests :material-arrow-right:](side_quests/){ .md-button .md-button--secondary }
+
+    ??? courses "**Coleções de Treinamento:** Caminhos de aprendizado recomendados através dos Side Quests"
+
+        As Coleções de Treinamento combinam múltiplos Side Quests para fornecer uma experiência de aprendizado abrangente em torno de um tema ou caso de uso específico.
+
+        [Navegue pelas Coleções de Treinamento :material-arrow-right:](training_collections/){ .md-button .md-button--secondary }
+
+</div>
+
+!!! info "Procurando materiais de treinamento arquivados?"
+
+    Materiais de treinamento mais antigos (Fundamentals Training, Advanced Training e outros cursos experimentais) foram removidos do portal de treinamento por serem incompatíveis com a sintaxe estrita do Nextflow 3.0.
+    Se você precisar de acesso a esses materiais, eles estão disponíveis no [histórico do git](https://github.com/nextflow-io/training) antes de janeiro de 2026.
+
+---
+
+<div markdown class="homepage_logos">
+
+![Seqera](assets/img/seqera_logo.png#only-light)
+
+![Seqera](assets/img/seqera_logo_dark.png#only-dark)
+
+</div>

--- a/docs/pt/llm-prompt.md
+++ b/docs/pt/llm-prompt.md
@@ -1,102 +1,47 @@
 # Translation Rules for Portuguese
 
-The target language for this translation is **Portuguese** (`pt`).
+The target language for this translation is **Brazilian Portuguese** (`pt`).
 
 ## Grammar Preferences
 
-- Use formal tone (você instead of tu)
+- Use informal tone (você instead of o senhor/a senhora)
 - Use Brazilian Portuguese spelling conventions
 - Prefer active voice when possible
+
+## Translation Context Rules
+
+**Important distinction**: Some technical terms have different translation rules depending on context:
+
+1. **In code blocks**: Keep ALL Nextflow syntax in English (the code must run)
+2. **In prose/explanatory text**: Follow the glossary below for translations
+
+For example:
+
+- In prose: "O canal de entrada recebe os arquivos..." (translate "channel" to "canal")
+- In code: `channel.fromPath('*.fastq')` (keep "channel" in English)
 
 ## Glossary
 
 ### Terms to Keep in English (DO NOT TRANSLATE)
 
-#### Nextflow Core Concepts
+These terms should remain in English in both code and prose:
 
 - Nextflow
 - DSL2
-- channel / channels
-- process / processes
-- workflow / workflows
 - pipeline / pipelines
 - script
-- shell
-- exec
-- emit
-- take
-- main
-- params
-
-#### Channel Types
-
-- queue channel
-- value channel
-
-#### Data Types
-
-- val
-- path
-- env
-- stdin
-- stdout
-- tuple
-- file (when referring to Nextflow type)
-
-#### Operators
-
-- map
-- filter
-- collect
-- flatten
-- groupTuple
-- join
-- combine
-- mix
-- merge
-- view
-- first
-- last
-- take (operator)
-- branch
-- multiMap
-- splitCsv
-- splitFastq
-- splitFasta
-- splitText
-
-#### Directives
-
-- publishDir
-- container
-- conda
-- memory
-- cpus
-- time
-- errorStrategy
-- maxRetries
-- maxErrors
-- queue
-- scratch
-- storeDir
-- tag
-- label
-- cache
-- executor
-
-#### Execution Concepts
-
-- resume
 - cache / caching
-- work directory
-- staging
-- unstaging
-- executor / executors
+- bucket
+- dataflow
 - job
-
-#### Tools & Platforms
-
-- Nextflow
+- pipe
+- quick start
+- resume
+- shell
+- staging
+- framework
+- log
+- debug (noun)
 - nf-core
 - Docker
 - Singularity
@@ -111,64 +56,80 @@ The target language for this translation is **Portuguese** (`pt`).
 - Seqera Platform
 - Wave
 - Fusion
-
-#### File Formats & Extensions
-
-- `.nf`
-- `nextflow.config`
-- `main.nf`
-- `modules.nf`
-- `workflows.nf`
-- FASTQ
-- FASTA
-- BAM
-- SAM
-- VCF
-- BED
-- GFF
-- GTF
-- CSV
-- TSV
-- JSON
-- YAML
-
-#### Programming Concepts
-
-- closure
 - Groovy
+- closure
 - shebang
 - glob / globbing
 - regex
-- string
-- boolean
-- integer
-- list
-- map (data structure)
-- set
 
-### Terms to Translate
+### Nextflow Keywords (keep in English in code only)
 
-| English        | Portuguese          |
-| -------------- | ------------------- |
-| alignment      | alinhamento         |
-| command        | comando             |
-| container      | contêiner           |
-| directive      | diretiva            |
-| directory      | diretório           |
-| environment    | ambiente            |
-| file (general) | arquivo             |
-| index          | índice              |
-| input          | entrada             |
-| module         | módulo              |
-| operator       | operador            |
-| output         | saída               |
-| parameter      | parâmetro           |
-| reference      | referência          |
-| run            | executar / execução |
-| sample         | amostra             |
-| task           | tarefa              |
-| training       | treinamento         |
-| tuple          | tupla               |
+These terms appear as Nextflow syntax and must remain in English in code blocks,
+but should be translated when used in explanatory prose:
+
+- channel / channels → canal / canais (in prose)
+- process / processes → processo / processos (in prose)
+- workflow / workflows → fluxo de trabalho / fluxos de trabalho (in prose)
+- emit → emitir (in prose)
+- take → receber (in prose)
+- main → principal (in prose)
+- params → parâmetros (in prose)
+- input → entrada (in prose)
+- output → saída (in prose)
+
+### Operators (keep in English)
+
+Operator names should always remain in English:
+
+- map, filter, collect, flatten, groupTuple, join, combine, mix, merge
+- view, first, last, take, branch, multiMap
+- splitCsv, splitFastq, splitFasta, splitText
+
+### Directives (keep in English)
+
+Directive names should always remain in English:
+
+- publishDir, container, conda, memory, cpus, time
+- errorStrategy, maxRetries, maxErrors, queue, scratch
+- storeDir, tag, label, cache, executor
+
+### Data Types (keep in English in code)
+
+- val, path, env, stdin, stdout, tuple, file
+
+### File Formats (keep in English)
+
+- FASTQ, FASTA, BAM, SAM, VCF, BED, GFF, GTF, CSV, TSV, JSON, YAML
+- `.nf`, `nextflow.config`, `main.nf`, `modules.nf`, `workflows.nf`
+
+### Terms to Translate (prose only, keep English in code)
+
+| English       | Portuguese              |
+| ------------- | ----------------------- |
+| channel       | canal / canais          |
+| process       | processo / processos    |
+| workflow      | fluxo de trabalho       |
+| directive     | diretiva / diretivas    |
+| container     | contêiner / contêineres |
+| input         | entrada                 |
+| output        | saída                   |
+| task          | tarefa                  |
+| tuple         | tupla                   |
+| queue channel | canal de fila           |
+| value channel | canal de valor          |
+| operator      | operador                |
+| parameter     | parâmetro               |
+| environment   | ambiente                |
+| directory     | diretório               |
+| file          | arquivo                 |
+| sample        | amostra                 |
+| alignment     | alinhamento             |
+| reference     | referência              |
+| training      | treinamento             |
+| module        | módulo                  |
+| command       | comando                 |
+| index         | índice                  |
+| run           | executar / execução     |
 
 ### Admonition Titles
 


### PR DESCRIPTION
## Summary

This PR adds the Portuguese (Brazilian) translation for the Hello Nextflow training course.

### Translated Content
- **Main pages**: `index.md`, `help.md`
- **Environment setup** (4 files): `envsetup/index.md`, `01_setup.md`, `02_local.md`, `03_devcontainer.md`
- **Hello Nextflow course** (10 files): Complete course including all 7 lessons (00-06), index, next_steps, and survey

### Translation Approach
- Used AI translation via `_scripts/translate.py` with language-specific glossary
- Informal tone (você) per Brazilian Portuguese conventions
- Technical terms translated in prose (e.g., channel → canal, process → processo, workflow → fluxo de trabalho)
- Code blocks preserved in English (executable code)
- Based on established Portuguese Nextflow community glossary

### Files Changed
- 17 new/modified files in `docs/pt/docs/`
- Updated `docs/pt/llm-prompt.md` with correct glossary and tone settings

### Excluded
- `transcripts/` folder (auto-generated, not translated)

### Verification
- Build verified with `uv run python docs.py build-lang pt`

---
Depends on #791 (infrastructure PR)