### PR TITLE
Add German translation

### DIFF
--- a/docs/de/docs/envsetup/01_setup.md
+++ b/docs/de/docs/envsetup/01_setup.md
@@ -1,0 +1,111 @@
+# GitHub Codespaces
+
+GitHub Codespaces ist eine webbasierte Plattform, die es uns ermöglicht, eine vorkonfigurierte Umgebung für das Training bereitzustellen, unterstützt durch virtuelle Maschinen in der Cloud.
+Die Plattform wird von GitHub (das zu Microsoft gehört) betrieben und ist kostenlos (mit Nutzungskontingenten) für jeden mit einem GitHub-Konto zugänglich.
+
+!!! warning "Warnung"
+
+    Konten, die mit Organisationen verbunden sind, können bestimmten zusätzlichen Einschränkungen unterliegen.
+    In diesem Fall musst du möglicherweise ein unabhängiges persönliches Konto verwenden oder stattdessen eine lokale Installation nutzen.
+
+## Erstellen eines GitHub-Kontos
+
+Du kannst ein kostenloses GitHub-Konto auf der [GitHub-Startseite](https://github.com/) erstellen.
+
+## Starten deines GitHub Codespace
+
+Sobald du bei GitHub angemeldet bist, öffne diesen Link in deinem Browser, um die Nextflow-Trainingsumgebung zu öffnen: <https://codespaces.new/nextflow-io/training?quickstart=1&ref=master>
+
+Alternativ kannst du auf den unten gezeigten Button klicken, der in jedem Trainingskurs wiederholt wird (typischerweise auf der Orientierungsseite).
+
+[![In GitHub Codespaces öffnen](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
+
+Dir sollte eine Seite angezeigt werden, auf der du einen neuen GitHub Codespace erstellen kannst:
+
+![Einen GitHub Codespace erstellen](img/codespaces_create.png)
+
+### Konfiguration
+
+Für die allgemeine Nutzung solltest du nichts konfigurieren müssen.
+Sofern nicht anders im Kurs angegeben, den du beginnst, kannst du einfach auf den Hauptbutton klicken, um fortzufahren.
+
+Es ist jedoch möglich, die Umgebung anzupassen, indem du auf den Button "Change options" klickst.
+
+??? info "Konfigurationsoptionen"
+
+    Wenn du auf den Button "Change options" klickst, erhältst du die Möglichkeit, Folgendes anzupassen:
+
+    #### Branch
+
+    Dies ermöglicht dir, eine andere Version der Trainingsmaterialien auszuwählen.
+    Der `master`-Branch enthält im Allgemeinen Fehlerbehebungen und Materialien, die kürzlich entwickelt und genehmigt wurden, aber noch nicht auf der Website veröffentlicht wurden.
+    Andere Branches enthalten laufende Arbeiten, die möglicherweise nicht vollständig funktionsfähig sind.
+
+    #### Maschinentyp
+
+    Dies ermöglicht dir, die virtuelle Maschine anzupassen, die du zum Durcharbeiten des Trainings verwendest.
+
+    Die Verwendung einer Maschine mit mehr Kernen ermöglicht es dir, Nextflows Fähigkeit zur Parallelisierung der Workflow-Ausführung besser zu nutzen.
+    Dies verbraucht jedoch dein kostenloses Kontingent schneller, daher empfehlen wir nicht, diese Einstellung zu ändern, es sei denn, es wird in den Anweisungen des Kurses empfohlen, den du planst zu absolvieren.
+
+    Siehe 'GitHub Codespaces-Kontingente' unten für weitere Details zu Kontingenten.
+
+### Startzeit
+
+Das erstmalige Öffnen einer neuen GitHub Codespaces-Umgebung kann mehrere Minuten dauern, da das System deine virtuelle Maschine einrichten muss. Mache dir also keine Sorgen, wenn es eine Wartezeit gibt.
+Es sollte jedoch nicht länger als fünf Minuten dauern.
+
+## Navigation in der Trainingsoberfläche
+
+Sobald dein GitHub Codespace geladen ist, solltest du etwas Ähnliches wie das Folgende sehen (das je nach deinen Kontoeinstellungen im hellen Modus geöffnet werden kann):
+
+![GitHub Codespaces Willkommen](img/codespaces_welcome.png)
+
+Dies ist die Oberfläche der VSCode IDE, einer beliebten Anwendung zur Codeentwicklung, die wir für die Nextflow-Entwicklung empfehlen.
+
+- **Der Haupteditor** ist der Bereich, in dem Nextflow-Code und andere Textdateien geöffnet werden. Hier wirst du Code bearbeiten. Wenn du den Codespace öffnest, zeigt dieser dir eine Vorschau der `README.md`-Datei.
+- **Das Terminal** unter dem Haupteditor ermöglicht es dir, Befehle auszuführen. Hier wirst du alle Befehlszeilen ausführen, die in den Kursanweisungen gegeben werden.
+- **Die Seitenleiste** ermöglicht es dir, deine Umgebung anzupassen und grundlegende Aufgaben durchzuführen (Kopieren, Einfügen, Dateien öffnen, Suchen, Git usw.). Standardmäßig ist sie im Datei-Explorer geöffnet, der es dir ermöglicht, den Inhalt des Repositorys zu durchsuchen. Das Klicken auf eine Datei im Explorer öffnet sie im Haupteditorfenster.
+
+Du kannst die relativen Proportionen der Fensterbereiche nach Belieben anpassen.
+
+<!-- TODO (future) Link to development best practices side quest? -->
+
+## Weitere Hinweise zur Verwendung von GitHub Codespaces
+
+### Wiederaufnahme einer Sitzung
+
+Sobald du eine Umgebung erstellt hast, kannst du sie einfach fortsetzen oder neu starten und dort weitermachen, wo du aufgehört hast.
+Deine Umgebung wird nach 30 Minuten Inaktivität in den Timeout gehen und deine Änderungen bis zu 2 Wochen speichern.
+
+Du kannst eine Umgebung unter <https://github.com/codespaces/> wieder öffnen.
+Frühere Umgebungen werden aufgelistet.
+Klicke auf eine Sitzung, um sie fortzusetzen.
+
+![GitHub Codespace-Sitzungen auflisten](img/codespaces_list.png)
+
+Wenn du die URL für deine frühere GitHub Codespaces-Umgebung gespeichert hast, kannst du sie einfach in deinem Browser öffnen.
+Alternativ klicke auf denselben Button, den du ursprünglich zum Erstellen verwendet hast:
+
+[![In GitHub Codespaces öffnen](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
+
+Du solltest die frühere Sitzung sehen. Die Standardoption ist, sie fortzusetzen:
+
+![Einen GitHub Codespace fortsetzen](img/codespaces_resume.png)
+
+### Dateien auf deinem lokalen Rechner speichern
+
+Um eine Datei aus dem Explorer-Panel zu speichern, klicke mit der rechten Maustaste auf die Datei und wähle `Download`.
+
+### Verwaltung der GitHub Codespaces-Kontingente
+
+GitHub Codespaces gibt dir bis zu 15 GB-Monat Speicherplatz pro Monat und 120 Core-Stunden pro Monat.
+Dies entspricht etwa 60 Stunden der Standard-Umgebungslaufzeit mit dem Standard-Workspace (2 Kerne, 8 GB RAM und 32 GB Speicher).
+
+Du kannst sie mit mehr Ressourcen erstellen (siehe Erklärung oben), aber dies verbraucht deine kostenlose Nutzung schneller und du hast weniger Stunden Zugang zu diesem Space.
+Wenn du beispielsweise eine 4-Kern-Maschine anstelle der 2-Kern-Standardmaschine auswählst, ist dein Kontingent in der Hälfte der Zeit aufgebraucht.
+
+Optional kannst du Zugang zu mehr Ressourcen erwerben.
+
+Weitere Informationen findest du in der GitHub-Dokumentation:
+[Über die Abrechnung für GitHub Codespaces](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-codespaces/about-billing-for-github-codespaces)

--- a/docs/de/docs/envsetup/02_local.md
+++ b/docs/de/docs/envsetup/02_local.md
@@ -1,0 +1,60 @@
+# Manuelle Installation
+
+Es ist möglich, alles, was du zum Ausführen des Trainings benötigst, manuell in deiner eigenen lokalen Umgebung zu installieren.
+
+Hier haben wir dokumentiert, wie das auf Standard-POSIX-kompatiblen Systemen geht (unter der Annahme eines persönlichen Rechners wie eines Laptops).
+Beachte, dass einige Details je nach deinem spezifischen System unterschiedlich sein können.
+
+!!! tip "Tipp"
+
+    Bevor du fortfährst, hast du den [Devcontainers-Ansatz](03_devcontainer.md) in Betracht gezogen?
+    Er stellt alle notwendigen Tools und Abhängigkeiten bereit, ohne dass eine manuelle Installation erforderlich ist.
+
+## Allgemeine Softwareanforderungen
+
+Nextflow kann auf jedem POSIX-kompatiblen System (Linux, macOS, Windows Subsystem for Linux usw.) mit installiertem Java verwendet werden.
+Unsere Trainingskurse haben einige zusätzliche Anforderungen.
+
+Insgesamt musst du die folgende Software installiert haben:
+
+- Bash oder eine gleichwertige Shell
+- [Java 11 (oder höher, bis 21)](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
+- [Git](https://git-scm.com/)
+- [Docker](https://docs.docker.com/get-docker/)
+- [Conda](https://conda.io/) 4.5 (oder höher)
+- [VSCode](https://code.visualstudio.com) mit der [Nextflow-Erweiterung](https://www.nextflow.io/docs/latest/developer-env.html#devenv-nextflow)
+
+Die VSCode-Anwendung ist technisch optional, aber wir empfehlen dringend, sie sowohl für das Durcharbeiten der Kurse als auch für deine Nextflow-Entwicklungsarbeit im Allgemeinen zu verwenden.
+
+Das Nextflow-Dokumentationshandbuch enthält Anweisungen zur Installation dieser Abhängigkeiten unter [Umgebungseinrichtung](https://www.nextflow.io/docs/latest/developer-env.html).
+
+## Nextflow und nf-core tools
+
+Du musst Nextflow selbst sowie die nf-core tools installieren, wie in den unten verlinkten Artikeln beschrieben:
+
+- [Nextflow-Installation](https://www.nextflow.io/docs/latest/install.html)
+- [nf-core tools](https://nf-co.re/docs/nf-core-tools/installation)
+
+Wir empfehlen die Self-Install-Option für Nextflow und die PyPI-Option für nf-core tools.
+
+!!! warning "Versionskompatibilität"
+
+    <!-- Any update to this content needs to be copied to the home page -->
+    **Ab Januar 2026 erfordern alle unsere Nextflow-Trainingskurse Nextflow Version 25.10.2 oder höher mit aktivierter strikter v2-Syntax, sofern nicht anders angegeben.**
+
+    Weitere Informationen zu Versionsanforderungen und strikter v2-Syntax findest du im [Nextflow-Versionen](../info/nxf_versions.md)-Leitfaden.
+
+    Ältere Versionen des Trainingsmaterials, die früherer Syntax entsprechen, sind über den Versionsauswähler in der Menüleiste dieser Webseite verfügbar.
+
+## Trainingsmaterialien
+
+Der einfachste Weg, die Trainingsmaterialien herunterzuladen, ist das Klonen des gesamten Repositorys mit diesem Befehl:
+
+```bash
+git clone https://github.com/nextflow-io/training.git
+```
+
+Jeder Kurs hat sein eigenes Verzeichnis.
+Um einen Kurs durchzuarbeiten, öffne ein Terminalfenster (idealerweise innerhalb der VSCode-Anwendung) und wechsle mit `cd` in das entsprechende Verzeichnis.
+
+Du kannst dann den Kursanweisungen auf der Website folgen.

--- a/docs/de/docs/envsetup/03_devcontainer.md
+++ b/docs/de/docs/envsetup/03_devcontainer.md
@@ -1,0 +1,106 @@
+# Lokale Devcontainers
+
+Wenn du eine lokale Docker-Installation hast oder bereit bist, eine zu installieren, ist der einfachste Weg, lokal mit diesen Materialien zu arbeiten, die Devcontainer-Funktion von Visual Studio Code zu verwenden. Dieser Ansatz stellt alle notwendigen Tools und Abhängigkeiten bereit, ohne dass eine manuelle Installation erforderlich ist.
+
+## Anforderungen
+
+Um das lokale Devcontainer-Setup zu verwenden, benötigst du:
+
+- [Visual Studio Code](https://code.visualstudio.com/)
+- Eine lokale Docker-Installation, zum Beispiel:
+  - [Docker Desktop](https://docs.docker.com/get-docker/) (für Windows/macOS)
+  - [Docker Engine](https://docs.docker.com/engine/install/) (für Linux)
+  - [Colima](https://github.com/abiosoft/colima) (Alternative für macOS)
+- [Docker Buildx](https://docs.docker.com/build/concepts/overview/#install-buildx) (in Docker Desktop enthalten, kann aber bei anderen Docker-Setups eine separate Installation erfordern)
+- [Dev Containers-Erweiterung](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) für VS Code
+
+Deine Docker-Installation muss laufen, bevor du versuchst, den Devcontainer zu öffnen.
+
+Um zu überprüfen, ob Docker buildx verfügbar ist, führe aus:
+
+```bash
+docker buildx version
+```
+
+Wenn dieser Befehl fehlschlägt, musst du die buildx-Erweiterung installieren, bevor du fortfährst.
+
+## Einrichtungsanleitung
+
+Folge diesen Schritten, um deine lokale Umgebung mit VS Code Devcontainers einzurichten:
+
+### Installiere die "Dev Containers"-Erweiterung in VS Code
+
+- Öffne VS Code
+- Gehe zu Extensions (Strg+Umschalt+X oder Cmd+Umschalt+X auf macOS)
+- Suche nach "Dev Containers"
+- Klicke auf "Install"
+
+![Installation der Dev Containers-Erweiterung in VS Code](img/install_extension.png)
+
+### Klone das Repository:
+
+```bash
+git clone https://github.com/nextflow-io/training.git
+cd training
+```
+
+### Öffne das Repository in VS Code:
+
+- Starte VS Code
+- Wähle **Datei -> Ordner öffnen** aus dem Menü
+- Navigiere zum gerade geklonten Training-Repository-Ordner und wähle ihn aus
+- Klicke auf **Öffnen**
+
+### In Container erneut öffnen
+
+Wenn VS Code dich auffordert, "In Container erneut öffnen", klicke darauf. Alternativ:
+
+- Drücke F1 (oder Strg+Umschalt+P / Cmd+Umschalt+P auf macOS)
+- Tippe "Dev Containers: Reopen in Container"
+- **Wichtig**: Wenn du aufgefordert wirst, eine Konfiguration auszuwählen, wähle die **local-dev** Devcontainer-Konfiguration
+
+![Aufforderung zum erneuten Öffnen im Container](img/reopen_prompt.png)
+
+![Auswahl der lokalen Konfiguration](img/select_local_config.png)
+
+Warte, bis der Container erstellt ist. Dies kann beim ersten Mal einige Minuten dauern, da alle notwendigen Komponenten heruntergeladen und eingerichtet werden.
+
+Sobald der Container erstellt und ausgeführt wird, hast du eine vollständig konfigurierte Umgebung mit allen installierten notwendigen Tools, einschließlich:
+
+- Java
+- Nextflow
+- Docker
+- Git
+- Und alle anderen für das Training erforderlichen Abhängigkeiten
+
+![VS Code mit laufendem Devcontainer](img/running_container.png)
+
+## Vorteile der Verwendung von Devcontainers
+
+Die Verwendung des Devcontainer-Ansatzes bietet mehrere Vorteile:
+
+- **Konsistenz**: Stellt eine konsistente Entwicklungsumgebung über verschiedene Maschinen hinweg sicher
+- **Einfachheit**: Alle Abhängigkeiten sind vorinstalliert und konfiguriert
+- **Isolation**: Die Entwicklungsumgebung ist von deinem lokalen System isoliert
+- **Reproduzierbarkeit**: Jeder, der den Devcontainer verwendet, erhält dasselbe Setup
+- **Keine manuelle Installation**: Keine Notwendigkeit, Java, Nextflow und andere Tools manuell zu installieren
+
+## Überprüfung deiner Umgebung
+
+Sobald dein Devcontainer läuft, kannst du überprüfen, ob alles korrekt eingerichtet ist, indem du ausführst:
+
+```bash
+nextflow info
+```
+
+Dies sollte die Nextflow-Version und Laufzeitinformationen anzeigen und bestätigen, dass deine Umgebung korrekt konfiguriert ist.
+
+## Fehlerbehebung
+
+Wenn du Probleme mit dem Devcontainer-Setup hast:
+
+1. Stelle sicher, dass deine Docker-Installation (Docker Desktop, Colima, Docker Engine usw.) läuft, bevor du den Devcontainer öffnest
+2. Überprüfe, dass du die **local-dev**-Konfiguration ausgewählt hast, wenn du dazu aufgefordert wurdest
+3. Überprüfe, ob Docker buildx installiert ist und funktioniert, indem du `docker buildx version` ausführst
+4. Wenn der Container nicht erstellt werden kann, versuche ihn neu zu erstellen, indem du den Befehl "Dev Containers: Rebuild Container" ausführst
+5. Bei anhaltenden Problemen siehe den [VS Code Dev Containers-Fehlerbehebungsleitfaden](https://code.visualstudio.com/docs/devcontainers/troubleshooting)

--- a/docs/de/docs/envsetup/index.md
+++ b/docs/de/docs/envsetup/index.md
@@ -1,0 +1,51 @@
+---
+title: Umgebungsoptionen
+description: Optionen zum Einrichten deiner Umgebung für die Nextflow-Trainings
+hide:
+  - toc
+  - footer
+---
+
+# Umgebungsoptionen
+
+Wir möchten eine konsistente und gründlich getestete Umgebung bereitstellen, die es Lernenden ermöglicht, sich auf das Erlernen von Nextflow zu konzentrieren, ohne Zeit und Mühe für die Softwareverwaltung aufwenden zu müssen.
+Zu diesem Zweck haben wir eine containerisierte Umgebung entwickelt, die alle notwendige Software, Codedateien und Beispieldaten enthält, um alle unsere Kurse durchzuarbeiten.
+
+Diese containerisierte Umgebung kann sofort auf GitHub Codespaces oder lokal in VS Code mit der Devcontainers-Erweiterung ausgeführt werden.
+
+<div class="grid cards" markdown>
+
+- :material-cloud-outline:{ .lg .middle } **GitHub Codespaces**
+
+  ***
+
+  GitHub Codespaces ist ein webbasierter Dienst, der es uns ermöglicht, eine vorkonfigurierte Umgebung für das Training bereitzustellen, mit allen Tools und Daten inklusive, unterstützt durch virtuelle Maschinen in der Cloud. Er ist kostenlos für jeden mit einem GitHub-Konto zugänglich.
+
+  [GitHub Codespaces verwenden:material-arrow-right:](01_setup.md){ .md-button .md-button--primary .mt-1 }
+
+- :material-laptop:{ .lg .middle } **Lokale Devcontainers**
+
+  ***
+
+  VS Code mit Devcontainers bietet eine lokal ausgeführte, containerisierte Entwicklungsumgebung mit allen vorinstallierten Trainingstools. Sie bietet dieselbe vorkonfigurierte Umgebung wie Codespaces, läuft aber vollständig auf deiner lokalen Hardware.
+
+  [Devcontainers lokal verwenden :material-arrow-right:](03_devcontainer.md){ .md-button .md-button--primary .mt-1 }
+
+</div>
+
+## Anleitung zur manuellen Installation
+
+Wenn keine der oben genannten Optionen deinen Anforderungen entspricht, kannst du diese Umgebung auf deinem eigenen lokalen System replizieren, indem du die Software-Abhängigkeiten manuell installierst und das Training-Repository klonst.
+
+[Manuelle Installation :material-arrow-right:](02_local.md){ .md-button .md-button--primary .mt-1 }
+
+---
+
+!!! info "Einstellung von Gitpod"
+
+    Das Nextflow-Training verwendete bis Februar 2025 [Gitpod](https://gitpod.io).
+    Allerdings entschieden sich die Macher von Gitpod, die kostenlose Funktionalität zugunsten des [Gitpod Flex](https://www.gitpod.io/blog/introducing-gitpod-flex)-Systems einzustellen.
+    Aus diesem Grund sind wir zu GitHub Codespaces gewechselt, das ebenfalls eine Ein-Klick-Entwicklungsumgebung ohne vorherige Einrichtung bietet.
+
+    Je nachdem, wann du dich bei Gitpod angemeldet hast und wann genau der Dienst eingestellt wird, kannst du das Training möglicherweise noch in deren alter Cloud-IDE starten, obwohl wir keinen zuverlässigen Zugang für die Zukunft garantieren können:
+    [In Gitpod öffnen](https://gitpod.io/#https://github.com/nextflow-io/training).

--- a/docs/de/docs/hello_nextflow/00_orientation.md
+++ b/docs/de/docs/hello_nextflow/00_orientation.md
@@ -1,0 +1,135 @@
+# Erste Schritte
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/G3CV-FcV-rc?si=nyLvwhrSB2m1NPc5&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Sieh dir [die gesamte Playlist](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) auf dem Nextflow YouTube-Kanal an.
+
+:green_book: Das Videotranskript ist [hier](./transcripts/00_orientation.md) verfügbar.
+///
+
+!!! tip "Tipp"
+
+    Die YouTube-Videos haben einige Superkräfte!
+
+    - :fontawesome-solid-closed-captioning: Hochwertige (manuell kuratierte) Untertitel. Schalte sie mit dem :material-subtitles: Symbol ein
+    - :material-bookmark: Videokapitel in der Zeitleiste, die den Seitenüberschriften entsprechen.
+
+## Trainingsumgebung starten
+
+Um die vorgefertigte Umgebung zu nutzen, die wir auf GitHub Codespaces bereitstellen, klicke auf den Button "Open in GitHub Codespaces" unten. Für weitere Optionen siehe [Umgebungsoptionen](../envsetup/index.md).
+
+Wir empfehlen, die Trainingsumgebung in einem neuen Browser-Tab oder -Fenster zu öffnen (verwende Rechtsklick, Strg-Klick oder Cmd-Klick je nach Gerät), damit du weiterlesen kannst, während die Umgebung lädt.
+Du musst diese Anweisungen parallel geöffnet halten, um den Kurs durchzuarbeiten.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
+
+### Grundlagen der Umgebung
+
+Diese Trainingsumgebung enthält alle Software, den Code und die Daten, die zum Durcharbeiten des Trainingskurses erforderlich sind, sodass du selbst nichts installieren musst.
+
+Der Codespace ist mit einer VSCode-Oberfläche eingerichtet, die einen Dateisystem-Explorer, einen Code-Editor und eine Terminal-Shell umfasst.
+Alle Anweisungen während des Kurses (z.B. 'öffne die Datei', 'bearbeite den Code' oder 'führe diesen Befehl aus') beziehen sich auf diese drei Teile der VScode-Oberfläche, sofern nicht anders angegeben.
+
+Wenn du diesen Kurs selbstständig durcharbeitest, mache dich bitte mit den [Grundlagen der Umgebung](../envsetup/01_setup.md) für weitere Details vertraut.
+
+### Versionsanforderungen
+
+Dieses Training ist für Nextflow 25.10.2 oder höher **mit aktiviertem v2 Syntax-Parser** konzipiert.
+Wenn du eine lokale oder benutzerdefinierte Umgebung verwendest, stelle bitte sicher, dass du die korrekten Einstellungen wie [hier](../info/nxf_versions.md) dokumentiert verwendest.
+
+## Vorbereitung
+
+Sobald dein Codespace läuft, musst du zwei Dinge tun, bevor du mit dem Training beginnst: das Arbeitsverzeichnis für diesen spezifischen Kurs festlegen und einen Blick auf die bereitgestellten Materialien werfen.
+
+### Arbeitsverzeichnis festlegen
+
+Standardmäßig öffnet der Codespace mit dem Arbeitsverzeichnis im Stammverzeichnis aller Trainingskurse, aber für diesen Kurs werden wir im Verzeichnis `hello-nextflow/` arbeiten.
+
+Wechsle jetzt das Verzeichnis, indem du diesen Befehl im Terminal ausführst:
+
+```bash
+cd hello-nextflow/
+```
+
+Du kannst VSCode auf dieses Verzeichnis fokussieren lassen, sodass nur die relevanten Dateien in der Datei-Explorer-Seitenleiste angezeigt werden:
+
+```bash
+code .
+```
+
+!!! tip "Tipp"
+
+    Falls du aus irgendeinem Grund dieses Verzeichnis verlässt (z.B. wenn dein Codespace in den Ruhezustand geht), kannst du immer den vollständigen Pfad verwenden, um dorthin zurückzukehren, vorausgesetzt du arbeitest in der Github Codespaces Trainingsumgebung:
+
+    ```bash
+    cd /workspaces/training/hello-nextflow
+    ```
+
+Schauen wir uns nun den Inhalt an.
+
+### Bereitgestellte Materialien erkunden
+
+Du kannst den Inhalt dieses Verzeichnisses über den Datei-Explorer auf der linken Seite des Trainingsarbeitsbereichs erkunden.
+Alternativ kannst du den `tree`-Befehl verwenden.
+
+Im gesamten Kurs verwenden wir die Ausgabe von `tree`, um die Verzeichnisstruktur und den Inhalt in einer lesbaren Form darzustellen, manchmal mit geringfügigen Änderungen zur Klarheit.
+
+Hier generieren wir ein Inhaltsverzeichnis bis zur zweiten Ebene:
+
+```bash
+tree . -L 2
+```
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    .
+    ├── data
+    │   └── greetings.csv
+    ├── hello-channels.nf
+    ├── hello-config.nf
+    ├── hello-containers.nf
+    ├── hello-modules.nf
+    ├── hello-workflow.nf
+    ├── hello-world.nf
+    ├── nextflow.config
+    ├── solutions
+    │   ├── 1-hello-world
+    │   ├── 2-hello-channels
+    │   ├── 3-hello-workflow
+    │   ├── 4-hello-modules
+    │   ├── 5-hello-containers
+    │   └── 6-hello-config
+    ├── test-params.json
+    └── test-params.yaml
+    ```
+
+Klicke auf das farbige Kästchen, um den Abschnitt zu erweitern und seinen Inhalt anzuzeigen.
+Wir verwenden ausklappbare Abschnitte wie diesen, um erwartete Befehlsausgaben kompakt darzustellen.
+
+- **Die `.nf`-Dateien** sind Workflow-Skripte, die nach dem Teil des Kurses benannt sind, in dem sie verwendet werden.
+
+- **Die Datei `nextflow.config`** ist eine Konfigurationsdatei, die minimale Umgebungseigenschaften festlegt.
+  Du kannst sie vorerst ignorieren.
+
+- **Die Datei `greetings.csv`** unter `data/` enthält Eingabedaten, die wir im größten Teil des Kurses verwenden werden. Sie wird in Teil 2 (Channels) beschrieben, wenn wir sie zum ersten Mal einführen.
+
+- **Die `test-params.*`-Dateien** sind Konfigurationsdateien, die wir in Teil 6 (Konfiguration) verwenden werden. Du kannst sie vorerst ignorieren.
+
+- **Das `solutions`-Verzeichnis** enthält die fertigen Workflow-Skripte, die aus jedem Schritt des Kurses resultieren.
+  Sie sind als Referenz gedacht, um deine Arbeit zu überprüfen und eventuelle Probleme zu beheben.
+
+## Bereitschafts-Checkliste
+
+Denkst du, du bist bereit einzutauchen?
+
+- [ ] Ich verstehe das Ziel dieses Kurses und seine Voraussetzungen
+- [ ] Meine Umgebung läuft
+- [ ] Ich habe mein Arbeitsverzeichnis entsprechend festgelegt
+
+Wenn du alle Kästchen abhaken kannst, bist du startklar.
+
+**Um zu [Teil 1: Hello World](./01_hello_world.md) fortzufahren, klicke auf den Pfeil in der unteren rechten Ecke dieser Seite.**

--- a/docs/de/docs/hello_nextflow/01_hello_world.md
+++ b/docs/de/docs/hello_nextflow/01_hello_world.md
@@ -1,0 +1,1224 @@
+# Teil 1: Hello World
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/8X2hHI-9vms?si=F0t9LFYLjAWoyRXj&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Siehe [die gesamte Playlist](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) auf dem Nextflow YouTube-Kanal.
+
+:green_book: Das Videotranskript ist [hier](./transcripts/01_hello_world.md) verfügbar.
+///
+
+In diesem ersten Teil des Hello Nextflow Trainingskurses führen wir dich mit einem sehr einfachen, domänenunabhängigen Hello World Beispiel an das Thema heran. Dieses werden wir schrittweise erweitern, um die Verwendung grundlegender Nextflow-Logik und -Komponenten zu demonstrieren.
+
+??? info "Was ist ein Hello World Beispiel?"
+
+    Ein "Hello World!" ist ein minimalistisches Beispiel, das die grundlegende Syntax und Struktur einer Programmiersprache oder eines Software-Frameworks demonstrieren soll.
+    Das Beispiel besteht typischerweise darin, den Text "Hello, World!" auf das Ausgabegerät, wie die Konsole oder das Terminal, zu drucken oder in eine Datei zu schreiben.
+
+---
+
+## 0. Aufwärmen: Ein Hello World Beispiel direkt ausführen
+
+Lass uns dies mit einem einfachen Befehl demonstrieren, den wir direkt im Terminal ausführen, um zu zeigen, was er macht, bevor wir ihn in Nextflow einbetten.
+
+!!! tip "Tipp"
+
+    Denke daran, dass du dich jetzt im Verzeichnis `hello-nextflow/` befinden solltest, wie auf der Seite [Erste Schritte](00_orientation.md) beschrieben.
+
+### 0.1. Das Terminal zur Begrüßung auffordern
+
+Führe den folgenden Befehl in deinem Terminal aus.
+
+```bash
+echo 'Hello World!'
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    Hello World!
+    ```
+
+Dies gibt den Text 'Hello World' direkt im Terminal aus.
+
+### 0.2. Die Ausgabe in eine Datei schreiben
+
+Bei der Ausführung von Pipelines geht es hauptsächlich darum, Daten aus Dateien zu lesen und Ergebnisse in andere Dateien zu schreiben. Lass uns den Befehl so modifizieren, dass die Textausgabe in eine Datei geschrieben wird, um das Beispiel etwas relevanter zu machen.
+
+```bash
+echo 'Hello World!' > output.txt
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+
+    ```
+
+Dies gibt nichts im Terminal aus.
+
+### 0.3. Die Ausgabe finden
+
+Der Text 'Hello World' sollte sich jetzt in der von uns angegebenen Ausgabedatei namens `output.txt` befinden.
+Du kannst sie im Datei-Explorer öffnen oder zum Beispiel mit dem Dienstprogramm `cat` von der Befehlszeile aus.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="output.txt" linenums="1"
+    Hello World!
+    ```
+
+Dies werden wir mit unserem allerersten Nextflow-Workflow zu replizieren versuchen.
+
+### Zusammenfassung
+
+Du weißt jetzt, wie man einen einfachen Befehl im Terminal ausführt, der etwas Text ausgibt, und optional, wie man ihn dazu bringt, die Ausgabe in eine Datei zu schreiben.
+
+### Was kommt als Nächstes?
+
+Finde heraus, wie das als Nextflow-Workflow aussehen würde.
+
+---
+
+## 1. Das Skript untersuchen und ausführen
+
+Wir stellen dir ein voll funktionsfähiges, wenn auch minimalistisches Workflow-Skript namens `hello-world.nf` zur Verfügung, das dasselbe macht wie zuvor (es gibt 'Hello World!' aus), aber mit Nextflow.
+
+Um dir den Einstieg zu erleichtern, öffnen wir das Workflow-Skript, damit du ein Gefühl für seine Struktur bekommst.
+Dann führen wir es aus und suchen nach seinen Ausgaben.
+
+### 1.1. Den Code untersuchen
+
+Du findest das Skript `hello-world.nf` in deinem aktuellen Verzeichnis, das `hello-nextflow` sein sollte. Öffne es im Editor-Bereich.
+
+??? full-code "Vollständige Codedatei"
+
+    ```groovy title="hello-world.nf" linenums="1"
+    #!/usr/bin/env nextflow
+
+    /*
+    * Use echo to print 'Hello World!' to a file
+    */
+    process sayHello {
+
+        output:
+        path 'output.txt'
+
+        script:
+        """
+        echo 'Hello World!' > output.txt
+        """
+    }
+
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello()
+    }
+    ```
+
+Ein Nextflow-Workflow-Skript enthält typischerweise eine oder mehrere **process**-Definitionen und den **workflow** selbst, plus einige optionale Blöcke (hier nicht vorhanden), die wir später einführen werden.
+
+Jeder **process** beschreibt, welche Operation(en) der entsprechende Schritt in der Pipeline ausführen soll, während der **workflow** die Datenflusslogik beschreibt, die die verschiedenen Schritte verbindet.
+
+Wir werden uns zuerst den **process**-Block genauer ansehen, dann werden wir uns den **workflow**-Block ansehen.
+
+#### 1.1.1. Die `process`-Definition
+
+Der erste Codeblock beschreibt einen **process**.
+
+Die Prozessdefinition beginnt mit dem Schlüsselwort `process`, gefolgt vom Prozessnamen und schließlich dem Prozesskörper, der von geschweiften Klammern begrenzt wird.
+Der Prozesskörper muss einen script-Block enthalten, der den auszuführenden Befehl angibt, der alles sein kann, was du in einem Befehlszeilen-Terminal ausführen könntest.
+
+```groovy title="hello-world.nf" linenums="3"
+/*
+* Use echo to print 'Hello World!' to a file
+*/
+process sayHello {
+
+    output:
+    path 'output.txt'
+
+    script:
+    """
+    echo 'Hello World!' > output.txt
+    """
+}
+```
+
+Hier haben wir einen **process** namens `sayHello`, der seine **output** in eine Datei namens `output.txt` schreibt.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_world.svg"
+</figure>
+
+Dies ist eine sehr minimale Prozessdefinition, die nur eine `output`-Definition und das auszuführende `script` enthält.
+
+Die `output`-Definition enthält den `path`-Qualifier, der Nextflow mitteilt, dass dies als Pfad behandelt werden soll (umfasst sowohl Verzeichnispfade als auch Dateien).
+Ein weiterer häufiger Qualifier ist `val`.
+
+Wichtig ist, dass die Output-Definition nicht _bestimmt_, welche Ausgabe erstellt wird.
+Sie _deklariert_ lediglich, was die erwartete Ausgabe ist, damit Nextflow nach Abschluss der Ausführung danach suchen kann.
+Dies ist notwendig, um zu überprüfen, ob der Befehl erfolgreich ausgeführt wurde, und um die Ausgabe bei Bedarf an nachgelagerte Prozesse weiterzugeben. Ausgaben, die nicht mit dem übereinstimmen, was im output-Block deklariert ist, werden nicht an nachgelagerte Prozesse weitergegeben.
+
+!!! warning "Warnung"
+
+    Dieses Beispiel ist fragil, weil wir den Ausgabedateinamen an zwei verschiedenen Stellen (im script- und im output-Block) fest eincodiert haben.
+    Wenn wir einen ändern, aber nicht den anderen, wird das Skript nicht mehr funktionieren.
+    Später wirst du lernen, wie du Variablen verwenden kannst, um dieses Problem zu vermeiden.
+
+In einer realen Pipeline enthält ein Prozess normalerweise zusätzliche Blöcke wie Direktiven und Eingaben, die wir gleich einführen werden.
+
+#### 1.1.2. Die `workflow`-Definition
+
+Der zweite Codeblock beschreibt den **workflow** selbst.
+Die Workflow-Definition beginnt mit dem Schlüsselwort `workflow`, gefolgt von einem optionalen Namen, dann dem Workflow-Körper, der von geschweiften Klammern begrenzt wird.
+
+Hier haben wir einen **workflow**, der aus einem `main:`-Block (der sagt 'dies ist der Hauptteil des Workflows') besteht, der einen Aufruf des `sayHello`-Prozesses enthält.
+
+```groovy title="hello-world.nf" linenums="17"
+workflow {
+
+    main:
+    // emit a greeting
+    sayHello()
+}
+```
+
+Dies ist eine sehr minimale **workflow**-Definition.
+In einer realen Pipeline enthält der Workflow typischerweise mehrere Aufrufe von **Prozessen**, die durch **Channels** verbunden sind, und die Prozesse erwarten eine oder mehrere variable **Eingabe(n)**.
+
+Du wirst lernen, wie man variable Eingaben hinzufügt, später in diesem Trainingsmodul; und du wirst lernen, wie man mehr Prozesse hinzufügt und sie durch Channels verbindet, in Teil 3 dieses Kurses.
+
+!!! tip "Tipp"
+
+    Technisch gesehen ist die `main:`-Zeile für einfache Workflows wie diesen nicht erforderlich, daher könntest du auf Workflows stoßen, die sie nicht haben.
+    Aber wir werden sie brauchen, um Workflow-Level-Outputs zu nutzen, also können wir sie gleich von Anfang an einbeziehen.
+
+### 1.2. Den Workflow ausführen
+
+Code anzuschauen macht nicht annähernd so viel Spaß wie ihn auszuführen, also lass uns das in der Praxis ausprobieren.
+
+#### 1.2.1. Den Workflow starten und die Ausführung überwachen
+
+Führe im Terminal den folgenden Befehl aus:
+
+```bash
+nextflow run hello-world.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console hl_lines="7"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [goofy_torvalds] DSL2 - revision: c33d41f479
+
+    executor >  local (1)
+    [65/7be2fa] sayHello | 1 of 1 ✔
+    ```
+
+Wenn deine Konsolenausgabe ungefähr so aussieht, dann herzlichen Glückwunsch, du hast gerade deinen ersten Nextflow-Workflow ausgeführt!
+
+Die wichtigste Ausgabe hier ist die letzte Zeile, die in der obigen Ausgabe hervorgehoben ist:
+
+```console
+[65/7be2fa] sayHello | 1 of 1 ✔
+```
+
+Dies sagt uns, dass der `sayHello`-Prozess einmal erfolgreich ausgeführt wurde (`1 of 1 ✔`).
+
+Wichtig ist, dass diese Zeile dir auch sagt, wo du die Ausgabe des `sayHello`-Prozessaufrufs findest.
+Lass uns das jetzt anschauen.
+
+#### 1.2.2. Die Ausgabe und Logs im `work`-Verzeichnis finden
+
+Wenn du Nextflow zum ersten Mal in einem bestimmten Verzeichnis ausführst, erstellt es ein Verzeichnis namens `work`, in das es alle Dateien (und alle Symlinks) schreibt, die im Laufe der Ausführung generiert werden.
+
+Innerhalb des `work`-Verzeichnisses organisiert Nextflow Ausgaben und Logs pro Prozessaufruf.
+Für jeden Prozessaufruf erstellt Nextflow ein verschachteltes Unterverzeichnis, das mit einem Hash benannt ist, um es eindeutig zu machen, in dem es alle notwendigen Eingaben bereitstellt (standardmäßig mit Symlinks), Hilfsdateien schreibt und Logs sowie alle Ausgaben des Prozesses ausgibt.
+
+Der Pfad zu diesem Unterverzeichnis wird in verkürzter Form in eckigen Klammern in der Konsolenausgabe angezeigt.
+Wenn wir uns ansehen, was wir für den oben gezeigten Lauf bekommen haben, beginnt die Konsolenlogzeile für den sayHello-Prozess mit `[65/7be2fa]`. Das entspricht dem folgenden Verzeichnispfad: `work/65/7be2fa7be2fad5e71e5f49998f795677fd68`
+
+Lass uns einen Blick darauf werfen, was dort drin ist.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    work
+    └── 65
+        └── 7be2fad5e71e5f49998f795677fd68
+            ├── .command.begin
+            ├── .command.err
+            ├── .command.log
+            ├── .command.out
+            ├── .command.run
+            ├── .command.sh
+            ├── .exitcode
+            └── output.txt
+    ```
+
+??? question "Siehst du nicht dasselbe?"
+
+    Die genauen Unterverzeichnisnamen werden auf deinem System anders sein.
+
+    Wenn du den Inhalt des Task-Unterverzeichnisses im VSCode-Datei-Explorer durchsuchst, siehst du alle Dateien sofort.
+    Die Logdateien sind jedoch so eingestellt, dass sie im Terminal unsichtbar sind. Wenn du also `ls` oder `tree` verwenden möchtest, um sie anzuzeigen, musst du die entsprechende Option zum Anzeigen unsichtbarer Dateien setzen.
+
+    ```bash
+    tree -a work
+    ```
+
+Das Erste, was du dir ansehen möchtest, ist die tatsächliche Ausgabe des Workflows, d.h. die Datei `output.txt`, die vom `sayHello`-Prozess erzeugt wurde.
+Öffne sie und du findest die Begrüßung `Hello World!`, was der Sinn unseres minimalistischen Workflows war.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="output.txt"
+    Hello World!
+    ```
+
+Es hat funktioniert!
+
+Zugegeben, das mag wie viel Wrapper-Code für ein so winziges Ergebnis erscheinen, aber der Wert all dieses Wrapper-Codes wird offensichtlicher, sobald wir beginnen, Eingabedateien zu lesen und mehrere Schritte miteinander zu verbinden.
+
+Davon abgesehen, lass uns auch die anderen Dateien in diesem Verzeichnis ansehen. Das sind Hilfs- und Logdateien, die Nextflow im Rahmen der Task-Ausführung erstellt hat.
+
+- **`.command.begin`**: Metadaten zum Beginn der Ausführung des Prozessaufrufs
+- **`.command.err`**: Fehlermeldungen (`stderr`), die vom Prozessaufruf ausgegeben wurden
+- **`.command.log`**: Vollständige Logausgabe, die vom Prozessaufruf ausgegeben wurde
+- **`.command.out`**: Reguläre Ausgabe (`stdout`) des Prozessaufrufs
+- **`.command.run`**: Vollständiges Skript, das von Nextflow ausgeführt wurde, um den Prozessaufruf auszuführen
+- **`.command.sh`**: Der Befehl, der tatsächlich vom Prozessaufruf ausgeführt wurde
+- **`.exitcode`**: Der Exit-Code, der sich aus dem Befehl ergab
+
+Die Datei `.command.sh` ist besonders nützlich, weil sie dir den Hauptbefehl zeigt, den Nextflow ausgeführt hat, ohne all die Buchhaltung und Task-/Umgebungseinrichtung.
+
+??? abstract "Dateiinhalt"
+
+    ```console title=".command.sh"
+    #!/bin/bash -ue
+    echo 'Hello World!' > output.txt
+    ```
+
+Dies entspricht dem, was wir zuvor manuell ausgeführt haben.
+
+In diesem Fall ist es sehr einfach, weil der Prozessbefehl fest eincodiert war, aber später im Kurs wirst du Prozessbefehle sehen, die eine gewisse Interpolation von Variablen beinhalten.
+Das macht es besonders wertvoll, genau sehen zu können, wie Nextflow den Code interpretiert hat und welcher Befehl erzeugt wurde, wenn du einen fehlgeschlagenen Lauf beheben möchtest.
+
+### 1.3. Den Workflow erneut ausführen
+
+Versuche, den Workflow ein paar Mal erneut auszuführen, und sieh dir dann die Task-Verzeichnisse unter `work/` an.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    work
+    ├── 0f
+    │   └── 52b7e07b0e274a80843fca48ed21b8
+    │       ├── .command.begin
+    │       ├── .command.err
+    │       ├── .command.log
+    │       ├── .command.out
+    │       ├── .command.run
+    │       ├── .command.sh
+    │       ├── .exitcode
+    │       └── output.txt
+    ├── 65
+        └── 7be2fad5e71e5f49998f795677fd68
+    │   │   ├── .command.begin
+    │   │   ├── .command.err
+    │   │   ├── .command.log
+    │   │   ├── .command.out
+    │   │   ├── .command.run
+    │   │   ├── .command.sh
+    │   │   ├── .exitcode
+    │   │   └── output.txt
+    │   └── e029f2e75305874a9ab263d21ebc2c
+    │       ├── .command.begin
+    │       ├── .command.err
+    │       ├── .command.log
+    │       ├── .command.out
+    │       ├── .command.run
+    │       ├── .command.sh
+    │       ├── .exitcode
+    │       └── output.txt
+    ├── 6c
+    │   └── d4fd787e0b01b3c82e85696c297500
+    │       ├── .command.begin
+    │       ├── .command.err
+    │       ├── .command.log
+    │       ├── .command.out
+    │       ├── .command.run
+    │       ├── .command.sh
+    │       ├── .exitcode
+    │       └── output.txt
+    └── e8
+        └── ab99fad46ade52905ec973ff39bb80
+            ├── .command.begin
+            ├── .command.err
+            ├── .command.log
+            ├── .command.out
+            ├── .command.run
+            ├── .command.sh
+            ├── .exitcode
+            └── output.txt
+    ```
+
+Du siehst, dass für jeden Lauf ein neues Unterverzeichnis mit einem vollständigen Satz von Ausgabe- und Logdateien erstellt wurde.
+Dies zeigt dir, dass das mehrmalige Ausführen desselben Workflows die Ergebnisse vorheriger Läufe nicht überschreibt.
+
+### Zusammenfassung
+
+Du weißt, wie man ein einfaches Nextflow-Skript entschlüsselt, es ausführt und die Ausgabe sowie die relevanten Logdateien im work-Verzeichnis findet.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du die Workflow-Ausgaben an einen bequemeren Ort veröffentlichen kannst.
+
+---
+
+## 2. Ausgaben veröffentlichen
+
+Wie du gerade gelernt hast, ist die von unserer Pipeline erzeugte Ausgabe mehrere Ebenen tief in einem Arbeitsverzeichnis vergraben.
+Dies geschieht absichtlich; Nextflow kontrolliert dieses Verzeichnis und wir sollen nicht damit interagieren.
+Das macht es jedoch unpraktisch, Ausgaben abzurufen, die uns wichtig sind.
+
+Glücklicherweise bietet Nextflow eine Möglichkeit, Ausgaben mit [Workflow-Level-Output-Definitionen](https://www.nextflow.io/docs/latest/workflow.html#workflow-outputs) in ein bestimmtes Verzeichnis zu veröffentlichen.
+
+### 2.1. Grundlegende Verwendung
+
+Dies wird zwei neue Code-Elemente beinhalten:
+
+1. Einen `publish:`-Block innerhalb des `workflow`-Körpers, der Prozessausgaben deklariert.
+2. Einen `output`-Block zum Skript, der Ausgabeoptionen wie Modus und Speicherort angibt.
+
+#### 2.1.1. Die Ausgabe des `sayHello`-Prozesses deklarieren
+
+Wir müssen einen `publish:`-Block zum Workflow-Körper hinzufügen (dasselbe Code-Element wie der `main:`-Block) und die Ausgabe des `sayHello()`-Prozesses auflisten.
+
+Füge in der Workflow-Skriptdatei `hello-world.nf` die folgenden Codezeilen hinzu:
+
+=== "Nachher"
+
+    ```groovy title="hello-world.nf" linenums="17" hl_lines="7-8"
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello()
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-world.nf" linenums="17"
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello()
+    }
+    ```
+
+Du siehst, dass wir uns auf die Ausgabe des Prozesses einfach mit `sayHello().out` beziehen und ihr einen beliebigen Namen `first_output` zuweisen können.
+
+#### 2.1.2. Einen `output:`-Block zum Skript hinzufügen
+
+Jetzt müssen wir nur noch den `output:`-Block hinzufügen, in dem der Pfad des Ausgabeverzeichnisses angegeben wird. Beachte, dass dieser neue Block **außerhalb** und **unterhalb** des `workflow`-Blocks innerhalb des Skripts sitzt.
+
+Füge in der Workflow-Skriptdatei `hello-world.nf` die folgenden Codezeilen hinzu:
+
+=== "Nachher"
+
+    ```groovy title="hello-world.nf" linenums="17" hl_lines="11-15"
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello()
+
+        publish:
+        first_output = sayHello.out
+    }
+
+    output {
+        first_output {
+            path '.'
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-world.nf" linenums="17"
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello()
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Wir können dies verwenden, um allen im `workflow`-Block deklarierten Prozessausgaben spezifische Pfade zuzuweisen.
+Später wirst du Möglichkeiten kennenlernen, ausgeklügelte Ausgabeverzeichnisstrukturen zu generieren, aber jetzt codieren wir der Einfachheit halber einen minimalen Pfad fest ein.
+
+#### 2.1.3. Den Workflow ausführen
+
+Führe jetzt das modifizierte Workflow-Skript aus:
+
+```bash
+nextflow run hello-world.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [jovial_mayer] DSL2 - revision: 35bd3425e5
+
+    executor >  local (1)
+    [9f/48ef97] sayHello | 1 of 1 ✔
+    ```
+
+Die Terminalausgabe sollte vertraut aussehen. Äußerlich hat sich nichts geändert.
+
+Überprüfe jedoch deinen Datei-Explorer: Diesmal hat Nextflow ein neues Verzeichnis namens `results/` erstellt.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console hl_lines="10-11 22"
+    .
+    ├── greetings.csv
+    ├── hello-channels.nf
+    ├── hello-config.nf
+    ├── hello-containers.nf
+    ├── hello-modules.nf
+    ├── hello-workflow.nf
+    ├── hello-world.nf
+    ├── nextflow.config
+    ├── results
+    │   └── output.txt -> /workspaces/training/hello-nextflow/work/9f/48ef97f110b0dbd83635d7cbe288d2/output.txt
+    ├── solutions
+    │   ├── 1-hello-world
+    │   ├── 2-hello-channels
+    │   ├── 3-hello-workflow
+    │   ├── 4-hello-modules
+    │   ├── 5-hello-containers
+    │   └── 6-hello-config
+    ├── test-params.json
+    └── work
+        ├── 65
+        └── 9f
+    ```
+
+Im Verzeichnis `results` finden wir einen symbolischen Link zur `output.txt`, die im work-Verzeichnis durch den gerade ausgeführten Befehl erzeugt wurde.
+
+Dies ermöglicht es uns, Ausgabedateien einfach abzurufen, ohne das work-Unterverzeichnis durchsuchen zu müssen.
+
+### 2.2. Einen benutzerdefinierten Speicherort festlegen
+
+Ein Standardspeicherort ist großartig, aber du möchtest vielleicht anpassen, wo die Ergebnisse gespeichert werden und wie sie organisiert sind.
+
+Du möchtest zum Beispiel deine Ausgaben in Unterverzeichnisse organisieren.
+Der einfachste Weg, das zu tun, ist, pro Ausgabe einen spezifischen Ausgabepfad zuzuweisen.
+
+#### 2.2.1. Den Ausgabepfad modifizieren
+
+Auch hier ist das Modifizieren des Veröffentlichungsverhaltens für eine bestimmte Ausgabe wirklich einfach.
+Um einen benutzerdefinierten Speicherort festzulegen, bearbeite einfach den `path` entsprechend:
+
+=== "Nachher"
+
+    ```groovy title="hello-world.nf" linenums="27" hl_lines="3"
+    output {
+        first_output {
+            path 'hello_world'
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-world.nf" linenums="27" hl_lines="3"
+    output {
+        first_output {
+            path '.'
+        }
+    }
+    ```
+
+Da dies auf der Ebene der einzelnen Ausgabe festgelegt wird, kannst du verschiedene Speicherorte und Unterverzeichnisse entsprechend deinen Bedürfnissen angeben.
+
+#### 2.2.2. Den Workflow erneut ausführen
+
+Lass es uns ausprobieren.
+
+```bash
+nextflow run hello-world.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [tiny_shaw] DSL2 - revision: 757723adc1
+
+    executor >  local (1)
+    [8c/79499c] process > sayHello [100%] 1 of 1 ✔
+    ```
+
+Diesmal wird das Ergebnis in das angegebene Unterverzeichnis geschrieben.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console hl_lines="2-3"
+    results/
+    ├── hello_world
+    │   └── output.txt -> /workspaces/training/hello-nextflow/work/8c/79499c2e506b79e2e01acb808d9d12/output.txt
+    └── output.txt -> /workspaces/training/hello-nextflow/work/65/f56f2cd75df1352e106fcdd084b97b/output.txt
+    ```
+
+Du siehst, dass das Ergebnis der vorherigen Ausführung immer noch da ist.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_world_output.svg"
+</figure>
+
+Du kannst so viele Verschachtelungsebenen verwenden, wie du möchtest.
+Es ist auch möglich, den Prozessnamen oder andere Variablen zu verwenden, um die Verzeichnisse zu benennen, die zur Organisation der Ergebnisse verwendet werden, und es ist möglich, den Standardnamen des Ausgabeverzeichnisses der obersten Ebene zu ändern (der durch die spezielle Variable `outputDir` gesteuert wird).
+Wir werden diese Optionen in späteren Trainings behandeln.
+
+### 2.3. Den Veröffentlichungsmodus auf Kopieren setzen
+
+Standardmäßig werden die Ausgaben als symbolische Links aus dem `work`-Verzeichnis veröffentlicht.
+Das bedeutet, dass es nur eine einzige Datei im Dateisystem gibt.
+
+Das ist großartig, wenn du mit sehr großen Dateien arbeitest, für die du nicht mehrere Kopien speichern möchtest.
+Wenn du jedoch irgendwann das work-Verzeichnis löschst (wir werden Bereinigungsoperationen in Kürze behandeln), verlierst du den Zugriff auf die Datei.
+Du musst also einen Plan haben, um Kopien aller wichtigen Dateien an einem sicheren Ort zu speichern.
+
+Eine einfache Option ist, den Veröffentlichungsmodus für die Ausgaben, die dir wichtig sind, auf Kopieren umzustellen.
+
+#### 2.3.1. Die mode-Direktive hinzufügen
+
+Dieser Teil ist wirklich einfach.
+Füge einfach `mode 'copy'` zur relevanten Workflow-Level-Output-Definition hinzu:
+
+=== "Nachher"
+
+    ```groovy title="hello-world.nf" linenums="27" hl_lines="4"
+    output {
+        first_output {
+            path 'hello_world'
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-world.nf" linenums="27"
+    output {
+        first_output {
+            path 'hello_world'
+        }
+    }
+    ```
+
+Dies setzt den Veröffentlichungsmodus für diese spezifische Ausgabe.
+
+#### 2.3.2. Den Workflow erneut ausführen
+
+Lass es uns ausprobieren.
+
+```bash
+nextflow run hello-world.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [tiny_shaw] DSL2 - revision: 757723adc1
+
+    executor >  local (1)
+    [df/521638] process > sayHello [100%] 1 of 1 ✔
+    ```
+
+Diesmal, wenn du dir die Ergebnisse ansiehst, ist die Datei eine echte Kopie anstatt nur ein Symlink.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console hl_lines="3"
+    results/
+    ├── hello_world
+    │   └── output.txt
+    └── output.txt -> /workspaces/training/hello-nextflow/work/65/f56f2cd75df1352e106fcdd084b97b/output.txt
+    ```
+
+Da dies auch auf der Ebene der einzelnen Ausgabe festgelegt wird, kannst du den Veröffentlichungsmodus sehr granular festlegen.
+Dies wird besonders praktisch sein, wenn wir zu mehrstufigen Pipelines übergehen, wo du vielleicht nur endgültige Ausgaben kopieren und Zwischenausgaben als Symlinks belassen möchtest.
+
+Wie bereits erwähnt, gibt es andere, ausgeklügeltere Optionen zur Steuerung, wie Ausgaben veröffentlicht werden.
+Wir werden dir zeigen, wie du sie zu gegebener Zeit in deiner Nextflow-Reise verwendest.
+
+### 2.4. Hinweis zu `publishDir`-Direktiven auf Prozessebene
+
+Bis vor kurzem war die etablierte Methode, Ausgaben zu veröffentlichen, dies auf der Ebene jedes einzelnen Prozesses mit einer `publishDir`-Direktive zu tun.
+
+Um das zu erreichen, was wir gerade für die Ausgaben des `sayHello`-Prozesses getan haben, hätten wir stattdessen die folgende Zeile zur Prozessdefinition hinzugefügt:
+
+```groovy title="hello-world.nf" linenums="6" hl_lines="3"
+process sayHello {
+
+    publishDir 'results/hello_world', mode: 'copy'
+
+    output:
+    path 'output.txt'
+
+    script:
+    """
+    echo 'Hello World!' > output.txt
+    """
+}
+```
+
+Du wirst dieses Codemuster immer noch überall in älteren Nextflow-Pipelines und Prozessmodulen finden, daher ist es wichtig, es zu kennen.
+Wir empfehlen jedoch nicht, es in neuer Arbeit zu verwenden, da es in zukünftigen Versionen der Nextflow-Sprache eventuell nicht mehr erlaubt sein wird.
+
+### Zusammenfassung
+
+Du weißt, wie man Workflow-Ausgaben an einen bequemeren Ort veröffentlicht.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du eine variable Eingabe über einen Befehlszeilenparameter bereitstellst und Standardwerte effektiv nutzt.
+
+---
+
+## 3. Eine variable Eingabe verwenden, die über die Befehlszeile übergeben wird
+
+In seinem aktuellen Zustand verwendet unser Workflow eine in den Prozessbefehl fest eincodierte Begrüßung.
+Wir möchten etwas Flexibilität hinzufügen, indem wir eine Eingabevariable verwenden, damit wir die Begrüßung zur Laufzeit leichter ändern können.
+
+Dies erfordert drei Änderungen an unserem Skript:
+
+1. Den Prozess so ändern, dass er eine variable Eingabe erwartet
+2. Einen Befehlszeilenparameter einrichten, um Benutzereingaben zu erfassen
+3. Die Eingabe an den Prozess im Workflow-Körper übergeben
+
+Lass uns diese Änderungen nacheinander vornehmen.
+
+### 3.1. Den `sayHello`-Prozess ändern, um eine variable Eingabe zu erwarten
+
+Wir müssen die Prozessdefinition bearbeiten, um (1) eine Eingabevariable zu akzeptieren und (2) diese Variable in der Befehlszeile zu verwenden.
+
+#### 3.1.1. Einen input-Block zur Prozessdefinition hinzufügen
+
+Zuerst passen wir die Prozessdefinition an, um eine Eingabe namens `greeting` zu akzeptieren.
+
+Nimm im Prozessblock die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-world.nf" linenums="6" hl_lines="3-4"
+    process sayHello {
+
+        input:
+        val greeting
+
+        output:
+        path 'output.txt'
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-world.nf" linenums="6"
+    process sayHello {
+
+        output:
+        path 'output.txt'
+    ```
+
+Der Variable `greeting` wird `val` vorangestellt, um Nextflow mitzuteilen, dass es sich um einen Wert handelt (nicht um einen Pfad).
+
+#### 3.1.2. Den Prozessbefehl bearbeiten, um die Eingabevariable zu verwenden
+
+Jetzt tauschen wir den ursprünglichen fest eincodierten Wert gegen den Wert der Eingabevariable aus, die wir erwarten zu erhalten.
+
+Nimm im Prozessblock die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-world.nf" linenums="14" hl_lines="3"
+    script:
+    """
+    echo '${greeting}' > output.txt
+    """
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-world.nf" linenums="14" hl_lines="3"
+    script:
+    """
+    echo 'Hello World!' > output.txt
+    """
+    ```
+
+Das `$`-Symbol und die geschweiften Klammern (`{ }`) sagen Nextflow, dass dies ein Variablenname ist, der durch den tatsächlichen Eingabewert ersetzt werden muss (=interpoliert).
+
+!!! tip "Tipp"
+
+    Die geschweiften Klammern (`{ }`) waren in früheren Versionen von Nextflow technisch optional, daher siehst du vielleicht ältere Workflows, in denen dies als `echo '$greeting' > output.txt` geschrieben ist.
+
+Jetzt, da der `sayHello()`-Prozess bereit ist, eine variable Eingabe zu akzeptieren, brauchen wir eine Möglichkeit, dem Prozessaufruf auf Workflow-Ebene einen Eingabewert bereitzustellen.
+
+### 3.2. Einen Befehlszeilenparameter einrichten, um Benutzereingaben zu erfassen
+
+Wir könnten einfach eine Eingabe direkt fest eincodieren, indem wir den Prozessaufruf `sayHello('Hello World!')` machen.
+Wenn wir jedoch echte Arbeit mit unserem Workflow erledigen, werden wir seine Eingaben von der Befehlszeile aus steuern wollen.
+
+Gute Nachricht: Nextflow hat ein eingebautes Workflow-Parameter-System namens `params`, das es einfach macht, CLI-Parameter zu deklarieren und zu verwenden.
+
+Die allgemeine Syntax ist, `params.<parameter_name>` zu deklarieren, um Nextflow mitzuteilen, dass es einen `--<parameter_name>`-Parameter auf der Befehlszeile erwartet.
+
+Hier wollen wir einen Parameter namens `--input` erstellen, also müssen wir irgendwo im Workflow `params.input` deklarieren.
+Im Prinzip können wir es überall hinschreiben; aber da wir es dem `sayHello()`-Prozessaufruf geben wollen, können wir es dort direkt einfügen, indem wir `sayHello(params.input)` schreiben.
+
+Nimm im Workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-world.nf" linenums="23" hl_lines="2"
+    // emit a greeting
+    sayHello(params.input)
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-world.nf" linenums="23" hl_lines="2"
+    // emit a greeting
+    sayHello()
+    ```
+
+Dies sagt Nextflow, den `sayHello`-Prozess mit dem über den `--input`-Parameter bereitgestellten Wert auszuführen.
+
+Tatsächlich haben wir die oben skizzierten Schritte (2) und (3) in einem Zug erledigt.
+
+### 3.3. Den Workflow-Befehl ausführen
+
+Lass es uns ausführen!
+
+```bash
+nextflow run hello-world.nf --input 'Bonjour le monde!'
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [elated_lavoisier] DSL2 - revision: 7c031b42ea
+
+    executor >  local (1)
+    [4b/654319] sayHello | 1 of 1 ✔
+    ```
+
+Wenn du alle diese Änderungen richtig gemacht hast, solltest du eine weitere erfolgreiche Ausführung erhalten.
+
+Öffne unbedingt die Ausgabedatei, um zu überprüfen, dass du jetzt die neue Version der Begrüßung hast.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="results/hello_world/output.txt"
+    Bonjour le monde!
+    ```
+
+Voilà!
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_world_input.svg"
+</figure>
+
+Beachte, dass die neue Ausführung die im `results`-Verzeichnis veröffentlichte Ausgabedatei überschrieben hat.
+Die Ergebnisse der vorherigen Läufe sind jedoch immer noch in den Task-Verzeichnissen unter `work` erhalten.
+
+!!! tip "Tipp"
+
+    Du kannst Nextflow-Level-Parameter leicht von Pipeline-Level-Parametern unterscheiden.
+
+    - Parameter, die für eine Pipeline gelten, nehmen immer einen doppelten Bindestrich (`--`).
+    - Parameter, die eine Nextflow-Einstellung ändern, _z.B._ die `-resume`-Funktion, die wir zuvor verwendet haben, nehmen einen einzelnen Bindestrich (`-`).
+
+### 3.4. Standardwerte für Befehlszeilenparameter verwenden
+
+Ok, das war praktisch, aber in vielen Fällen ist es sinnvoll, einen Standardwert für einen bestimmten Parameter anzugeben, damit du ihn nicht bei jedem Lauf angeben musst.
+
+#### 3.4.1. Einen Standardwert für den CLI-Parameter festlegen
+
+Lass uns dem `input`-Parameter einen Standardwert geben, indem wir ihn vor der Workflow-Definition deklarieren.
+
+```groovy title="hello-world.nf" linenums="20"
+/*
+ * Pipeline parameters
+ */
+params {
+    input: String = 'Holà mundo!'
+}
+```
+
+Wie du siehst, können wir den Typ der Eingabe angeben, die der Workflow erwartet (Nextflow 25.10.2 und später).
+Die Syntax ist `name: Type = default_value`.
+Unterstützte Typen sind `String`, `Integer`, `Float`, `Boolean` und `Path`.
+
+!!! info "Info"
+
+    In älteren Workflows siehst du vielleicht, dass der gesamte `params`-Block nur als `input = 'Holà mundo!'` geschrieben ist.
+
+Wenn du deiner Pipeline weitere Parameter hinzufügst, solltest du sie alle zu diesem Block hinzufügen, unabhängig davon, ob du ihnen einen Standardwert geben musst.
+So kannst du alle konfigurierbaren Parameter auf einen Blick leicht finden.
+
+#### 3.4.2. Den Workflow erneut ausführen, ohne den Parameter anzugeben
+
+Jetzt, da du einen Standardwert festgelegt hast, kannst du den Workflow erneut ausführen, ohne einen Wert in der Befehlszeile angeben zu müssen.
+
+```bash
+nextflow run hello-world.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [determined_edison] DSL2 - revision: 3539118582
+
+    executor >  local (1)
+    [72/394147] sayHello | 1 of 1 ✔
+    ```
+
+Die Ausgabe wird an derselben Stelle wie zuvor sein, aber der Inhalt sollte mit dem neuen Text aktualisiert sein.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="results/hello_world/output.txt"
+    Holà mundo!
+    ```
+
+Nextflow hat den Standardwert des greeting-Parameters verwendet, um die Ausgabe zu erstellen.
+
+#### 3.4.3. Den Standardwert überschreiben
+
+Wenn du den Parameter auf der Befehlszeile angibst, überschreibt der CLI-Wert den Standardwert.
+
+Probiere es aus:
+
+```bash
+nextflow run hello-world.nf --input 'Konnichiwa!'
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [elegant_faraday] DSL2 - revision: 3539118582
+
+    executor >  local (1)
+    [6f/a12a91] sayHello | 1 of 1 ✔
+    ```
+
+Auch hier solltest du die entsprechend aktualisierte Ausgabe in deinem results-Verzeichnis finden.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="results/hello_world/output.txt"
+    Konnichiwa!
+    ```
+
+!!! note "Hinweis"
+
+    In Nextflow gibt es mehrere Stellen, an denen du Werte für Parameter angeben kannst.
+    Wenn derselbe Parameter an mehreren Stellen auf verschiedene Werte gesetzt wird, bestimmt Nextflow anhand der [hier](https://www.nextflow.io/docs/latest/config.html) beschriebenen Rangfolge, welcher Wert verwendet wird.
+
+    Wir werden dies in Teil 6 (Konfiguration) ausführlicher behandeln.
+
+### Zusammenfassung
+
+Du weißt, wie man eine einfache variable Eingabe verwendet, die zur Laufzeit über einen Befehlszeilenparameter bereitgestellt wird, sowie wie man Standardwerte einrichtet, verwendet und überschreibt.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du Ausführungen bequemer verwalten kannst.
+
+---
+
+## 4. Workflow-Ausführungen verwalten
+
+Zu wissen, wie man Workflows startet und Ausgaben abruft, ist großartig, aber du wirst schnell feststellen, dass es einige andere Aspekte der Workflow-Verwaltung gibt, die dein Leben einfacher machen werden, besonders wenn du deine eigenen Workflows entwickelst.
+
+Hier zeigen wir dir, wie du die `resume`-Funktion verwendest, wenn du denselben Workflow erneut starten musst, wie du das Log vergangener Ausführungen mit `nextflow log` inspizierst und wie du ältere work-Verzeichnisse mit `nextflow clean` löschst.
+
+<!-- Any other cool options we should include? Added log -->
+
+### 4.1. Einen Workflow mit `-resume` erneut starten
+
+Manchmal möchtest du eine Pipeline, die du bereits zuvor gestartet hast, erneut ausführen, ohne Schritte zu wiederholen, die bereits erfolgreich abgeschlossen wurden.
+
+Nextflow hat eine Option namens `-resume`, die dir dies ermöglicht.
+Konkret werden in diesem Modus alle Prozesse, die bereits mit genau demselben Code, denselben Einstellungen und Eingaben ausgeführt wurden, übersprungen.
+Das bedeutet, dass Nextflow nur Prozesse ausführt, die du seit dem letzten Lauf hinzugefügt oder geändert hast, oder denen du neue Einstellungen oder Eingaben bereitstellst.
+
+Es gibt zwei Hauptvorteile:
+
+- Wenn du mitten in der Entwicklung deiner Pipeline bist, kannst du schneller iterieren, da du nur den/die Prozess(e) ausführen musst, an dem/denen du aktiv arbeitest, um deine Änderungen zu testen.
+- Wenn du eine Pipeline in der Produktion ausführst und etwas schief geht, kannst du in vielen Fällen das Problem beheben und die Pipeline neu starten, und sie wird von der Fehlerstelle aus weiterlaufen, was dir viel Zeit und Rechenleistung sparen kann.
+
+Um es zu verwenden, füge einfach `-resume` zu deinem Befehl hinzu und führe ihn aus:
+
+```bash
+nextflow run hello-world.nf -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console hl_lines="5"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-world.nf` [golden_cantor] DSL2 - revision: 35bd3425e5
+
+    [62/49a1f8] sayHello | 1 of 1, cached: 1 ✔
+    ```
+
+Die Konsolenausgabe sollte vertraut aussehen, aber es gibt eine Sache, die im Vergleich zu vorher ein wenig anders ist.
+
+Achte auf das `cached:`-Bit, das in der Prozessstatuszeile (Zeile 5) hinzugefügt wurde, was bedeutet, dass Nextflow erkannt hat, dass es diese Arbeit bereits erledigt hat und einfach das Ergebnis vom vorherigen erfolgreichen Lauf wiederverwendet hat.
+
+Du kannst auch sehen, dass der work-Unterverzeichnis-Hash derselbe ist wie beim vorherigen Lauf.
+Nextflow zeigt buchstäblich auf die vorherige Ausführung und sagt "Das habe ich schon dort drüben gemacht."
+
+!!! tip "Tipp"
+
+    Wenn du eine Pipeline mit `resume` erneut ausführst, überschreibt Nextflow keine Dateien, die außerhalb des work-Verzeichnisses von zuvor erfolgreich ausgeführten Ausführungen veröffentlicht wurden.
+
+### 4.2. Das Log vergangener Ausführungen inspizieren
+
+Ob du eine neue Pipeline entwickelst oder Pipelines in der Produktion ausführst, irgendwann musst du wahrscheinlich Informationen über vergangene Läufe nachschlagen.
+So geht's.
+
+Immer wenn du einen Nextflow-Workflow startest, wird eine Zeile in eine Logdatei namens `history` geschrieben, unter einem versteckten Verzeichnis namens `.nextflow` im aktuellen Arbeitsverzeichnis.
+
+??? abstract "Dateiinhalt"
+
+    ```txt title=".nextflow/history" linenums="1"
+    2025-07-04 19:27:09	1.8s	wise_watson	OK	3539118582ccde68dde471cc2c66295c	a02c9c46-c3c7-4085-9139-d1b9b5b194c8	nextflow run 1-hello.nf --input 'Hello World'
+    2025-07-04 19:27:20	2.9s	spontaneous_blackwell	OK	3539118582ccde68dde471cc2c66295c	59a5db23-d83c-4c02-a54e-37ddb73a337e	nextflow run 1-hello.nf --input Bonjour
+    2025-07-04 19:27:31	1.8s	gigantic_yonath	OK	3539118582ccde68dde471cc2c66295c	5acaa83a-6ad6-4509-bebc-cb25d5d7ddd0	nextflow run 1-hello.nf --input 'Dobry den'
+    2025-07-04 19:27:45	2.4s	backstabbing_swartz	OK	3539118582ccde68dde471cc2c66295c	5f4b3269-5b53-404a-956c-cac915fbb74e	nextflow run 1-hello.nf --input Konnichiwa
+    2025-07-04 19:27:57	2.1s	goofy_wilson	OK	3539118582ccde68dde471cc2c66295c	5f4b3269-5b53-404a-956c-cac915fbb74e	nextflow run 1-hello.nf --input Konnichiwa -resume
+    ```
+
+Diese Datei gibt dir den Zeitstempel, Laufnamen, Status, Revisions-ID, Session-ID und die vollständige Befehlszeile für jeden Nextflow-Lauf, der aus dem aktuellen Arbeitsverzeichnis gestartet wurde.
+
+Eine bequemere Möglichkeit, auf diese Informationen zuzugreifen, ist die Verwendung des Befehls `nextflow log`.
+
+```bash
+nextflow log
+```
+
+??? success "Befehlsausgabe"
+
+    ```console linenums="1"
+    TIMESTAMP               DURATION        RUN NAME                STATUS  REVISION ID     SESSION ID                              COMMAND
+    2025-07-04 19:27:09     1.8s            wise_watson             OK       3539118582     a02c9c46-c3c7-4085-9139-d1b9b5b194c8    nextflow run 1-hello.nf --input 'Hello World'
+    2025-07-04 19:27:20     2.9s            spontaneous_blackwell   OK       3539118582     59a5db23-d83c-4c02-a54e-37ddb73a337e    nextflow run 1-hello.nf --input Bonjour
+    2025-07-04 19:27:31     1.8s            gigantic_yonath         OK       3539118582     5acaa83a-6ad6-4509-bebc-cb25d5d7ddd0    nextflow run 1-hello.nf --input 'Dobry den'
+    2025-07-04 19:27:45     2.4s            backstabbing_swartz     OK       3539118582     5f4b3269-5b53-404a-956c-cac915fbb74e    nextflow run 1-hello.nf --input Konnichiwa
+    2025-07-04 19:27:57     2.1s            goofy_wilson            OK       3539118582     5f4b3269-5b53-404a-956c-cac915fbb74e    nextflow run 1-hello.nf --input Konnichiwa -resume
+    ```
+
+Dies gibt den Inhalt der Logdatei im Terminal aus, ergänzt um eine Kopfzeile.
+
+Du wirst bemerken, dass sich die Session-ID jedes Mal ändert, wenn du einen neuen `nextflow run`-Befehl ausführst, AUSSER wenn du die `-resume`-Option verwendest.
+In diesem Fall bleibt die Session-ID gleich.
+
+Nextflow verwendet die Session-ID, um Lauf-Caching-Informationen unter dem Verzeichnis `cache` zu gruppieren, das sich ebenfalls unter `.nextflow` befindet.
+
+### 4.3. Ältere work-Verzeichnisse löschen
+
+Während des Entwicklungsprozesses wirst du deine Entwurfs-Pipeline typischerweise sehr oft ausführen, was zur Ansammlung vieler Dateien in vielen Unterverzeichnissen führen kann.
+
+Glücklicherweise enthält Nextflow einen hilfreichen `clean`-Unterbefehl, der automatisch die work-Unterverzeichnisse für vergangene Läufe löschen kann, die dich nicht mehr interessieren.
+
+#### 4.3.1. Löschkriterien bestimmen
+
+Es gibt mehrere [Optionen](https://www.nextflow.io/docs/latest/reference/cli.html#clean), um zu bestimmen, was gelöscht werden soll.
+
+Hier zeigen wir dir ein Beispiel, das alle Unterverzeichnisse von Läufen vor einem bestimmten Lauf löscht, der anhand seines Laufnamens angegeben wird.
+
+Suche den aktuellsten erfolgreichen Lauf, bei dem du `-resume` nicht verwendet hast; in unserem Fall war der Laufname `golden_cantor`.
+
+Der Laufname ist die maschinengenerierte zweiteilige Zeichenkette, die in eckigen Klammern in der Konsolenausgabezeile `Launching (...)` angezeigt wird.
+Du kannst auch das Nextflow-Log verwenden, um einen Lauf basierend auf seinem Zeitstempel und/oder seiner Befehlszeile nachzuschlagen.
+
+#### 4.3.2. Einen Probelauf durchführen
+
+Zuerst verwenden wir das Probelauf-Flag `-n`, um zu überprüfen, was bei dem Befehl gelöscht wird:
+
+```bash
+nextflow clean -before golden_cantor -n
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    Would remove /workspaces/training/hello-nextflow/work/a3/7be2fad5e71e5f49998f795677fd68
+    ```
+
+Deine Ausgabe wird andere Task-Verzeichnisnamen haben und möglicherweise eine andere Anzahl von Zeilen, aber sie sollte ähnlich wie das Beispiel aussehen.
+
+Wenn du keine Zeilen in der Ausgabe siehst, hast du entweder keinen gültigen Laufnamen angegeben oder es gibt keine vergangenen Läufe zu löschen. Stelle sicher, dass du `golden_cantor` im Beispielbefehl durch den entsprechenden letzten Laufnamen in deinem Log ersetzt.
+
+#### 4.3.3. Mit dem Löschen fortfahren
+
+Wenn die Ausgabe wie erwartet aussieht und du mit dem Löschen fortfahren möchtest, führe den Befehl mit dem `-f`-Flag anstelle von `-n` erneut aus:
+
+```bash
+nextflow clean -before golden_cantor -f
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    Removed /workspaces/training/hello-nextflow/work/a3/7be2fad5e71e5f49998f795677fd68
+    ```
+
+Die Ausgabe sollte ähnlich wie zuvor sein, aber jetzt mit 'Removed' anstelle von 'Would remove'.
+Beachte, dass dies nicht die zweistelligen Unterverzeichnisse (wie `a3/` oben) entfernt, aber deren Inhalte leert.
+
+!!! warning "Warnung"
+
+    Das Löschen von work-Unterverzeichnissen aus vergangenen Läufen entfernt sie aus dem Nextflow-Cache und löscht alle Ausgaben, die in diesen Verzeichnissen gespeichert waren.
+    Das bedeutet, dass Nextflows Fähigkeit, die Ausführung fortzusetzen, ohne die entsprechenden Prozesse erneut auszuführen, beeinträchtigt wird.
+
+    Du bist verantwortlich für das Speichern aller Ausgaben, die dir wichtig sind oder auf die du dich verlassen willst! Das ist der Hauptgrund, warum wir den `copy`-Modus anstelle des `symlink`-Modus für die `publish`-Direktive bevorzugen.
+
+### Zusammenfassung
+
+Du weißt, wie man Ausgaben in ein bestimmtes Verzeichnis veröffentlicht, eine Pipeline erneut startet, ohne Schritte zu wiederholen, die bereits auf identische Weise ausgeführt wurden, und den `nextflow clean`-Befehl verwendet, um alte work-Verzeichnisse zu bereinigen.
+
+Allgemeiner gesagt, weißt du, wie man einen einfachen Nextflow-Workflow interpretiert, seine Ausführung verwaltet und Ausgaben abruft.
+
+### Was kommt als Nächstes?
+
+Mach eine kleine Pause, du hast sie dir verdient!
+
+Wenn du bereit bist, gehe zu [**Teil 2: Hello Channels**](./02_hello_channels.md), um zu lernen, wie du Channels verwendest, um Eingaben in deinen Workflow einzuspeisen, was es dir ermöglicht, Nextflows eingebaute Datenflussparallelisierung und andere leistungsstarke Funktionen zu nutzen.
+
+---
+
+## Quiz
+
+<quiz>
+Was sind die mindestens erforderlichen Komponenten eines Nextflow-Prozesses?
+- [ ] Nur input- und output-Blöcke
+- [x] Output- und script-Blöcke
+- [ ] Input-, output- und script-Blöcke
+- [ ] Nur ein script-Block
+
+Mehr erfahren: [1.1.1. Die process-Definition](#111-die-process-definition)
+</quiz>
+
+<quiz>
+Was ist der Zweck des output-Blocks in einem Prozess?
+- [ ] Ergebnisse auf der Konsole ausgeben
+- [ ] Dateien im work-Verzeichnis speichern
+- [x] Erwartete Ausgaben des Prozesses deklarieren
+- [ ] Umgebungsvariablen definieren
+
+Mehr erfahren: [1.1.1. Die process-Definition](#111-die-process-definition)
+</quiz>
+
+<quiz>
+Welcher Befehl wird verwendet, um einen Nextflow-Workflow auszuführen?
+- [ ] `nextflow start`
+- [ ] `nextflow execute`
+- [x] `nextflow run`
+- [ ] `nextflow launch`
+</quiz>
+
+<quiz>
+Welche Datei im work-Verzeichnis eines Tasks enthält den tatsächlich ausgeführten Befehl?
+
+```
+work/a3/7be2fa.../
+├── .command.begin
+├── .command.err
+├── .command.log
+├── .command.out
+├── .command.run
+├── .command.sh
+├── .exitcode
+└── output.txt
+```
+
+- [ ] `.command.run`
+- [x] `.command.sh`
+- [ ] `.command.log`
+- [ ] `.command.out`
+
+Mehr erfahren: [1.2.2. Die Ausgabe und Logs im `work`-Verzeichnis finden](#122-die-ausgabe-und-logs-im-work-verzeichnis-finden)
+</quiz>
+
+<quiz>
+Was macht das `-resume`-Flag?
+- [ ] Startet den Workflow von Anfang an neu
+- [ ] Pausiert den Workflow
+- [x] Überspringt Prozesse, die bereits erfolgreich abgeschlossen wurden
+- [ ] Erstellt ein Backup des Workflows
+
+Mehr erfahren: [4.1. Einen Workflow mit `-resume` erneut starten](#41-einen-workflow-mit--resume-erneut-starten)
+</quiz>
+
+<quiz>
+Was ist der Standardmodus für die Veröffentlichung von Workflow-Ausgaben?
+- [ ] Dateien in das Ausgabeverzeichnis kopieren
+- [x] Symbolische Links im Ausgabeverzeichnis erstellen
+- [ ] Dateien in das Ausgabeverzeichnis verschieben
+- [ ] Dateien im Ausgabeverzeichnis komprimieren
+
+Mehr erfahren: [2.3. Den Veröffentlichungsmodus auf Kopieren setzen](#23-den-veröffentlichungsmodus-auf-kopieren-setzen)
+</quiz>
+
+<quiz>
+Wie übergibst du einen Parameterwert an einen Nextflow-Workflow von der Befehlszeile?
+- [ ] `-parameter value`
+- [ ] `--parameter:value`
+- [x] `--parameter value`
+- [ ] `-p parameter=value`
+
+Mehr erfahren: [3.2. Einen Befehlszeilenparameter einrichten, um Benutzereingaben zu erfassen](#32-einen-befehlszeilenparameter-einrichten-um-benutzereingaben-zu-erfassen)
+</quiz>
+
+<quiz>
+Wie referenzierst du eine Variable innerhalb eines Nextflow-script-Blocks?
+- [ ] Mit `%variable%`-Syntax
+- [x] Mit `#!groovy ${variable}`-Syntax
+- [ ] Mit `{{variable}}`-Syntax
+- [ ] Mit `[variable]`-Syntax
+</quiz>

--- a/docs/de/docs/hello_nextflow/02_hello_channels.md
+++ b/docs/de/docs/hello_nextflow/02_hello_channels.md
@@ -1,0 +1,1429 @@
+# Teil 2: Hallo Channels
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/lJ41WMMm44M?si=xCItHLiOQWqoqBB9&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Siehe [die gesamte Playlist](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) auf dem Nextflow YouTube-Kanal.
+
+:green_book: Das Videotranskript ist [hier](./transcripts/02_hello_channels.md) verfügbar.
+///
+
+In Teil 1 dieses Kurses (Hello World) haben wir dir gezeigt, wie du einem process eine variable Eingabe übergibst, indem du die Eingabe direkt im process-Aufruf angibst: `sayHello(params.input)`.
+Das war ein bewusst vereinfachter Ansatz.
+In der Praxis hat dieser Ansatz wesentliche Einschränkungen; er funktioniert nämlich nur für sehr einfache Fälle, bei denen wir den process nur einmal mit einem einzelnen Wert ausführen möchten.
+In den meisten realistischen Workflow-Anwendungsfällen wollen wir mehrere Werte verarbeiten (z.B. experimentelle Daten für mehrere Proben), daher brauchen wir einen ausgefeilteren Weg, um Eingaben zu handhaben.
+
+Dafür sind Nextflow **channels** da.
+Channels sind Warteschlangen, die entwickelt wurden, um Eingaben effizient zu handhaben und sie von einem Schritt zum nächsten in mehrstufigen Workflows zu transportieren, während sie eingebaute Parallelität und viele zusätzliche Vorteile bieten.
+
+In diesem Teil des Kurses lernst du, wie du einen channel verwendest, um mehrere Eingaben aus verschiedenen Quellen zu handhaben.
+Du lernst auch, **Operatoren** zu verwenden, um channel-Inhalte nach Bedarf zu transformieren.
+
+??? info "Wie du von diesem Abschnitt aus beginnen kannst"
+
+    Dieser Abschnitt des Kurses setzt voraus, dass du Teil 1 des [Hello Nextflow](./index.md)-Kurses abgeschlossen hast, aber wenn du mit den dort behandelten Grundlagen vertraut bist, kannst du von hier aus starten, ohne etwas Besonderes tun zu müssen.
+
+---
+
+## 0. Aufwärmübung: `hello-channels.nf` ausführen
+
+Wir werden das Workflow-Skript `hello-channels.nf` als Ausgangspunkt verwenden.
+Es entspricht dem Skript, das durch das Durcharbeiten von Teil 1 dieses Trainingskurses erstellt wurde, außer dass wir das Ausgabeziel geändert haben:
+
+```groovy title="hello-channels.nf" linenums="37" hl_lines="3"
+output {
+    first_output {
+        path 'hello_channels'
+        mode 'copy'
+    }
+}
+```
+
+Um sicherzustellen, dass alles funktioniert, führe das Skript einmal aus, bevor du Änderungen vornimmst:
+
+```bash
+nextflow run hello-channels.nf --input 'Hello Channels!'
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [wise_jennings] DSL2 - revision: b24f4902d6
+
+    executor >  local (1)
+    [6f/824bc1] process > sayHello [100%] 1 of 1 ✔
+    ```
+
+Wie zuvor findest du die Ausgabedatei `output.txt` im Verzeichnis `results/hello_channels` (wie im `output`-Block des Workflow-Skripts oben angegeben).
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console title="results/hello_channels" hl_lines="2-3"
+    results
+    ├── hello_channels
+    │   └── output.txt
+    ├── hello_world
+    │   └── output.txt
+    └── output.txt -> /workspaces/training/hello-nextflow/work/8c/79499c11beea6e9d43605141f2817f/output.txt
+    ```
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/hello_channels/output.txt"
+    Hello Channels!
+    ```
+
+Wenn das bei dir funktioniert hat, bist du bereit, etwas über channels zu lernen.
+
+---
+
+## 1. Variable Eingaben explizit über einen channel bereitstellen
+
+Wir werden einen **channel** erstellen, um die variable Eingabe an den `sayHello()`-process zu übergeben, anstatt uns auf die implizite Handhabung zu verlassen, die gewisse Einschränkungen hat.
+
+### 1.1. Einen Eingabe-channel erstellen
+
+Es gibt verschiedene **channel factories**, die wir verwenden können, um einen channel einzurichten.
+Um die Dinge vorerst einfach zu halten, werden wir die grundlegendste channel factory namens `channel.of` verwenden, die einen channel mit einem einzelnen Wert erstellt.
+Funktional wird dies ähnlich sein wie zuvor, aber anstatt Nextflow einen channel implizit erstellen zu lassen, tun wir dies jetzt explizit.
+
+Dies ist die Codezeile, die wir verwenden werden:
+
+```console title="Syntax"
+greeting_ch = channel.of('Hello Channels!')
+```
+
+Dies erstellt einen channel namens `greeting_ch` unter Verwendung der `channel.of()` channel factory, die einen einfachen queue channel einrichtet, und lädt den String `'Hello Channels!'` als Begrüßungswert.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-pipeline-channel.svg"
+</figure>
+
+!!! note "Hinweis"
+
+    Wir wechseln vorübergehend zurück zu fest codierten Strings, anstatt einen CLI-Parameter zu verwenden, um die Lesbarkeit zu verbessern. Wir werden zurück zu CLI-Parametern wechseln, sobald wir behandelt haben, was auf Ebene des channels passiert.
+
+Füge im workflow-Block den channel factory-Code hinzu:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="4 5"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello Channels!')
+        // emit a greeting
+        sayHello(params.input)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="27"
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello(params.input)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Dies ist noch nicht funktionsfähig, da wir die Eingabe für den process-Aufruf noch nicht umgestellt haben.
+
+### 1.2. Den channel als Eingabe zum process-Aufruf hinzufügen
+
+Jetzt müssen wir unseren neu erstellten channel tatsächlich in den `sayHello()`-process-Aufruf einbinden und den CLI-Parameter ersetzen, den wir zuvor direkt bereitgestellt haben.
+
+Nimm im workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello Channels!')
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello Channels!')
+        // emit a greeting
+        sayHello(params.input)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Dies sagt Nextflow, den `sayHello`-process auf den Inhalt des `greeting_ch`-channels auszuführen.
+
+Jetzt ist unser Workflow richtig funktionsfähig; es ist das explizite Äquivalent zum Schreiben von `sayHello('Hello Channels!')`.
+
+### 1.3. Den Workflow ausführen
+
+Lass ihn laufen!
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [fabulous_crick] DSL2 - revision: 23e20f76e8
+
+    executor >  local (1)
+    [c0/4f1872] process > sayHello (1) [100%] 1 of 1 ✔
+    ```
+
+Wenn du beide Änderungen korrekt vorgenommen hast, solltest du eine erfolgreiche Ausführung erhalten.
+Du kannst das Ergebnisverzeichnis überprüfen, um dich zu vergewissern, dass das Ergebnis noch dasselbe ist wie zuvor.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/hello_channels/output.txt"
+    Hello Channels!
+    ```
+
+Wir haben also die Flexibilität unseres Workflows erhöht, während wir dasselbe Endergebnis erzielen.
+Das mag so erscheinen, als würden wir mehr Code für keinen greifbaren Nutzen schreiben, aber der Wert wird deutlich, sobald wir anfangen, mehr Eingaben zu handhaben.
+
+Als Vorschau darauf schauen wir uns noch eine Sache an, bevor wir weitermachen: einen kleinen, aber praktischen Vorteil der Verwendung eines expliziten channels zur Verwaltung von Dateneingaben.
+
+### 1.4. `view()` verwenden, um channel-Inhalte zu inspizieren
+
+Nextflow channels sind so aufgebaut, dass wir mit Operatoren auf ihre Inhalte einwirken können, was wir später in diesem Kapitel ausführlich behandeln werden.
+
+Vorerst zeigen wir dir nur, wie du einen super einfachen Operator namens [`view()`](https://www.nextflow.io/docs/latest/reference/operator.html#view) verwendest, um die Inhalte eines channels zu inspizieren.
+Du kannst `view()` als Debugging-Werkzeug betrachten, wie eine `print()`-Anweisung in Python oder deren Äquivalent in anderen Sprachen.
+
+Füge diese kleine Zeile zum workflow-Block hinzu:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello Channels!')
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="27"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello Channels!')
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Die genaue Anzahl der Leerzeichen spielt keine Rolle, solange es ein Vielfaches von 4 ist; wir zielen nur darauf ab, den Anfang der `.view()`-Anweisung mit dem `.of()`-Teil der channel-Konstruktion auszurichten.
+
+Führe jetzt den Workflow erneut aus:
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console hl_lines="7"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [scruffy_shaw] DSL2 - revision: 2ede41e14a
+
+    executor >  local (1)
+    [ef/f7e40a] sayHello (1) [100%] 1 of 1 ✔
+    Hello Channels!
+    ```
+
+Wie du sehen kannst, gibt dies die channel-Inhalte in der Konsole aus.
+Hier haben wir nur ein Element, aber wenn wir im nächsten Abschnitt anfangen, mehrere Werte in den channel zu laden, wirst du sehen, dass dies so eingestellt ist, dass ein Element pro Zeile ausgegeben wird.
+
+### Zusammenfassung
+
+Du weißt, wie du eine grundlegende channel factory verwendest, um eine Eingabe an einen process zu übergeben.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du channels verwendest, damit der Workflow über mehrere Eingabewerte iteriert.
+
+---
+
+## 2. Den Workflow so modifizieren, dass er mit mehreren Eingabewerten läuft
+
+Workflows werden typischerweise auf Stapel von Eingaben ausgeführt, die in großen Mengen verarbeitet werden sollen, daher wollen wir den Workflow aufrüsten, um mehrere Eingabewerte zu akzeptieren.
+
+### 2.1. Mehrere Begrüßungen in den Eingabe-channel laden
+
+Praktischerweise ist die `channel.of()` channel factory, die wir verwendet haben, durchaus bereit, mehr als einen Wert zu akzeptieren, daher müssen wir das überhaupt nicht ändern.
+Wir können einfach mehrere Werte in den channel laden.
+
+Machen wir sie zu `'Hello'`, `'Bonjour'` und `'Holà'`.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-pipeline-channel-multi.svg"
+</figure>
+
+_Im Diagramm wird der channel in Grün dargestellt, und die Reihenfolge der Elemente wird wie Murmeln in einer Röhre dargestellt: das zuerst geladene ist rechts, dann das zweite in der Mitte, dann das dritte links._
+
+#### 2.1.1. Weitere Begrüßungen hinzufügen
+
+Nimm vor dem workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="30" hl_lines="2"
+    // create a channel for inputs
+    greeting_ch = channel.of('Hello','Bonjour','Holà')
+                         .view()
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="30" hl_lines="2"
+    // create a channel for inputs
+    greeting_ch = channel.of('Hello Channels')
+                         .view()
+    ```
+
+Die Dokumentation sagt uns, dass das funktionieren sollte. Kann es wirklich so einfach sein?
+
+#### 2.1.2. Den Befehl ausführen und die Log-Ausgabe betrachten
+
+Lass uns es versuchen.
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console hl_lines="6"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [amazing_crick] DSL2 - revision: 59a9a5888a
+
+    executor >  local (3)
+    [f4/c9962c] process > sayHello (1) [100%] 3 of 3 ✔
+    Hello
+    Bonjour
+    Holà
+    ```
+
+Es scheint tatsächlich gut gelaufen zu sein.
+Der Ausführungsmonitor zeigt, dass `3 von 3` Aufrufe für den `sayHello`-process gemacht wurden, und wir sehen die drei Begrüßungen, die durch die `view()`-Anweisung aufgelistet werden, eine pro Zeile wie versprochen.
+
+Allerdings gibt es im Ergebnisverzeichnis immer noch nur eine Ausgabe:
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console title="results/hello_channels" hl_lines="3"
+    results
+    ├── hello_channels
+    │   └── output.txt
+    ├── hello_world
+    │   └── output.txt
+    └── output.txt -> /workspaces/training/hello-nextflow/work/8c/79499c11beea6e9d43605141f2817f/output.txt
+    ```
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/hello_channels/output.txt"
+    Holà
+    ```
+
+Du solltest eine der drei Begrüßungen darin sehen, aber die, die du bekommen hast, könnte anders sein als hier gezeigt.
+Kannst du dir vorstellen, warum das so sein könnte?
+
+Wenn wir zurück auf den Ausführungsmonitor schauen, hat er uns nur einen Unterverzeichnispfad gegeben (`f4/c9962c`).
+Lass uns dort hineinschauen.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console hl_lines="9"
+    work/f4/c9962ce91ef87480babcb86b2b9042/
+    ├── .command.begin
+    ├── .command.err
+    ├── .command.log
+    ├── .command.out
+    ├── .command.run
+    ├── .command.sh
+    ├── .exitcode
+    └── output.txt
+    ```
+
+??? abstract "Dateiinhalte"
+
+    ```console title="work/f4/c9962ce91ef87480babcb86b2b9042/output.txt"
+    Hello
+    ```
+
+Das ist nicht einmal dieselbe Begrüßung, die wir im Ergebnisverzeichnis bekommen haben! Was geht hier vor?
+
+An diesem Punkt müssen wir dir sagen, dass das ANSI-Logging-System standardmäßig das Logging von mehreren Aufrufen desselben process auf derselben Zeile schreibt.
+Also landen die Statusmeldungen von allen drei Aufrufen des sayHello()-process an derselben Stelle.
+
+Glücklicherweise können wir dieses Verhalten deaktivieren, um die vollständige Liste der process-Aufrufe zu sehen.
+
+#### 2.1.3. Den Befehl erneut mit der Option `-ansi-log false` ausführen
+
+Um das Logging zu erweitern und eine Zeile pro process-Aufruf anzuzeigen, füge `-ansi-log false` zum Befehl hinzu.
+
+```bash
+nextflow run hello-channels.nf -ansi-log false
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W  ~  version 25.10.2
+    Launching `hello-channels.nf` [desperate_monod] DSL2 - revision: 59a9a5888a
+    Hello
+    Bonjour
+    Holà
+    [23/871c7e] Submitted process > sayHello (2)
+    [7f/21e2c2] Submitted process > sayHello (1)
+    [f4/ea10a6] Submitted process > sayHello (3)
+    ```
+
+Diesmal sehen wir alle drei process-Ausführungen und ihre zugehörigen work-Unterverzeichnisse in der Ausgabe aufgelistet.
+
+Das ist viel besser, zumindest für einen einfachen Workflow.
+Für einen komplexen Workflow oder eine große Anzahl von Eingaben würde die vollständige Liste, die im Terminal ausgegeben wird, etwas überwältigend werden.
+Deshalb ist `-ansi-log false` nicht das Standardverhalten.
+
+!!! tip "Tipp"
+
+    Die Art und Weise, wie der Status gemeldet wird, ist zwischen den beiden Logging-Modi etwas unterschiedlich.
+    Im komprimierten Modus meldet Nextflow, ob Aufrufe erfolgreich abgeschlossen wurden oder nicht.
+    In diesem erweiterten Modus wird nur gemeldet, dass sie eingereicht wurden.
+
+Wie auch immer, jetzt da wir die Unterverzeichnisse jedes process-Aufrufs haben, können wir nach ihren Logs und Ausgaben suchen.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console
+    work/23/871c7ec3642a898ecd5e6090d21300/
+    ├── .command.begin
+    ├── .command.err
+    ├── .command.log
+    ├── .command.out
+    ├── .command.run
+    ├── .command.sh
+    ├── .exitcode
+    └── output.txt
+    ```
+
+    ```console
+    work/7f/21e2c2f3cc8833ef3858b236e5575c/
+    ├── .command.begin
+    ├── .command.err
+    ├── .command.log
+    ├── .command.out
+    ├── .command.run
+    ├── .command.sh
+    ├── .exitcode
+    └── output.txt
+    ```
+
+    ```console
+    work/f4/ea10a680d5687596d3eaa3fcf69272/
+    ├── .command.begin
+    ├── .command.err
+    ├── .command.log
+    ├── .command.out
+    ├── .command.run
+    ├── .command.sh
+    ├── .exitcode
+    └── output.txt
+    ```
+
+??? abstract "Dateiinhalte"
+
+    ```txt title="work/23/871c7ec3642a898ecd5e6090d21300/output.txt"
+    Bonjour
+    ```
+
+    ```txt title="work/7f/21e2c2f3cc8833ef3858b236e5575c/output.txt"
+    Hello
+    ```
+
+    ```txt title="work/f4/ea10a680d5687596d3eaa3fcf69272/output.txt"
+    Holà
+    ```
+
+Dies zeigt, dass alle drei processes erfolgreich ausgeführt wurden (juhu).
+
+Allerdings haben wir immer noch das Problem, dass es nur eine Ausgabedatei im Ergebnisverzeichnis gibt.
+
+Du erinnerst dich vielleicht, dass wir den Ausgabedateinamen für den `sayHello`-process fest codiert haben, sodass alle drei Aufrufe eine Datei namens `output.txt` produziert haben.
+
+Solange die Ausgabedateien in den work-Unterverzeichnissen bleiben, isoliert von den anderen processes, ist das in Ordnung.
+Aber wenn sie in dasselbe Ergebnisverzeichnis veröffentlicht werden, wird die, die zuerst dort kopiert wurde, von der nächsten überschrieben, und so weiter.
+
+### 2.2. Sicherstellen, dass die Ausgabedateinamen eindeutig sind
+
+Wir können weiterhin alle Ausgaben in dasselbe Ergebnisverzeichnis veröffentlichen, aber wir müssen sicherstellen, dass sie eindeutige Namen haben werden.
+Genauer gesagt müssen wir den ersten process so modifizieren, dass er einen Dateinamen dynamisch generiert, sodass die endgültigen Dateinamen eindeutig sein werden.
+
+Wie machen wir also die Dateinamen eindeutig?
+Ein gängiger Weg, das zu tun, ist, ein eindeutiges Stück Metadaten aus den Eingaben (die vom Eingabe-channel empfangen wurden) als Teil des Ausgabedateinamens zu verwenden.
+Hier werden wir der Einfachheit halber nur die Begrüßung selbst verwenden, da sie nur ein kurzer String ist, und sie dem Basis-Ausgabedateinamen voranstellen.
+
+#### 2.2.1. Einen dynamischen Ausgabedateinamen konstruieren
+
+Nimm im process-Block die folgenden Codeänderungen vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="6" hl_lines="7 11"
+    process sayHello {
+
+        input:
+        val greeting
+
+        output:
+        path "${greeting}-output.txt"
+
+        script:
+        """
+        echo '${greeting}' > '${greeting}-output.txt'
+        """
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="6" hl_lines="7 11"
+    process sayHello {
+
+        input:
+        val greeting
+
+        output:
+        path 'output.txt'
+
+        script:
+        """
+        echo '${greeting}' > output.txt
+        """
+    }
+    ```
+
+Stelle sicher, dass du `output.txt` sowohl in der Ausgabedefinition als auch im `script:`-Befehlsblock ersetzt.
+
+!!! tip "Tipp"
+
+    In der Ausgabedefinition MUSST du doppelte Anführungszeichen um den Ausgabedateinamensausdruck verwenden (NICHT einfache Anführungszeichen), sonst schlägt es fehl.
+
+Dies sollte jedes Mal einen eindeutigen Ausgabedateinamen produzieren, wenn der process aufgerufen wird, sodass er von den Ausgaben anderer Aufrufe desselben process im Ausgabeverzeichnis unterschieden werden kann.
+
+#### 2.2.2. Den Workflow ausführen
+
+Lass ihn laufen. Beachte, dass wir wieder mit den Standard-ANSI-Log-Einstellungen ausführen.
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [sharp_minsky] DSL2 - revision: 16a291febe
+
+    executor >  local (3)
+    [e8/33ee64] sayHello (2) [100%] 3 of 3 ✔
+    Hello
+    Bonjour
+    Holà
+    ```
+
+Zurück in der Zusammenfassungsansicht wird die Ausgabe wieder auf einer Zeile zusammengefasst.
+Schau in das `results`-Verzeichnis, um zu sehen, ob alle Ausgabebegrüßungen da sind.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console
+    results/hello_channels/
+    ├── Bonjour-output.txt
+    ├── Hello-output.txt
+    ├── Holà-output.txt
+    └── output.txt
+    ```
+
+Ja! Und sie haben jeweils die erwarteten Inhalte.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="Bonjour-output.txt"
+    Bonjour
+    ```
+
+    ```console title="Hello-output.txt"
+    Hello
+    ```
+
+    ```console title="Holà-output.txt"
+    Holà
+    ```
+
+Erfolg! Jetzt können wir so viele Begrüßungen hinzufügen, wie wir möchten, ohne uns Sorgen zu machen, dass Ausgabedateien überschrieben werden.
+
+!!! tip "Tipp"
+
+    In der Praxis ist das Benennen von Dateien basierend auf den Eingabedaten selbst fast immer unpraktisch.
+    Der bessere Weg, dynamische Dateinamen zu generieren, ist, Metadaten zusammen mit den Eingabedateien an einen process zu übergeben.
+    Die Metadaten werden typischerweise über ein 'Sample Sheet' oder Äquivalente bereitgestellt.
+    Du wirst später in deinem Nextflow-Training lernen, wie du das machst (siehe [Metadaten-Side Quest](../side_quests/metadata.md)).
+
+### Zusammenfassung
+
+Du weißt, wie du mehrere Eingabeelemente durch einen channel führst.
+
+### Was kommt als Nächstes?
+
+Lerne, einen Operator zu verwenden, um die Inhalte eines channels zu transformieren.
+
+---
+
+## 3. Mehrere Eingaben über ein Array bereitstellen
+
+Wir haben dir gerade gezeigt, wie du mehrere Eingabeelemente handhabst, die direkt in der channel factory fest codiert waren.
+Was ist, wenn wir diese mehreren Eingaben auf eine andere Weise bereitstellen wollten?
+
+Stell dir zum Beispiel vor, wir richten eine Eingabevariable ein, die ein Array von Elementen enthält wie dieses:
+
+`greetings_array = ['Hello','Bonjour','Holà']`
+
+Können wir das in unseren Ausgabe-channel laden und erwarten, dass es funktioniert?
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-pipeline-multi-inputs-array.svg"
+</figure>
+
+Lass uns das herausfinden.
+
+### 3.1. Ein Array von Werten als Eingabe für den channel bereitstellen
+
+Der gesunde Menschenverstand legt nahe, dass wir einfach ein Array von Werten anstelle eines einzelnen Wertes übergeben können sollten.
+Lass uns es versuchen; wir müssen die Eingabevariable einrichten und sie in die channel factory laden.
+
+#### 3.1.1. Die Eingabevariable einrichten
+
+Lass uns die `greetings_array`-Variable, die wir uns gerade vorgestellt haben, Realität werden lassen, indem wir sie zum workflow-Block hinzufügen:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="4 5"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello','Bonjour','Holà')
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="27"
+    workflow {
+
+        main:
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello','Bonjour','Holà')
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Dies ist noch nicht funktionsfähig, wir haben nur eine Deklaration für das Array hinzugefügt.
+
+#### 3.1.2. Das Array von Begrüßungen als Eingabe für die channel factory setzen
+
+Jetzt werden wir die Werte `'Hello','Bonjour','Holà'`, die derzeit in der channel factory fest codiert sind, durch das `greetings_array` ersetzen, das wir gerade erstellt haben.
+
+Nimm im workflow-Block die folgende Änderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of('Hello','Bonjour','Holà')
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Dies sollte jetzt funktionsfähig sein.
+
+#### 3.1.3. Den Workflow ausführen
+
+Lass uns versuchen, ihn auszuführen:
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? failure "Befehlsausgabe"
+
+    ```console hl_lines="7 11 16"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [friendly_koch] DSL2 - revision: 97256837a7
+
+    executor >  local (1)
+    [a8/1f6ead] sayHello (1) | 0 of 1
+    [Hello, Bonjour, Holà]
+    ERROR ~ Error executing process > 'sayHello (1)'
+
+    Caused by:
+      Missing output file(s) `[Hello, Bonjour, Holà]-output.txt` expected by process `sayHello (1)`
+
+
+    Command executed:
+
+      echo '[Hello, Bonjour, Holà]' > '[Hello, Bonjour, Holà]-output.txt'
+
+    Command exit status:
+      0
+
+    Command output:
+      (empty)
+
+    Work dir:
+      /workspaces/training/hello-nextflow/work/a8/1f6ead5f3fa30a3c508e2e7cf83ffb
+
+    Tip: you can replicate the issue by changing to the process work dir and entering the command `bash .command.run`
+
+    -- Check '.nextflow.log' file for details
+    ```
+
+Oh nein! Es gibt einen Fehler!
+
+Schau dir die Ausgabe von `view()` und die Fehlermeldungen an.
+
+Es sieht so aus, als hätte Nextflow versucht, einen einzelnen process-Aufruf auszuführen, wobei `[Hello, Bonjour, Holà]` als Stringwert verwendet wurde, anstatt die drei Strings im Array als separate Werte zu verwenden.
+
+Es ist also die 'Verpackung', die das Problem verursacht.
+Wie bringen wir Nextflow dazu, das Array zu entpacken und die einzelnen Strings in den channel zu laden?
+
+### 3.2. Einen Operator verwenden, um channel-Inhalte zu transformieren
+
+Hier kommen **[Operatoren](https://www.nextflow.io/docs/latest/reference/operator.html)** ins Spiel.
+Du hast bereits den `.view()`-Operator verwendet, der nur hineinschaut, was drin ist.
+Jetzt werden wir uns Operatoren ansehen, die es uns ermöglichen, auf die Inhalte eines channels einzuwirken.
+
+Wenn du durch die [Liste der Operatoren](https://www.nextflow.io/docs/latest/reference/operator.html) in der Nextflow-Dokumentation blätterst, wirst du [`flatten()`](https://www.nextflow.io/docs/latest/reference/operator.html#flatten) finden, das genau das tut, was wir brauchen: den Inhalt eines Arrays entpacken und sie als einzelne Elemente ausgeben.
+
+#### 3.2.1. Den `flatten()`-Operator hinzufügen
+
+Um den `flatten()`-Operator auf unseren Eingabe-channel anzuwenden, hängen wir ihn an die channel factory-Deklaration an.
+
+Nimm im workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="9"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view()
+                             .flatten()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="27"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Hier haben wir den Operator für die Lesbarkeit in der nächsten Zeile hinzugefügt, aber du kannst Operatoren auch auf derselben Zeile wie die channel factory hinzufügen, wenn du möchtest, so:
+`greeting_ch = channel.of(greetings_array).view().flatten()`
+
+#### 3.2.2. Die `view()`-Anweisung(en) verfeinern
+
+Wir könnten dies jetzt sofort ausführen, um zu testen, ob es funktioniert, aber während wir dabei sind, werden wir verfeinern, wie wir die channel-Inhalte inspizieren.
+
+Wir wollen den Inhalt vor und nach der Anwendung des `flatten()`-Operators vergleichen können, also werden wir ein zweites hinzufügen, UND wir werden etwas Code hinzufügen, um sie in der Ausgabe deutlicher zu beschriften.
+
+Nimm im workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="8-10"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view { greeting -> "Before flatten: $greeting" }
+                             .flatten()
+                             .view { greeting -> "After flatten: $greeting" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="8-9"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view()
+                             .flatten()
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Du siehst, wir haben eine zweite `.view`-Anweisung hinzugefügt, und für jede von ihnen haben wir die leeren Klammern (`()`) durch geschweifte Klammern mit etwas Code ersetzt, wie `{ greeting -> "Before flatten: $greeting" }`.
+
+Diese werden _closures_ genannt. Der Code, den sie enthalten, wird für jedes Element im channel ausgeführt.
+Wir definieren eine temporäre Variable für den inneren Wert, hier `greeting` genannt (aber es könnte ein beliebiger Name sein), die nur innerhalb des Gültigkeitsbereichs dieser closure verwendet wird.
+
+In diesem Beispiel repräsentiert `$greeting` jedes einzelne Element, das in den channel geladen wurde.
+Dies führt zu sauber beschrifteter Konsolenausgabe.
+
+!!! info
+
+    In einigen Pipelines siehst du möglicherweise eine spezielle Variable namens `$it`, die innerhalb von Operator-closures verwendet wird.
+    Dies ist eine _implizite_ Variable, die einen Kurzform-Zugriff auf die innere Variable ermöglicht,
+    ohne sie mit einem `->` definieren zu müssen.
+
+    Wir bevorzugen die explizite Form, um die Klarheit des Codes zu unterstützen. Die `$it`-Syntax wird nicht empfohlen und wird langsam aus der Nextflow-Sprache auslaufen.
+
+#### 3.2.3. Den Workflow ausführen
+
+Schließlich kannst du versuchen, den Workflow erneut auszuführen!
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console hl_lines="7-10"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [sleepy_gutenberg] DSL2 - revision: 1db4f760ee
+
+    executor >  local (3)
+    [b1/6a1e15] sayHello (2) [100%] 3 of 3 ✔
+    Before flatten: [Hello, Bonjour, Holà]
+    After flatten: Hello
+    After flatten: Bonjour
+    After flatten: Holà
+    ```
+
+Diesmal funktioniert es UND gibt uns den zusätzlichen Einblick, wie die Inhalte des channels vor und nach der Ausführung des `flatten()`-Operators aussehen.
+
+- Du siehst, dass wir eine einzelne `Before flatten:`-Anweisung bekommen, weil zu diesem Zeitpunkt der channel ein Element enthält, das ursprüngliche Array.
+  Dann bekommen wir drei separate `After flatten:`-Anweisungen, eine für jede Begrüßung, die jetzt einzelne Elemente im channel sind.
+
+Wichtig ist, dass dies bedeutet, dass jedes Element jetzt separat vom Workflow verarbeitet werden kann.
+
+!!! tip "Tipp"
+
+    Es ist technisch möglich, dieselben Ergebnisse zu erzielen, indem man eine andere channel factory verwendet, [`channel.fromList`](https://nextflow.io/docs/latest/reference/channel.html#fromlist), die einen impliziten Mapping-Schritt in ihrer Operation enthält.
+    Hier haben wir uns entschieden, das nicht zu verwenden, um die Verwendung eines Operators an einem einfachen Anwendungsfall zu demonstrieren.
+
+### Zusammenfassung
+
+Du weißt, wie du einen Operator wie `flatten()` verwendest, um die Inhalte eines channels zu transformieren, und wie du den `view()`-Operator verwendest, um channel-Inhalte vor und nach der Anwendung eines Operators zu inspizieren.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du den Workflow so einrichtest, dass er eine Datei als Quelle von Eingabewerten verwendet.
+
+---
+
+## 4. Eingabewerte aus einer CSV-Datei lesen
+
+Realistischerweise werden wir selten, wenn überhaupt, von einem Array von Werten ausgehen.
+Höchstwahrscheinlich haben wir eine oder mehrere Dateien, die die zu verarbeitenden Daten enthalten, in irgendeiner Art von strukturiertem Format.
+
+Wir haben eine CSV-Datei namens `greetings.csv` vorbereitet, die mehrere Eingabebegrüßungen enthält und die Art von tabellarischen Daten nachahmt, die du in einer echten Datenanalyse verarbeiten möchtest, gespeichert unter `data/`.
+(Die Zahlen sind nicht bedeutsam, sie sind nur zu Illustrationszwecken da.)
+
+```csv title="data/greetings.csv" linenums="1"
+Hello,English,123
+Bonjour,French,456
+Holà,Spanish,789
+```
+
+Unsere nächste Aufgabe ist es, unseren Workflow anzupassen, um die Werte aus dieser Datei einzulesen.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-pipeline-multi-inputs-csv.svg"
+</figure>
+
+Lass uns sehen, wie wir das bewerkstelligen können.
+
+### 4.1. Das Skript so modifizieren, dass es eine CSV-Datei als Quelle von Begrüßungen erwartet
+
+Um loszulegen, müssen wir zwei wichtige Änderungen am Skript vornehmen:
+
+- Den Eingabeparameter so umstellen, dass er auf die CSV-Datei zeigt
+- Die channel factory auf eine umstellen, die für das Handhaben einer Datei ausgelegt ist
+
+#### 4.1.1. Den Eingabeparameter so umstellen, dass er auf die CSV-Datei zeigt
+
+Erinnerst du dich an den `params.input`-Parameter, den wir in Teil 1 eingerichtet haben?
+Wir werden ihn aktualisieren, um auf die CSV-Datei zu zeigen, die unsere Begrüßungen enthält.
+
+Nimm die folgende Änderung an der Parameterdeklaration vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="20" hl_lines="5"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path = 'data/greetings.csv'
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="20" hl_lines="5"
+    /*
+     * Pipeline parameters
+     */
+    input: String = 'Holà mundo!'
+    ```
+
+Dies setzt voraus, dass die Datei am selben Ort wie der Workflow-Code liegt.
+Du wirst später auf deiner Nextflow-Reise lernen, wie du mit anderen Datenspeicherorten umgehst.
+
+#### 4.1.2. Zu einer channel factory wechseln, die für das Handhaben einer Datei ausgelegt ist
+
+Da wir jetzt eine Datei anstelle von einfachen Strings als Eingabe verwenden wollen, können wir die `channel.of()` channel factory von vorher nicht verwenden.
+Wir müssen zu einer neuen channel factory wechseln, [`channel.fromPath()`](https://www.nextflow.io/docs/latest/reference/channel.html#channel-path), die einige eingebaute Funktionalitäten für das Handhaben von Dateipfaden hat.
+
+Nimm im workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="4-8"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                             .view { greeting -> "Before flatten: $greeting" }
+                             // .flatten()
+                             // .view { greeting -> "After flatten: $greeting" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="4-8"
+    workflow {
+
+        main:
+        // declare an array of input greetings
+        greetings_array = ['Hello','Bonjour','Holà']
+        // create a channel for inputs
+        greeting_ch = channel.of(greetings_array)
+                             .view { greeting -> "Before flatten: $greeting" }
+                             .flatten()
+                             .view { greeting -> "After flatten: $greeting" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Du wirst bemerken, dass wir die channel-Eingabe zurück zu `param.input` gewechselt und die `greetings_array`-Deklaration gelöscht haben, da wir sie nicht mehr brauchen werden.
+Wir haben auch `flatten()` und die zweite `view()`-Anweisung auskommentiert.
+
+#### 4.1.3. Den Workflow ausführen
+
+Lass uns versuchen, den Workflow mit der neuen channel factory und der Eingabedatei auszuführen.
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? failure "Befehlsausgabe"
+
+    ```console hl_lines="5 6 9 14"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [peaceful_poisson] DSL2 - revision: a286c08ad5
+
+    [-        ] sayHello [  0%] 0 of 1
+    Before flatten: /workspaces/training/hello-nextflow/data/greetings.csv
+    ERROR ~ Error executing process > 'sayHello (1)'
+
+    Caused by:
+      File `/workspaces/training/hello-nextflow/data/greetings.csv-output.txt` is outside the scope of the process work directory: /workspaces/training/hello-nextflow/work/30/e610cb4ea5ae8693f456ac3329c92f
+
+
+    Command executed:
+
+      echo '/workspaces/training/hello-nextflow/data/greetings.csv' > '/workspaces/training/hello-nextflow/data/greetings.csv-output.txt'
+
+    Command exit status:
+      -
+
+    Command output:
+      (empty)
+
+    Work dir:
+      /workspaces/training/hello-nextflow/work/30/e610cb4ea5ae8693f456ac3329c92f
+
+    Tip: when you have fixed the problem you can continue the execution adding the option `-resume` to the run command line
+
+    -- Check '.nextflow.log' file for details
+    ```
+
+Oh nein, es funktioniert nicht. Schau dir den Anfang der Konsolenausgabe und die Fehlermeldung an.
+Der Teil `Command executed:` ist hier besonders hilfreich.
+
+Das sieht vielleicht ein bisschen vertraut aus.
+Es sieht so aus, als hätte Nextflow versucht, einen einzelnen process-Aufruf auszuführen, wobei der Dateipfad selbst als Stringwert verwendet wurde.
+Also hat es den Dateipfad korrekt aufgelöst, aber es hat nicht wirklich seinen Inhalt geparst, was wir wollten.
+
+Wie bringen wir Nextflow dazu, die Datei zu öffnen und ihren Inhalt in den channel zu laden?
+
+Klingt so, als bräuchten wir einen weiteren [Operator](https://www.nextflow.io/docs/latest/reference/operator.html)!
+
+### 4.2. Den `splitCsv()`-Operator verwenden, um die Datei zu parsen
+
+Wenn wir wieder durch die Liste der Operatoren schauen, finden wir [`splitCsv()`](https://www.nextflow.io/docs/latest/reference/operator.html#splitCsv), das dafür ausgelegt ist, CSV-formatierten Text zu parsen und zu teilen.
+
+#### 4.2.1. `splitCsv()` auf den channel anwenden
+
+Um den Operator anzuwenden, hängen wir ihn wie zuvor an die channel factory-Zeile an.
+
+Nimm im workflow-Block die folgende Codeänderung vor, um `flatten()` durch `splitcsv()` zu ersetzen (nicht auskommentiert):
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="6-8"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                             .view { csv -> "Before splitCsv: $csv" }
+                             .splitCsv()
+                             .view { csv -> "After splitCsv: $csv" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="6-8"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                             .view { greeting -> "Before flatten: $greeting" }
+                             // .flatten()
+                             // .view { greeting -> "After flatten: $greeting" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Wie du sehen kannst, haben wir auch die vorher/nachher `view()`-Anweisungen aktualisiert.
+Technisch hätten wir denselben Variablennamen (`greeting`) verwenden können, aber wir haben ihn auf etwas Passenderes (`csv`) aktualisiert, um den Code für andere lesbarer zu machen.
+
+#### 4.2.2. Den Workflow erneut ausführen
+
+Lass uns versuchen, den Workflow mit der hinzugefügten CSV-Parsing-Logik auszuführen.
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? failure "Befehlsausgabe"
+
+    ```console hl_lines="7-11 14 19"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [insane_fermat] DSL2 - revision: 8e62fcbeb1
+
+    executor >  local (3)
+    [24/76da2f] sayHello (2) [  0%] 0 of 3 ✘
+    Before splitCsv: /workspaces/training/hello-nextflow/data/greetings.csv
+    After splitCsv: [Hello, English, 123]
+    After splitCsv: [Bonjour, French, 456]
+    After splitCsv: [Holà, Spanish, 789]
+    ERROR ~ Error executing process > 'sayHello (2)'
+
+    Caused by:
+      Missing output file(s) `[Bonjour, French, 456]-output.txt` expected by process `sayHello (2)`
+
+
+    Command executed:
+
+      echo '[Bonjour, French, 456]' > '[Bonjour, French, 456]-output.txt'
+
+    Command exit status:
+      0
+
+    Command output:
+      (empty)
+
+    Work dir:
+      /workspaces/training/hello-nextflow/work/24/76da2fcc4876b61632749f99e26a50
+
+    Tip: you can try to figure out what's wrong by changing to the process work dir and showing the script file named `.command.sh`
+
+    -- Check '.nextflow.log' file for details
+    ```
+
+Interessanterweise schlägt dies auch fehl, aber mit einem anderen Fehler.
+Diesmal hat Nextflow den Inhalt der Datei geparst (juhu!), aber es hat jede Zeile als Array geladen, und jedes Array ist ein Element im channel.
+
+Wir müssen ihm sagen, dass es nur die erste Spalte in jeder Zeile nehmen soll.
+Wie entpacken wir das also?
+
+Wir haben zuvor `flatten()` verwendet, um die Inhalte eines channels zu entpacken, aber das würde hier nicht funktionieren, weil flatten _alles_ entpackt (versuche es gerne, wenn du es selbst sehen möchtest).
+
+Stattdessen werden wir einen anderen Operator namens `map()` verwenden, der wirklich nützlich ist und in Nextflow-Pipelines häufig vorkommt.
+
+### 4.3. Den `map()`-Operator verwenden, um die Begrüßungen zu extrahieren
+
+Der [`map()`](https://www.nextflow.io/docs/latest/reference/operator.html#map)-Operator ist ein sehr praktisches kleines Werkzeug, das es uns ermöglicht, alle Arten von Mappings auf die Inhalte eines channels durchzuführen.
+
+In diesem Fall werden wir ihn verwenden, um das eine Element zu extrahieren, das wir aus jeder Zeile in unserer Datendatei wollen.
+So sieht die Syntax aus:
+
+```groovy title="Syntax"
+.map { row -> row[0] }
+```
+
+Das bedeutet 'für jede Zeile im channel, nimm das 0. (erste) Element, das sie enthält'.
+
+Also wenden wir das auf unser CSV-Parsing an.
+
+#### 4.3.1. `map()` auf den channel anwenden
+
+Nimm im workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="9 10"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                             .view { csv -> "Before splitCsv: $csv" }
+                             .splitCsv()
+                             .view { csv -> "After splitCsv: $csv" }
+                             .map { item -> item[0] }
+                             .view { csv -> "After map: $csv" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-channels.nf" linenums="27"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                             .view { csv -> "Before splitCsv: $csv" }
+                             .splitCsv()
+                             .view { csv -> "After splitCsv: $csv" }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Du siehst, wir haben einen weiteren `view()`-Aufruf hinzugefügt, um zu bestätigen, dass der Operator das tut, was wir erwarten.
+
+#### 4.3.2. Den Workflow ausführen
+
+Lass uns das noch einmal ausführen:
+
+```bash
+nextflow run hello-channels.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-channels.nf` [focused_volhard] DSL2 - revision: de435e45be
+
+    executor >  local (3)
+    [54/6eebe3] sayHello (3) [100%] 3 of 3 ✔
+    Before splitCsv: /workspaces/training/hello-nextflow/data/greetings.csv
+    After splitCsv: [Hello, English, 123]
+    After splitCsv: [Bonjour, French, 456]
+    After splitCsv: [Holà, Spanish, 789]
+    After map: Hello
+    After map: Bonjour
+    After map: Holà
+    ```
+
+Diesmal sollte es ohne Fehler laufen.
+
+Wenn du dir die Ausgabe der `view()`-Anweisungen anschaust, siehst du Folgendes:
+
+- Eine einzelne `Before splitCsv:`-Anweisung: zu diesem Zeitpunkt enthält der channel ein Element, den ursprünglichen Dateipfad.
+- Drei separate `After splitCsv:`-Anweisungen: eine für jede Begrüßung, aber jede ist in einem Array enthalten, das dieser Zeile in der Datei entspricht.
+- Drei separate `After map:`-Anweisungen: eine für jede Begrüßung, die jetzt einzelne Elemente im channel sind.
+
+Beachte, dass die Zeilen in deiner Ausgabe in einer anderen Reihenfolge erscheinen können.
+
+Du kannst auch die Ausgabedateien ansehen, um zu überprüfen, dass jede Begrüßung korrekt extrahiert und durch den Workflow verarbeitet wurde.
+
+Wir haben dasselbe Ergebnis wie zuvor erzielt, aber jetzt haben wir viel mehr Flexibilität, um weitere Elemente zum channel von Begrüßungen hinzuzufügen, die wir verarbeiten möchten, indem wir eine Eingabedatei modifizieren, ohne Code zu ändern.
+Du wirst in einem späteren Training anspruchsvollere Ansätze für das Handhaben komplexer Eingaben lernen.
+
+### Zusammenfassung
+
+Du weißt, wie du den `.fromPath()` channel-Konstruktor und die Operatoren `splitCsv()` und `map()` verwendest, um eine Datei mit Eingabewerten einzulesen und sie angemessen zu handhaben.
+
+Allgemeiner hast du ein grundlegendes Verständnis davon, wie Nextflow **channels** verwendet, um Eingaben für processes zu verwalten, und **Operatoren**, um ihre Inhalte zu transformieren.
+
+### Was kommt als Nächstes?
+
+Mach eine große Pause, du hast in diesem Teil hart gearbeitet!
+
+Wenn du bereit bist, gehe zu [**Teil 3: Hallo Workflow**](./03_hello_workflow.md), um zu lernen, wie du weitere Schritte hinzufügst und sie zu einem richtigen Workflow verbindest.
+
+---
+
+## Quiz
+
+<quiz>
+Was ist ein channel in Nextflow?
+- [ ] Eine Dateipfadspezifikation
+- [ ] Eine process-Definition
+- [x] Eine warteschlangenartige Struktur zum Übergeben von Daten zwischen processes
+- [ ] Eine Konfigurationseinstellung
+
+Mehr erfahren: [1.1. Einen Eingabe-channel erstellen](#11-einen-eingabe-channel-erstellen)
+</quiz>
+
+<quiz>
+Was wird dieser Code ausgeben?
+
+```groovy
+channel.of('Hello', 'Bonjour', 'Hola')
+    .view()
+```
+
+- [ ] `['Hello', 'Bonjour', 'Hola']` (eine einzelne Liste)
+- [x] Jedes Element in einer separaten Zeile: `Hello`, `Bonjour`, `Hola`
+- [ ] Nichts (channels drucken standardmäßig nicht)
+- [ ] Einen Fehler (ungültige Syntax)
+
+Mehr erfahren: [1.1. Einen Eingabe-channel erstellen](#11-einen-eingabe-channel-erstellen)
+</quiz>
+
+<quiz>
+Wenn ein channel mehrere Werte enthält, wie handhabt Nextflow die process-Ausführung?
+- [ ] Der process läuft einmal mit allen Werten
+- [x] Der process läuft einmal für jeden Wert im channel
+- [ ] Der process läuft nur mit dem ersten Wert
+- [ ] Der process läuft nur mit dem letzten Wert
+
+Mehr erfahren: [2. Den Workflow so modifizieren, dass er mit mehreren Eingabewerten läuft](#2-den-workflow-so-modifizieren-dass-er-mit-mehreren-eingabewerten-lauft)
+</quiz>
+
+<quiz>
+Was macht der `flatten()`-Operator?
+- [ ] Kombiniert mehrere channels zu einem
+- [ ] Sortiert channel-Elemente
+- [x] Entpackt Arrays in einzelne Elemente
+- [ ] Entfernt doppelte Elemente
+
+Mehr erfahren: [3.2.1. Den `flatten()`-Operator hinzufügen](#321-den-flatten-operator-hinzufugen)
+</quiz>
+
+<quiz>
+Was ist der Zweck des `view()`-Operators?
+- [ ] Channel-Inhalte zu filtern
+- [ ] Channel-Elemente zu transformieren
+- [x] Channel-Inhalte zu inspizieren und zu debuggen
+- [ ] Channel-Inhalte in eine Datei zu speichern
+
+Mehr erfahren: [1.4. `view()` verwenden, um channel-Inhalte zu inspizieren](#14-view-verwenden-um-channel-inhalte-zu-inspizieren)
+</quiz>
+
+<quiz>
+Was macht `splitCsv()`?
+- [ ] Erstellt eine CSV-Datei aus channel-Inhalten
+- [ ] Teilt einen String durch Kommas
+- [x] Parst eine CSV-Datei in Arrays, die jede Zeile repräsentieren
+- [ ] Führt mehrere CSV-Dateien zusammen
+
+Mehr erfahren: [4.2. Den `splitCsv()`-Operator verwenden, um die Datei zu parsen](#42-den-splitcsv-operator-verwenden-um-die-datei-zu-parsen)
+</quiz>
+
+<quiz>
+Was ist der Zweck des `map()`-Operators?
+- [ ] Elemente aus einem channel zu filtern
+- [ ] Mehrere channels zu kombinieren
+- [x] Jedes Element in einem channel zu transformieren
+- [ ] Elemente in einem channel zu zählen
+
+Mehr erfahren: [4.3. Den `map()`-Operator verwenden, um die Begrüßungen zu extrahieren](#43-den-map-operator-verwenden-um-die-begrussungen-zu-extrahieren)
+</quiz>
+
+<quiz>
+Warum ist es wichtig, dynamische Ausgabedateinamen zu verwenden, wenn mehrere Eingaben verarbeitet werden?
+- [ ] Um die Leistung zu verbessern
+- [ ] Um Speicherplatz zu reduzieren
+- [x] Um zu verhindern, dass sich Ausgabedateien gegenseitig überschreiben
+- [ ] Um die resume-Funktionalität zu aktivieren
+
+Mehr erfahren: [2.2. Sicherstellen, dass die Ausgabedateinamen eindeutig sind](#22-sicherstellen-dass-die-ausgabedateinamen-eindeutig-sind)
+</quiz>

--- a/docs/de/docs/hello_nextflow/03_hello_workflow.md
+++ b/docs/de/docs/hello_nextflow/03_hello_workflow.md
@@ -1,0 +1,1170 @@
+# Teil 3: Hallo Workflow
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/zJP7cUYPEbA?si=Irl9nAQniDyICp2b&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Siehe [die gesamte Playlist](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) auf dem Nextflow YouTube-Kanal.
+
+:green_book: Das Videotranskript ist [hier](./transcripts/03_hello_workflow.md) verfügbar.
+///
+
+Die meisten realen Workflows umfassen mehr als einen Schritt.
+In diesem Trainingsmodul lernst du, wie du processes in einem mehrstufigen Workflow verbindest.
+
+Dies wird dir den Nextflow-Weg beibringen, um Folgendes zu erreichen:
+
+1. Daten von einem process zum nächsten fließen lassen
+2. Ausgaben von mehreren process-Aufrufen in einen einzelnen process-Aufruf sammeln
+3. Mehr als eine Eingabe an einen process übergeben
+4. Mehrere Ausgaben aus einem process handhaben
+
+Zur Demonstration werden wir weiterhin auf dem domänenunabhängigen Hello World-Beispiel aus den Teilen 1 und 2 aufbauen.
+Diesmal werden wir die folgenden Änderungen an unserem Workflow vornehmen, um besser widerzuspiegeln, wie Leute tatsächliche Workflows erstellen:
+
+1. Einen zweiten Schritt hinzufügen, der die Begrüßung in Großbuchstaben umwandelt.
+2. Einen dritten Schritt hinzufügen, der alle transformierten Begrüßungen sammelt und sie in eine einzelne Datei schreibt.
+3. Einen Parameter hinzufügen, um die endgültige Ausgabedatei zu benennen, und diesen als sekundäre Eingabe an den Sammelschritt übergeben.
+4. Den Sammelschritt auch eine einfache Statistik über das Verarbeitete berichten lassen.
+
+??? info "Wie du von diesem Abschnitt aus beginnen kannst"
+
+    Dieser Abschnitt des Kurses setzt voraus, dass du die Teile 1-2 des [Hello Nextflow](./index.md)-Kurses abgeschlossen hast, aber wenn du mit den dort behandelten Grundlagen vertraut bist, kannst du von hier aus starten, ohne etwas Besonderes tun zu müssen.
+
+---
+
+## 0. Aufwärmübung: `hello-workflow.nf` ausführen
+
+Wir werden das Workflow-Skript `hello-workflow.nf` als Ausgangspunkt verwenden.
+Es entspricht dem Skript, das durch das Durcharbeiten von Teil 2 dieses Trainingskurses erstellt wurde, außer dass wir die `view()`-Anweisungen entfernt und das Ausgabeziel geändert haben:
+
+```groovy title="hello-workflow.nf" linenums="37" hl_lines="3"
+output {
+    first_output {
+        path 'hello_workflow'
+        mode 'copy'
+    }
+}
+```
+
+Um sicherzustellen, dass alles funktioniert, führe das Skript einmal aus, bevor du Änderungen vornimmst:
+
+```bash
+nextflow run hello-workflow.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [admiring_lamarr] DSL2 - revision: 4d4053520d
+
+    executor >  local (3)
+    [b1/5826b5] process > sayHello (2) [100%] 3 of 3 ✔
+    ```
+
+Wie zuvor findest du die Ausgabedateien an dem im `output`-Block angegebenen Ort.
+Für dieses Kapitel ist es unter `results/hello_workflow/`.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console
+    results/hello_workflow
+    ├── Bonjour-output.txt
+    ├── Hello-output.txt
+    └── Holà-output.txt
+    ```
+
+Wenn das bei dir funktioniert hat, bist du bereit zu lernen, wie man einen mehrstufigen Workflow zusammenstellt.
+
+---
+
+## 1. Einen zweiten Schritt zum Workflow hinzufügen
+
+Wir werden einen Schritt hinzufügen, um jede Begrüßung in Großbuchstaben umzuwandeln.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-multistep.svg"
+</figure>
+
+Dazu müssen wir drei Dinge tun:
+
+- Den Befehl definieren, den wir für die Großbuchstaben-Umwandlung verwenden werden.
+- Einen neuen process schreiben, der den Großbuchstaben-Befehl umhüllt.
+- Den neuen process im workflow-Block aufrufen und so einrichten, dass er die Ausgabe des `sayHello()`-process als Eingabe nimmt.
+
+### 1.1. Den Großbuchstaben-Befehl definieren und im Terminal testen
+
+Für die Umwandlung der Begrüßungen in Großbuchstaben werden wir ein klassisches UNIX-Tool namens `tr` für 'text replacement' verwenden, mit der folgenden Syntax:
+
+```bash title="Syntax"
+tr '[a-z]' '[A-Z]'
+```
+
+Dies ist ein sehr naiver Textersetzungs-Einzeiler, der keine akzentuierten Buchstaben berücksichtigt, also wird zum Beispiel 'Holà' zu 'HOLà', aber er wird für die Demonstration der Nextflow-Konzepte gut genug funktionieren, und das ist, was zählt.
+
+Um es auszuprobieren, können wir den Befehl `echo 'Hello World'` ausführen und seine Ausgabe an den `tr`-Befehl pipen:
+
+```bash
+echo 'Hello World' | tr '[a-z]' '[A-Z]' > UPPER-output.txt
+```
+
+Die Ausgabe ist eine Textdatei namens `UPPER-output.txt`, die die Großbuchstaben-Version des `Hello World`-Strings enthält.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="UPPER-output.txt"
+    HELLO WORLD
+    ```
+
+Das ist im Grunde das, was wir mit unserem Workflow versuchen werden zu tun.
+
+### 1.2. Den Großbuchstaben-Schritt als Nextflow process schreiben
+
+Wir können unseren neuen process nach dem ersten modellieren, da wir alle dieselben Komponenten verwenden wollen.
+
+Füge die folgende process-Definition zum Workflow-Skript hinzu, direkt unter dem ersten:
+
+```groovy title="hello-workflow.nf" linenums="20"
+/*
+ * Use a text replacement tool to convert the greeting to uppercase
+ */
+process convertToUpper {
+
+    input:
+    path input_file
+
+    output:
+    path "UPPER-${input_file}"
+
+    script:
+    """
+    cat '$input_file' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    """
+}
+```
+
+In diesem Fall setzen wir den zweiten Ausgabedateinamen basierend auf dem Eingabedateinamen zusammen, ähnlich wie wir es ursprünglich für die Ausgabe des ersten process getan haben.
+
+### 1.3. Einen Aufruf des neuen process im workflow-Block hinzufügen
+
+Jetzt müssen wir Nextflow sagen, dass es den process, den wir gerade definiert haben, tatsächlich aufrufen soll.
+
+Nimm im workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="44" hl_lines="10-11"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emit a greeting
+        sayHello(greeting_ch)
+        // convert the greeting to uppercase
+        convertToUpper()
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="44"
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Dies ist noch nicht funktionsfähig, weil wir nicht angegeben haben, was in den `convertToUpper()`-process eingegeben werden soll.
+
+### 1.4. Die Ausgabe des ersten process an den zweiten process übergeben
+
+Jetzt müssen wir die Ausgabe des `sayHello()`-process in den `convertToUpper()`-process fließen lassen.
+
+Praktischerweise verpackt Nextflow automatisch die Ausgabe eines process in einen channel namens `<process>.out`.
+Also ist die Ausgabe des `sayHello`-process ein channel namens `sayHello.out`, den wir direkt in den Aufruf von `convertToUpper()` einstecken können.
+
+Nimm im workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="53" hl_lines="2"
+        // convert the greeting to uppercase
+        convertToUpper(sayHello.out)
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="53" hl_lines="2"
+        // convert the greeting to uppercase
+        convertToUpper()
+    ```
+
+Für einen einfachen Fall wie diesen (eine Ausgabe zu einer Eingabe) ist das alles, was wir tun müssen, um zwei processes zu verbinden!
+
+### 1.5. Die Workflow-Ausgabeveröffentlichung einrichten
+
+Zum Schluss aktualisieren wir die Workflow-Ausgaben, um auch die Ergebnisse des zweiten process zu veröffentlichen.
+
+#### 1.5.1. Den `publish:`-Abschnitt des `workflow`-Blocks aktualisieren
+
+Nimm im `workflow`-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="56" hl_lines="3"
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="56"
+        publish:
+        first_output = sayHello.out
+    }
+    ```
+
+Die Logik ist dieselbe wie zuvor.
+
+#### 1.5.2. Den `output`-Block aktualisieren
+
+Nimm im `output`-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="61" hl_lines="6-9"
+    output {
+        first_output {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="61"
+    output {
+        first_output {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+    }
+    ```
+
+Wieder ist die Logik dieselbe wie zuvor.
+
+Dies zeigt dir, dass du die Ausgabeeinstellungen auf einer sehr granularen Ebene kontrollieren kannst, für jede einzelne Ausgabe.
+Versuche gerne, die Pfade oder den Veröffentlichungsmodus für einen der processes zu ändern, um zu sehen, was passiert.
+
+Natürlich bedeutet das, dass wir hier einige Informationen wiederholen, was unpraktisch werden könnte, wenn wir den Speicherort für alle Ausgaben auf dieselbe Weise aktualisieren wollten.
+Später im Kurs lernst du, wie du diese Einstellungen für mehrere Ausgaben auf strukturierte Weise konfigurierst.
+
+### 1.6. Den Workflow mit `-resume` ausführen
+
+Lass uns das mit dem `-resume`-Flag testen, da wir den ersten Schritt des Workflows bereits erfolgreich ausgeführt haben.
+
+```bash
+nextflow run hello-workflow.nf -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [high_cantor] DSL2 - revision: d746983511
+
+    executor >  local (3)
+    [ab/816321] process > sayHello (3)       [100%] 3 of 3, cached: 3 ✔
+    [e0/ecf81b] process > convertToUpper (3) [100%] 3 of 3 ✔
+    ```
+
+In der Konsolenausgabe gibt es jetzt eine zusätzliche Zeile, die dem neuen process entspricht, den wir gerade hinzugefügt haben.
+
+Du findest die Ausgaben im Verzeichnis `results/hello_workflow`, wie im `output`-Block festgelegt.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console
+    results/hello_workflow/
+    ├── Bonjour-output.txt
+    ├── Hello-output.txt
+    ├── Holà-output.txt
+    ├── UPPER-Bonjour-output.txt
+    ├── UPPER-Hello-output.txt
+    └── UPPER-Holà-output.txt
+    ```
+
+Das ist praktisch! Aber es lohnt sich trotzdem, einen Blick in das work-Verzeichnis eines der Aufrufe des zweiten process zu werfen.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console
+    work/e0/ecf81b4cacc648b9b994218d5b29d7/
+    ├── Holà-output.txt -> /workspaces/training/hello-nextflow/work/ab/81632178cd37e9e815959278808819/Holà-output.txt
+    └── UPPER-Holà-output.txt
+    ```
+
+Beachte, dass es zwei `*-output`-Dateien gibt: die Ausgabe des ersten process sowie die Ausgabe des zweiten.
+
+Die Ausgabe des ersten process ist dort, weil Nextflow sie dort **gestageed** hat, um alles Notwendige für die Ausführung innerhalb desselben Unterverzeichnisses zu haben.
+
+Es handelt sich jedoch tatsächlich um einen symbolischen Link, der auf die Originaldatei im Unterverzeichnis des ersten process-Aufrufs zeigt.
+Standardmäßig verwendet Nextflow, wenn es auf einer einzelnen Maschine wie hier ausgeführt wird, symbolische Links anstelle von Kopien, um Eingabe- und Zwischendateien zu stagen.
+
+Bevor du weitermachst, denke darüber nach, wie wir nur die Ausgabe von `sayHello` mit der Eingabe von `convertToUpper` verbunden haben und die beiden processes nacheinander ausgeführt werden konnten.
+Nextflow hat die harte Arbeit erledigt, einzelne Eingabe- und Ausgabedateien zu handhaben und sie zwischen den beiden Befehlen für uns weiterzugeben.
+
+Das ist einer der Gründe, warum Nextflow channels so mächtig sind: Sie kümmern sich um die Routinearbeit, die beim Verbinden von Workflow-Schritten anfällt.
+
+### Zusammenfassung
+
+Du weißt, wie du processes verketten kannst, indem du die Ausgabe eines Schritts als Eingabe für den nächsten Schritt bereitstellst.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du Ausgaben von gestapelten process-Aufrufen sammelst und sie in einen einzelnen process einspeist.
+
+---
+
+## 2. Einen dritten Schritt hinzufügen, um alle Begrüßungen zu sammeln
+
+Wenn wir einen process verwenden, um eine Transformation auf jedes der Elemente in einem channel anzuwenden, wie wir es hier mit den mehreren Begrüßungen tun, wollen wir manchmal Elemente aus dem Ausgabe-channel dieses process sammeln und sie in einen anderen process einspeisen, der eine Art Analyse oder Zusammenfassung durchführt.
+
+Zur Demonstration werden wir einen neuen Schritt zu unserer Pipeline hinzufügen, der alle vom `convertToUpper`-process produzierten Großbuchstaben-Begrüßungen sammelt und sie in eine einzelne Datei schreibt.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello-collect.svg"
+</figure>
+
+Um die Überraschung nicht zu verderben, aber das wird einen sehr nützlichen Operator beinhalten.
+
+### 2.1. Den Sammelbefehl definieren und im Terminal testen
+
+Der Sammelschritt, den wir zu unserem Workflow hinzufügen wollen, wird den `cat`-Befehl verwenden, um mehrere Großbuchstaben-Begrüßungen in eine einzelne Datei zu verketten.
+
+Lass uns den Befehl für sich allein im Terminal ausführen, um zu überprüfen, dass er wie erwartet funktioniert, genau wie wir es zuvor getan haben.
+
+Führe Folgendes in deinem Terminal aus:
+
+```bash
+echo 'Hello' | tr '[a-z]' '[A-Z]' > UPPER-Hello-output.txt
+echo 'Bonjour' | tr '[a-z]' '[A-Z]' > UPPER-Bonjour-output.txt
+echo 'Holà' | tr '[a-z]' '[A-Z]' > UPPER-Holà-output.txt
+cat UPPER-Hello-output.txt UPPER-Bonjour-output.txt UPPER-Holà-output.txt > COLLECTED-output.txt
+```
+
+Die Ausgabe ist eine Textdatei namens `COLLECTED-output.txt`, die die Großbuchstaben-Versionen der ursprünglichen Begrüßungen enthält.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="COLLECTED-output.txt"
+    HELLO
+    BONJOUR
+    HOLà
+    ```
+
+Das ist das Ergebnis, das wir mit unserem Workflow erreichen wollen.
+
+### 2.2. Einen neuen process für den Sammelschritt erstellen
+
+Lass uns einen neuen process erstellen und ihn `collectGreetings()` nennen.
+Wir können beginnen, ihn basierend auf dem zu schreiben, was wir bisher gesehen haben.
+
+#### 2.2.1. Die 'offensichtlichen' Teile des process schreiben
+
+Füge die folgende process-Definition zum Workflow-Skript hinzu:
+
+```groovy title="hello-workflow.nf" linenums="37"
+/*
+ * Collect uppercase greetings into a single output file
+ */
+process collectGreetings {
+
+    input:
+    ???
+
+    output:
+    path "COLLECTED-output.txt"
+
+    script:
+    """
+    cat ??? > 'COLLECTED-output.txt'
+    """
+}
+```
+
+Das ist, was wir mit Zuversicht basierend auf dem, was du bisher gelernt hast, schreiben können.
+Aber das ist nicht funktionsfähig!
+Es lässt die Eingabedefinition(en) und die erste Hälfte des Skriptbefehls aus, weil wir herausfinden müssen, wie wir das schreiben.
+
+#### 2.2.2. Eingaben für `collectGreetings()` definieren
+
+Wir müssen die Begrüßungen von allen Aufrufen des `convertToUpper()`-process sammeln.
+Was wissen wir, dass wir vom vorherigen Schritt im Workflow bekommen können?
+
+Der von `convertToUpper()` ausgegebene channel wird die Pfade zu den einzelnen Dateien enthalten, die die Großbuchstaben-Begrüßungen enthalten.
+Das entspricht einem Eingabeslot; nennen wir ihn der Einfachheit halber `input_files`.
+
+Nimm im process-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="42" hl_lines="2"
+          input:
+          path input_files
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="42" hl_lines="2"
+          input:
+          ???
+    ```
+
+Beachte, dass wir das `path`-Präfix verwenden, obwohl wir erwarten, dass dies mehrere Dateien enthält.
+
+#### 2.2.3. Den Verkettungsbefehl zusammenstellen
+
+Hier könnten die Dinge etwas knifflig werden, weil wir in der Lage sein müssen, eine beliebige Anzahl von Eingabedateien zu handhaben.
+Konkret können wir den Befehl nicht im Voraus schreiben, also müssen wir Nextflow sagen, wie es ihn zur Laufzeit basierend auf den Eingaben, die in den process fließen, zusammenstellen soll.
+
+Mit anderen Worten, wenn wir einen Eingabe-channel haben, der das Element `[file1.txt, file2.txt, file3.txt]` enthält, brauchen wir Nextflow, um das in `cat file1.txt file2.txt file3.txt` umzuwandeln.
+
+Glücklicherweise macht Nextflow das gerne für uns, wenn wir einfach `cat ${input_files}` in den Skriptbefehl schreiben.
+
+Nimm im process-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="54" hl_lines="3"
+        script:
+        """
+        cat ${input_files} > 'COLLECTED-output.txt'
+        """
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="54"
+        script:
+        """
+        cat ??? > 'COLLECTED-output.txt'
+        """
+    ```
+
+Theoretisch sollte dies jede beliebige Anzahl von Eingabedateien handhaben können.
+
+!!! tip "Tipp"
+
+    Einige Kommandozeilenwerkzeuge erfordern die Angabe eines Arguments (wie `-input`) für jede Eingabedatei.
+    In diesem Fall müssten wir ein bisschen zusätzliche Arbeit leisten, um den Befehl zusammenzustellen.
+    Du kannst ein Beispiel dafür im [Nextflow for Genomics](../../nf4_science/genomics/)-Trainingskurs sehen.
+
+### 2.3. Den Sammelschritt zum Workflow hinzufügen
+
+Jetzt sollten wir nur noch den Sammel-process auf der Ausgabe des Großbuchstaben-Schritts aufrufen müssen.
+
+#### 2.3.1. Die process-Aufrufe verbinden
+
+Nimm im workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="75" hl_lines="4 5"
+        // convert the greeting to uppercase
+        convertToUpper(sayHello.out)
+
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out)
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="75"
+        // convert the greeting to uppercase
+        convertToUpper(sayHello.out)
+    }
+    ```
+
+Dies verbindet die Ausgabe von `convertToUpper()` mit der Eingabe von `collectGreetings()`.
+
+#### 2.3.2. Den Workflow mit `-resume` ausführen
+
+Lass uns es versuchen.
+
+```bash
+nextflow run hello-workflow.nf -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console hl_lines="8"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [mad_gilbert] DSL2 - revision: 6acfd5e28d
+
+    executor >  local (3)
+    [79/33b2f0] sayHello (2)         | 3 of 3, cached: 3 ✔
+    [99/79394f] convertToUpper (3)   | 3 of 3, cached: 3 ✔
+    [47/50fe4a] collectGreetings (1) | 3 of 3 ✔
+    ```
+
+Es läuft erfolgreich, einschließlich des dritten Schritts.
+
+Schau dir jedoch die Anzahl der Aufrufe für `collectGreetings()` in der letzten Zeile an.
+Wir haben nur einen erwartet, aber es sind drei.
+
+Schau dir jetzt den Inhalt der endgültigen Ausgabedatei an.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/COLLECTED-output.txt"
+    Holà
+    ```
+
+Oh nein. Der Sammelschritt wurde einzeln auf jede Begrüßung ausgeführt, was NICHT das ist, was wir wollten.
+
+Wir müssen etwas tun, um Nextflow explizit zu sagen, dass wir wollen, dass dieser dritte Schritt auf allen Elementen im vom `convertToUpper()` ausgegebenen channel läuft.
+
+### 2.4. Einen Operator verwenden, um die Begrüßungen in eine einzelne Eingabe zu sammeln
+
+Ja, wieder einmal ist die Antwort auf unser Problem ein Operator.
+
+Konkret werden wir den treffend benannten [`collect()`](https://www.nextflow.io/docs/latest/reference/operator.html#collect)-Operator verwenden.
+
+#### 2.4.1. Den `collect()`-Operator hinzufügen
+
+Diesmal wird es etwas anders aussehen, weil wir den Operator nicht im Kontext einer channel factory hinzufügen; wir fügen ihn zu einem Ausgabe-channel hinzu.
+
+Wir nehmen das `convertToUpper.out` und hängen den `collect()`-Operator an, was uns `convertToUpper.out.collect()` gibt.
+Wir können das direkt in den `collectGreetings()`-process-Aufruf einstecken.
+
+Nimm im workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="73" hl_lines="2"
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect())
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="73" hl_lines="2"
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out)
+    }
+    ```
+
+#### 2.4.2. Einige `view()`-Anweisungen hinzufügen
+
+Lass uns auch ein paar `view()`-Anweisungen einfügen, um die Zustände des channel-Inhalts vor und nach zu visualisieren.
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="73" hl_lines="4-6"
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect())
+
+        // optional view statements
+        convertToUpper.out.view { contents -> "Before collect: $contents" }
+        convertToUpper.out.collect().view { contents -> "After collect: $contents" }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="73"
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect())
+    }
+    ```
+
+Die `view()`-Anweisungen können überall platziert werden, wo du möchtest; wir haben sie für die Lesbarkeit direkt nach dem Aufruf platziert.
+
+#### 2.4.3. Den Workflow erneut mit `-resume` ausführen
+
+Lass uns es versuchen:
+
+```bash
+nextflow run hello-workflow.nf -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [soggy_franklin] DSL2 - revision: bc8e1b2726
+
+    [d6/cdf466] sayHello (1)       | 3 of 3, cached: 3 ✔
+    [99/79394f] convertToUpper (2) | 3 of 3, cached: 3 ✔
+    [1e/83586c] collectGreetings   | 1 of 1 ✔
+    Before collect: /workspaces/training/hello-nextflow/work/b3/d52708edba8b864024589285cb3445/UPPER-Bonjour-output.txt
+    Before collect: /workspaces/training/hello-nextflow/work/99/79394f549e3040dfc2440f69ede1fc/UPPER-Hello-output.txt
+    Before collect: /workspaces/training/hello-nextflow/work/aa/56bfe7cf00239dc5badc1d04b60ac4/UPPER-Holà-output.txt
+    After collect: [/workspaces/training/hello-nextflow/work/b3/d52708edba8b864024589285cb3445/UPPER-Bonjour-output.txt, /workspaces/training/hello-nextflow/work/99/79394f549e3040dfc2440f69ede1fc/UPPER-Hello-output.txt, /workspaces/training/hello-nextflow/work/aa/56bfe7cf00239dc5badc1d04b60ac4/UPPER-Holà-output.txt]
+    ```
+
+Es läuft erfolgreich, obwohl die Log-Ausgabe möglicherweise etwas unordentlicher aussieht als dies (wir haben es für die Lesbarkeit aufgeräumt).
+
+Diesmal wurde der dritte Schritt nur einmal aufgerufen!
+
+Wenn du dir die Ausgabe der `view()`-Anweisungen anschaust, siehst du Folgendes:
+
+- Drei `Before collect:`-Anweisungen, eine für jede Begrüßung: zu diesem Zeitpunkt sind die Dateipfade einzelne Elemente im channel.
+- Eine einzelne `After collect:`-Anweisung: die drei Dateipfade sind jetzt in ein einzelnes Element verpackt.
+
+Schau dir den Inhalt der endgültigen Ausgabedatei an.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/COLLECTED-output.txt"
+    BONJOUR
+    HELLO
+    HOLà
+    ```
+
+Diesmal haben wir alle drei Begrüßungen in der endgültigen Ausgabedatei. Erfolg!
+
+!!! note "Hinweis"
+
+    Wenn du dies mehrmals ohne `-resume` ausführst, wirst du sehen, dass sich die Reihenfolge der Begrüßungen von einem Lauf zum nächsten ändert.
+    Dies zeigt dir, dass die Reihenfolge, in der Elemente durch process-Aufrufe fließen, nicht garantiert konsistent ist.
+
+#### 2.4.4. `view()`-Anweisungen für die Lesbarkeit entfernen
+
+Bevor du zum nächsten Abschnitt übergehst, empfehlen wir, die `view()`-Anweisungen zu löschen, um die Konsolenausgabe nicht zu überladen.
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="73"
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect())
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="73" hl_lines="4-6"
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect())
+
+        // optional view statements
+        convertToUpper.out.view { contents -> "Before collect: $contents" }
+        convertToUpper.out.collect().view { contents -> "After collect: $contents" }
+    ```
+
+Dies ist im Grunde die umgekehrte Operation von Punkt 2.4.2.
+
+### Zusammenfassung
+
+Du weißt, wie du Ausgaben aus einem Stapel von process-Aufrufen sammelst und sie in einen gemeinsamen Analyse- oder Zusammenfassungsschritt einspeist.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du mehr als eine Eingabe an einen process übergibst.
+
+---
+
+## 3. Mehr als eine Eingabe an einen process übergeben
+
+Wir wollen in der Lage sein, der endgültigen Ausgabedatei einen bestimmten Namen zu geben, um nachfolgende Stapel von Begrüßungen verarbeiten zu können, ohne die endgültigen Ergebnisse zu überschreiben.
+
+Zu diesem Zweck werden wir die folgenden Verfeinerungen am Workflow vornehmen:
+
+- Den Sammel-process so modifizieren, dass er einen benutzerdefinierten Namen für die Ausgabedatei akzeptiert
+- Einen Kommandozeilenparameter zum Workflow hinzufügen und ihn an den Sammel-process übergeben
+
+### 3.1. Den Sammel-process modifizieren
+
+Wir müssen die zusätzliche Eingabe deklarieren und sie in den Ausgabedateinamen integrieren.
+
+#### 3.1.1. Die zusätzliche Eingabe deklarieren
+
+Gute Nachricht: Wir können so viele Eingabevariablen deklarieren, wie wir wollen, in der process-Definition.
+Nennen wir diese `batch_name`.
+
+Nimm im process-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="42" hl_lines="3"
+        input:
+        path input_files
+        val batch_name
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="42"
+        input:
+        path input_files
+    ```
+
+Du kannst deine processes so einrichten, dass sie so viele Eingaben erwarten, wie du möchtest.
+Im Moment sind diese alle als erforderliche Eingaben eingerichtet; du _musst_ einen Wert angeben, damit der Workflow funktioniert.
+
+Du wirst später auf deiner Nextflow-Reise lernen, wie du erforderliche vs. optionale Eingaben handhabst.
+
+#### 3.1.2. Die `batch_name`-Variable im Ausgabedateinamen verwenden
+
+Wir können die Variable auf dieselbe Weise in den Ausgabedateinamen einfügen, wie wir zuvor dynamische Dateinamen zusammengestellt haben.
+
+Nimm im process-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="46" hl_lines="2 6"
+        output:
+        path "COLLECTED-${batch_name}-output.txt"
+
+        script:
+        """
+        cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+        """
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="46" hl_lines="2 6"
+        output:
+        path "COLLECTED-output.txt"
+
+        script:
+        """
+        cat ${input_files} > 'COLLECTED-output.txt'
+        """
+    ```
+
+Dies richtet den process ein, den `batch_name`-Wert zu verwenden, um einen spezifischen Dateinamen für die endgültige Ausgabe des Workflows zu generieren.
+
+### 3.2. Einen `batch`-Kommandozeilenparameter hinzufügen
+
+Jetzt brauchen wir einen Weg, den Wert für `batch_name` zu liefern und ihn an den process-Aufruf zu übergeben.
+
+#### 3.2.1. `params` verwenden, um den Parameter einzurichten
+
+Du weißt bereits, wie du das `params`-System verwendest, um CLI-Parameter zu deklarieren.
+Lass uns das verwenden, um einen `batch`-Parameter zu deklarieren (mit einem Standardwert, weil wir faul sind).
+
+Nimm im Abschnitt für Pipeline-Parameter die folgenden Codeänderungen vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="55" hl_lines="6"
+    /*
+     * Pipeline parameters
+     */
+    params {
+        input: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="55"
+    /*
+     * Pipeline parameters
+     */
+    params {
+        input: Path = 'data/greetings.csv'
+    }
+    ```
+
+Genau wie wir es für `--input` demonstriert haben, kannst du diesen Standardwert überschreiben, indem du einen Wert mit `--batch` auf der Kommandozeile angibst.
+
+#### 3.2.2. Den `batch`-Parameter an den process übergeben
+
+Um den Wert des Parameters an den process zu übergeben, müssen wir ihn im process-Aufruf hinzufügen.
+
+Nimm im workflow-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="74" hl_lines="2"
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect(), params.batch)
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="74" hl_lines="2"
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect())
+    ```
+
+Du siehst, dass um mehrere Eingaben an einen process zu übergeben, du sie einfach in den Aufruf-Klammern auflistest, durch Kommas getrennt.
+
+!!! warning "Warnung"
+
+    Du MUSST die Eingaben an den process in der EXAKT GLEICHEN REIHENFOLGE übergeben, wie sie im Eingabedefinitionsblock des process aufgelistet sind.
+
+### 3.3. Den Workflow ausführen
+
+Lass uns versuchen, dies mit einem Stapelnamen auf der Kommandozeile auszuführen.
+
+```bash
+nextflow run hello-workflow.nf -resume --batch trio
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [confident_rutherford] DSL2 - revision: bc58af409c
+
+    executor >  local (1)
+    [79/33b2f0] sayHello (2)       | 3 of 3, cached: 3 ✔
+    [99/79394f] convertToUpper (2) | 3 of 3, cached: 3 ✔
+    [b5/f19efe] collectGreetings   | 1 of 1 ✔
+    ```
+
+Es läuft erfolgreich und produziert die gewünschte Ausgabe:
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/COLLECTED-trio-output.txt"
+    HELLO
+    BONJOUR
+    HOLà
+    ```
+
+Solange wir den Parameter entsprechend angeben, werden nachfolgende Läufe auf anderen Eingabestapeln keine vorherigen Ergebnisse überschreiben.
+
+### Zusammenfassung
+
+Du weißt, wie du mehr als eine Eingabe an einen process übergibst.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du mehrere Ausgaben ausgibst und sie bequem handhabst.
+
+---
+
+## 4. Eine Ausgabe zum Sammelschritt hinzufügen
+
+Bisher haben wir processes verwendet, die jeweils nur eine Ausgabe produzierten.
+Wir konnten auf ihre jeweiligen Ausgaben sehr bequem mit der `<process>.out`-Syntax zugreifen, die wir sowohl im Kontext der Übergabe einer Ausgabe an den nächsten process (z.B. `convertToUpper(sayHello.out)`) als auch im Kontext des `publish:`-Abschnitts (z.B. `first_output = sayHello.out`) verwendet haben.
+
+Was passiert, wenn ein process mehr als eine Ausgabe produziert?
+Wie handhaben wir die mehreren Ausgaben?
+Können wir eine bestimmte Ausgabe auswählen und verwenden?
+
+Alles ausgezeichnete Fragen, und die kurze Antwort ist ja, das können wir!
+
+Mehrere Ausgaben werden in separate channels verpackt.
+Wir können entweder wählen, diesen Ausgabe-channels Namen zu geben, was es einfach macht, sie später einzeln zu referenzieren, oder wir können sie per Index referenzieren.
+
+Lass uns mit einem Beispiel eintauchen.
+
+Zur Demonstration sagen wir, dass wir die Anzahl der Begrüßungen zählen wollen, die für einen gegebenen Eingabestapel gesammelt werden, und sie in einer Datei berichten wollen.
+
+### 4.1. Den process so modifizieren, dass er die Anzahl der Begrüßungen zählt und ausgibt
+
+Dies erfordert zwei wichtige Änderungen an der process-Definition: wir brauchen einen Weg, die Begrüßungen zu zählen und eine Berichtsdatei zu schreiben, dann müssen wir diese Berichtsdatei zum `output`-Block des process hinzufügen.
+
+#### 4.1.1. Die Anzahl der gesammelten Begrüßungen zählen
+
+Praktischerweise erlaubt Nextflow uns, beliebigen Code im `script:`-Block der process-Definition hinzuzufügen, was wirklich praktisch ist, um solche Dinge zu tun.
+
+Das bedeutet, wir können Nextflows eingebaute `size()`-Funktion verwenden, um die Anzahl der Dateien im `input_files`-Array zu erhalten, und das Ergebnis mit einem `echo`-Befehl in eine Datei schreiben.
+
+Nimm im `collectGreetings`-process-Block die folgenden Codeänderungen vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="55" hl_lines="2 5"
+        script:
+        count_greetings = input_files.size()
+        """
+        cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+        echo 'There were ${count_greetings} greetings in this batch.' > '${batch_name}-report.txt'
+        """
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="55"
+        script:
+        """
+        cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+        """
+    ```
+
+Die `count_greetings`-Variable wird zur Laufzeit berechnet.
+
+#### 4.1.2. Die Berichtsdatei ausgeben und Ausgaben benennen
+
+Im Prinzip müssen wir nur die Berichtsdatei zum `output:`-Block hinzufügen.
+
+Aber während wir dabei sind, werden wir auch einige `emit:`-Tags zu unseren Ausgabedeklarationen hinzufügen. Diese werden es uns ermöglichen, die Ausgaben per Namen auszuwählen, anstatt Positionsindizes verwenden zu müssen.
+
+Nimm im process-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="46" hl_lines="2 3"
+        output:
+        path "COLLECTED-${batch_name}-output.txt", emit: outfile
+        path "${batch_name}-report.txt", emit: report
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="46"
+        output:
+        path "COLLECTED-${batch_name}-output.txt"
+    ```
+
+Die `emit:`-Tags sind optional, und wir hätten ein Tag nur zu einer der Ausgaben hinzufügen können.
+Aber wie das Sprichwort sagt, warum nicht beides?
+
+!!! tip "Tipp"
+
+    Wenn du die Ausgaben eines process nicht mit `emit:` benennst, kannst du trotzdem einzeln auf sie zugreifen, indem du ihren jeweiligen (nullbasierten) Index verwendest.
+    Zum Beispiel würdest du `<process>.out[0]` verwenden, um die erste Ausgabe zu bekommen, `<process>.out[1]` für die zweite Ausgabe, und so weiter.
+
+    Wir bevorzugen es, Ausgaben zu benennen, weil es sonst zu einfach ist, versehentlich den falschen Index zu greifen, besonders wenn der process viele Ausgaben produziert.
+
+### 4.2. Die Workflow-Ausgaben aktualisieren
+
+Jetzt, da wir zwei Ausgaben aus dem `collectGreetings`-process haben, enthält die `collectGreetings.out`-Ausgabe zwei channels:
+
+- `collectGreetings.out.outfile` enthält die endgültige Ausgabedatei
+- `collectGreetings.out.report` enthält die Berichtsdatei
+
+Wir müssen die Workflow-Ausgaben entsprechend aktualisieren.
+
+#### 4.2.1. Den `publish:`-Abschnitt aktualisieren
+
+Nimm im `workflow`-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="80" hl_lines="4 5"
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out.outfile
+        batch_report = collectGreetings.out.report
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="80" hl_lines="4"
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out
+    ```
+
+Wie du sehen kannst, ist das Referenzieren spezifischer process-Ausgaben jetzt trivial.
+Wenn wir in Teil 5 (Containers) einen weiteren Schritt zu unserer Pipeline hinzufügen, werden wir in der Lage sein, leicht auf `collectGreetings.out.outfile` zu verweisen und es dem neuen process zu übergeben (Spoiler: der neue process heißt `cowpy`).
+
+Aber für jetzt aktualisieren wir die Workflow-Level-Ausgaben fertig.
+
+#### 4.2.2. Den `output`-Block aktualisieren
+
+Nimm im `output`-Block die folgende Codeänderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-workflow.nf" linenums="86" hl_lines="14-17"
+    output {
+        first_output {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        collected {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        batch_report {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-workflow.nf" linenums="80"
+    output {
+        first_output {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+        collected {
+            path 'hello_workflow'
+            mode 'copy'
+        }
+    }
+    ```
+
+Wir müssen die `collected`-Ausgabedefinition nicht aktualisieren, da sich dieser Name nicht geändert hat.
+Wir müssen nur die neue Ausgabe hinzufügen.
+
+### 4.3. Den Workflow ausführen
+
+Lass uns versuchen, dies mit dem aktuellen Stapel von Begrüßungen auszuführen.
+
+```bash
+nextflow run hello-workflow.nf -resume --batch trio
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-workflow.nf` [ecstatic_wilson] DSL2 - revision: c80285f8c8
+
+    executor >  local (1)
+    [c5/4c6ca9] sayHello (3)       [100%] 3 of 3, cached: 3 ✔
+    [0e/6cbc59] convertToUpper (3) [100%] 3 of 3, cached: 3 ✔
+    [02/61ead2] collectGreetings   [100%] 1 of 1 ✔
+    ```
+
+Wenn du ins Verzeichnis `results/hello_workflow/` schaust, findest du die neue Berichtsdatei `trio-report.txt`.
+Öffne sie, um zu überprüfen, dass der Workflow korrekt die Anzahl der verarbeiteten Begrüßungen berichtet hat.
+
+??? abstract "Dateiinhalte"
+
+    ```txt title="trio-report.txt"
+    There were 3 greetings in this batch.
+    ```
+
+Du kannst gerne weitere Begrüßungen zur CSV hinzufügen und testen, was passiert.
+
+### Zusammenfassung
+
+Du weißt, wie du einen process mehrere benannte Ausgaben ausgeben lässt und wie du sie auf Workflow-Ebene angemessen handhabst.
+
+Allgemeiner verstehst du die wichtigsten Prinzipien, die beim Verbinden von processes auf gängige Weise involviert sind.
+
+### Was kommt als Nächstes?
+
+Mach eine extra lange Pause, du hast sie verdient.
+
+Wenn du bereit bist, gehe zu [**Teil 4: Hallo Module**](./04_hello_modules.md), um zu lernen, wie du deinen Code für bessere Wartbarkeit und Code-Effizienz modularisierst.
+
+---
+
+## Quiz
+
+<quiz>
+Wie greifst du auf die Ausgabe eines process im workflow-Block zu?
+- [ ] `process.output`
+- [ ] `output.processName`
+- [x] `processName.out`
+- [ ] `get(processName)`
+
+Mehr erfahren: [1.4. Die Ausgabe des ersten process an den zweiten process übergeben](#14-die-ausgabe-des-ersten-process-an-den-zweiten-process-ubergeben)
+</quiz>
+
+<quiz>
+Was bestimmt die Reihenfolge der process-Ausführung in Nextflow?
+- [ ] Die Reihenfolge, in der processes im workflow-Block geschrieben sind
+- [ ] Alphabetische Reihenfolge nach process-Namen
+- [x] Datenabhängigkeiten zwischen processes
+- [ ] Zufällige Reihenfolge für parallele Ausführung
+
+Mehr erfahren: [1.4. Die Ausgabe des ersten process an den zweiten process übergeben](#14-die-ausgabe-des-ersten-process-an-den-zweiten-process-ubergeben)
+</quiz>
+
+<quiz>
+Welcher Operator sollte `???` ersetzen, um alle Ausgaben in eine einzelne Liste für den nachfolgenden process zu sammeln?
+
+```groovy hl_lines="4"
+workflow {
+    greetings_ch = Channel.of('Hello', 'Bonjour', 'Hola')
+    SAYHELLO(greetings_ch)
+    GATHER_ALL(SAYHELLO.out.???)
+}
+```
+
+- [ ] `flatten()`
+- [x] `collect()`
+- [ ] `mix()`
+- [ ] `join()`
+
+Mehr erfahren: [2.4. Einen Operator verwenden, um die Begrüßungen in eine einzelne Eingabe zu sammeln](#24-einen-operator-verwenden-um-die-begrussungen-in-eine-einzelne-eingabe-zu-sammeln)
+</quiz>
+
+<quiz>
+Wann solltest du den `collect()`-Operator verwenden?
+- [ ] Wenn du Elemente parallel verarbeiten möchtest
+- [ ] Wenn du channel-Inhalte filtern musst
+- [x] Wenn ein nachfolgender process alle Elemente von einem vorgelagerten process benötigt
+- [ ] Wenn du Daten auf mehrere processes aufteilen möchtest
+
+Mehr erfahren: [2.4. Einen Operator verwenden, um die Begrüßungen in eine einzelne Eingabe zu sammeln](#24-einen-operator-verwenden-um-die-begrussungen-in-eine-einzelne-eingabe-zu-sammeln)
+</quiz>
+
+<quiz>
+Wie greifst du auf eine benannte Ausgabe von einem process zu?
+- [ ] `processName.outputName`
+- [ ] `processName.get(outputName)`
+- [x] `processName.out.outputName`
+- [ ] `output.processName.outputName`
+
+Mehr erfahren: [4.1.2. Die Berichtsdatei ausgeben und Ausgaben benennen](#412-die-berichtsdatei-ausgeben-und-ausgaben-benennen)
+</quiz>
+
+<quiz>
+Was ist die korrekte Syntax, um eine Ausgabe in einem process zu benennen?
+- [ ] `name: outputName`
+- [ ] `output: outputName`
+- [x] `emit: outputName`
+- [ ] `label: outputName`
+
+Mehr erfahren: [4.1.2. Die Berichtsdatei ausgeben und Ausgaben benennen](#412-die-berichtsdatei-ausgeben-und-ausgaben-benennen)
+</quiz>
+
+<quiz>
+Was muss bei der Übergabe mehrerer Eingaben an einen process zutreffen?
+- [ ] Alle Eingaben müssen vom gleichen Typ sein
+- [ ] Eingaben müssen in alphabetischer Reihenfolge übergeben werden
+- [x] Die Reihenfolge der Eingaben muss mit der im Eingabeblock definierten Reihenfolge übereinstimmen
+- [ ] Nur zwei Eingaben können gleichzeitig übergeben werden
+
+Mehr erfahren: [3. Mehr als eine Eingabe an einen process übergeben](#3-mehr-als-eine-eingabe-an-einen-process-ubergeben)
+</quiz>

--- a/docs/de/docs/hello_nextflow/04_hello_modules.md
+++ b/docs/de/docs/hello_nextflow/04_hello_modules.md
@@ -1,0 +1,510 @@
+# Teil 4: Hallo Module
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/Xxp_menS0E8?si=0AWnXB7xqHAzJdJV&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Siehe [die gesamte Playlist](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) auf dem Nextflow YouTube-Kanal.
+
+:green_book: Das Videotranskript ist [hier](./transcripts/04_hello_modules.md) verfügbar.
+///
+
+Dieser Abschnitt behandelt, wie du deinen Workflow-Code organisierst, um die Entwicklung und Wartung deiner Pipeline effizienter und nachhaltiger zu gestalten.
+Konkret werden wir demonstrieren, wie man **Module** verwendet.
+
+In Nextflow ist ein **Modul** eine einzelne process-Definition, die für sich allein in einer eigenständigen Codedatei gekapselt ist.
+Um ein Modul in einem Workflow zu verwenden, fügst du einfach eine einzeilige Import-Anweisung zu deiner Workflow-Codedatei hinzu; dann kannst du den process genauso in den Workflow integrieren, wie du es normalerweise tun würdest.
+Das ermöglicht es, process-Definitionen in mehreren Workflows wiederzuverwenden, ohne mehrere Kopien des Codes zu produzieren.
+
+Als wir anfingen, unseren Workflow zu entwickeln, haben wir alles in einer einzigen Codedatei geschrieben.
+Jetzt werden wir die processes in einzelne Module auslagern.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/modules.svg"
+</figure>
+
+Dies wird unseren Code besser teilbar, flexibler und wartbarer machen.
+
+??? info "Wie du von diesem Abschnitt aus beginnen kannst"
+
+    Dieser Abschnitt des Kurses setzt voraus, dass du die Teile 1-3 des [Hello Nextflow](./index.md)-Kurses abgeschlossen hast, aber wenn du mit den dort behandelten Grundlagen vertraut bist, kannst du von hier aus starten, ohne etwas Besonderes tun zu müssen.
+
+---
+
+## 0. Aufwärmübung: `hello-modules.nf` ausführen
+
+Wir werden das Workflow-Skript `hello-modules.nf` als Ausgangspunkt verwenden.
+Es entspricht dem Skript, das durch das Durcharbeiten von Teil 3 dieses Trainingskurses erstellt wurde, außer dass wir die Ausgabeziele geändert haben:
+
+```groovy title="hello-modules.nf" linenums="37" hl_lines="3 7 11 15"
+output {
+    first_output {
+        path 'hello_modules'
+        mode 'copy'
+    }
+    uppercased {
+        path 'hello_modules'
+        mode 'copy'
+    }
+    collected {
+        path 'hello_modules'
+        mode 'copy'
+    }
+    batch_report {
+        path 'hello_modules'
+        mode 'copy'
+    }
+}
+```
+
+Um sicherzustellen, dass alles funktioniert, führe das Skript einmal aus, bevor du Änderungen vornimmst:
+
+```bash
+nextflow run hello-modules.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-modules.nf` [hopeful_avogadro] DSL2 - revision: b09af1237d
+
+    executor >  local (7)
+    [0f/8795c9] sayHello (3)       [100%] 3 of 3 ✔
+    [6a/eb2510] convertToUpper (3) [100%] 3 of 3 ✔
+    [af/479117] collectGreetings   [100%] 1 of 1 ✔
+    ```
+
+Wie zuvor findest du die Ausgabedateien in dem im `output`-Block angegebenen Verzeichnis (hier `results/hello_modules/`).
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console
+    results/hello_modules/
+    ├── Bonjour-output.txt
+    ├── COLLECTED-batch-output.txt
+    ├── Hello-output.txt
+    ├── Holà-output.txt
+    ├── batch-report.txt
+    ├── UPPER-Bonjour-output.txt
+    ├── UPPER-Hello-output.txt
+    └── UPPER-Holà-output.txt
+    ```
+
+Wenn das bei dir funktioniert hat, bist du bereit zu lernen, wie du deinen Workflow-Code modularisierst.
+
+---
+
+## 1. Ein Verzeichnis zum Speichern von Modulen erstellen
+
+Es ist eine bewährte Praxis, deine Module in einem bestimmten Verzeichnis zu speichern.
+Du kannst dieses Verzeichnis beliebig nennen, aber die Konvention ist, es `modules/` zu nennen.
+
+```bash
+mkdir modules
+```
+
+!!! tip "Tipp"
+
+    Hier zeigen wir dir, wie du **lokale Module** verwendest, also Module, die lokal im selben Repository wie der Rest des Workflow-Codes gespeichert sind, im Gegensatz zu Remote-Modulen, die in anderen (entfernten) Repositories gespeichert sind.
+    Für weitere Informationen über **Remote-Module**, siehe die [Dokumentation](https://www.nextflow.io/docs/latest/module.html).
+
+---
+
+## 2. Ein Modul für `sayHello()` erstellen
+
+In seiner einfachsten Form ist das Umwandeln eines bestehenden process in ein Modul kaum mehr als eine Kopier-und-Einfüge-Operation.
+Wir werden einen Dateistub für das Modul erstellen, den relevanten Code hinüberkopieren und ihn dann aus der Haupt-Workflow-Datei löschen.
+
+Dann müssen wir nur noch eine Import-Anweisung hinzufügen, damit Nextflow weiß, dass es den relevanten Code zur Laufzeit einziehen soll.
+
+### 2.1. Einen Dateistub für das neue Modul erstellen
+
+Lass uns eine leere Datei für das Modul namens `sayHello.nf` erstellen.
+
+```bash
+touch modules/sayHello.nf
+```
+
+Dies gibt uns einen Platz, um den process-Code zu platzieren.
+
+### 2.2. Den `sayHello`-process-Code in die Moduldatei verschieben
+
+Kopiere die gesamte process-Definition von der Workflow-Datei in die Moduldatei und stelle sicher, dass du auch den `#!/usr/bin/env nextflow`-Shebang mit kopierst.
+
+```groovy title="modules/sayHello.nf" linenums="1"
+#!/usr/bin/env nextflow
+
+/*
+ * Use echo to print 'Hello World!' to a file
+ */
+process sayHello {
+
+    input:
+    val greeting
+
+    output:
+    path "${greeting}-output.txt"
+
+    script:
+    """
+    echo '${greeting}' > '${greeting}-output.txt'
+    """
+}
+```
+
+Sobald das erledigt ist, lösche die process-Definition aus der Workflow-Datei, aber stelle sicher, dass du den Shebang an Ort und Stelle lässt.
+
+### 2.3. Eine Import-Deklaration vor dem workflow-Block hinzufügen
+
+Die Syntax für das Importieren eines lokalen Moduls ist ziemlich unkompliziert:
+
+```groovy title="Syntax: Import-Deklaration"
+include { <MODULE_NAME> } from '<path_to_module>'
+```
+
+Lass uns das oberhalb des `params`-Blocks einfügen und es entsprechend ausfüllen.
+
+=== "Nachher"
+
+    ```groovy title="hello-modules.nf" linenums="44" hl_lines="1 2"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-modules.nf" linenums="44"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+Du siehst, wir haben den Modulnamen `sayHello` und den Pfad zu der Datei, die den Modulcode enthält, `./modules/sayHello.nf`, ausgefüllt.
+
+### 2.4. Den Workflow ausführen
+
+Wir führen den Workflow mit im Wesentlichen demselben Code und denselben Eingaben wie zuvor aus, also lass ihn uns mit dem `-resume`-Flag ausführen und sehen, was passiert.
+
+```bash
+nextflow run hello-modules.nf -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-modules.nf` [romantic_poisson] DSL2 - revision: 96edfa9ad3
+
+    [f6/cc0107] sayHello (1)       | 3 of 3, cached: 3 ✔
+    [3c/4058ba] convertToUpper (2) | 3 of 3, cached: 3 ✔
+    [1a/bc5901] collectGreetings   | 1 of 1, cached: 1 ✔
+    ```
+
+Dies sollte sehr schnell laufen, weil alles im Cache ist.
+Du kannst gerne die veröffentlichten Ausgaben überprüfen.
+
+Nextflow hat erkannt, dass es immer noch dieselbe Arbeit zu erledigen gibt, auch wenn der Code auf mehrere Dateien aufgeteilt ist.
+
+### Zusammenfassung
+
+Du weißt, wie du einen process in ein lokales Modul extrahierst und weißt, dass dies die Wiederaufnahmefähigkeit des Workflows nicht beeinträchtigt.
+
+### Was kommt als Nächstes?
+
+Übe das Erstellen weiterer Module.
+Sobald du eines gemacht hast, kannst du eine Million weitere machen...
+Aber lass uns vorerst nur noch zwei weitere machen.
+
+---
+
+## 3. Den `convertToUpper()`-process modularisieren
+
+### 3.1. Einen Dateistub für das neue Modul erstellen
+
+Erstelle eine leere Datei für das Modul namens `convertToUpper.nf`.
+
+```bash
+touch modules/convertToUpper.nf
+```
+
+### 3.2. Den `convertToUpper`-process-Code in die Moduldatei verschieben
+
+Kopiere die gesamte process-Definition von der Workflow-Datei in die Moduldatei und stelle sicher, dass du auch den `#!/usr/bin/env nextflow`-Shebang mit kopierst.
+
+```groovy title="modules/convertToUpper.nf" linenums="1"
+#!/usr/bin/env nextflow
+
+/*
+ * Use a text replacement tool to convert the greeting to uppercase
+ */
+process convertToUpper {
+
+    input:
+    path input_file
+
+    output:
+    path "UPPER-${input_file}"
+
+    script:
+    """
+    cat '${input_file}' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+    """
+}
+```
+
+Sobald das erledigt ist, lösche die process-Definition aus der Workflow-Datei, aber stelle sicher, dass du den Shebang an Ort und Stelle lässt.
+
+### 3.3. Eine Import-Deklaration vor dem `params`-Block hinzufügen
+
+Füge die Import-Deklaration oberhalb des `params`-Blocks ein und fülle sie entsprechend aus.
+
+=== "Nachher"
+
+    ```groovy title="hello-modules.nf" linenums="23" hl_lines="3"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-modules.nf" linenums="23"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+Dies sollte jetzt sehr vertraut aussehen.
+
+### 3.4. Den Workflow erneut ausführen
+
+Führe dies mit dem `-resume`-Flag aus.
+
+```bash
+nextflow run hello-modules.nf -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-modules.nf` [nauseous_heisenberg] DSL2 - revision: a04a9f2da0
+
+    [c9/763d42] sayHello (3)       | 3 of 3, cached: 3 ✔
+    [60/bc6831] convertToUpper (3) | 3 of 3, cached: 3 ✔
+    [1a/bc5901] collectGreetings   | 1 of 1, cached: 1 ✔
+    ```
+
+Dies sollte immer noch dieselbe Ausgabe wie zuvor produzieren.
+
+Zwei erledigt, noch eines übrig!
+
+---
+
+## 4. Den `collectGreetings()`-process modularisieren
+
+### 4.1. Einen Dateistub für das neue Modul erstellen
+
+Erstelle eine leere Datei für das Modul namens `collectGreetings.nf`.
+
+```bash
+touch modules/collectGreetings.nf
+```
+
+### 4.2. Den `collectGreetings`-process-Code in die Moduldatei verschieben
+
+Kopiere die gesamte process-Definition von der Workflow-Datei in die Moduldatei und stelle sicher, dass du auch den `#!/usr/bin/env nextflow`-Shebang mit kopierst.
+
+```groovy title="modules/collectGreetings.nf" linenums="1"
+#!/usr/bin/env nextflow
+
+/*
+ * Collect uppercase greetings into a single output file
+ */
+process collectGreetings {
+
+    input:
+    path input_files
+    val batch_name
+
+    output:
+    path "COLLECTED-${batch_name}-output.txt", emit: outfile
+    path "${batch_name}-report.txt", emit: report
+
+    script:
+    count_greetings = input_files.size()
+    """
+    cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+    echo 'There were ${count_greetings} greetings in this batch.' > '${batch_name}-report.txt'
+    """
+}
+```
+
+Sobald das erledigt ist, lösche die process-Definition aus der Workflow-Datei, aber stelle sicher, dass du den Shebang an Ort und Stelle lässt.
+
+### 4.3. Eine Import-Deklaration vor dem `params`-Block hinzufügen
+
+Füge die Import-Deklaration oberhalb des `params`-Blocks ein und fülle sie entsprechend aus.
+
+=== "Nachher"
+
+    ```groovy title="hello-modules.nf" linenums="3" hl_lines="4"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+    include { collectGreetings } from './modules/collectGreetings.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-modules.nf" linenums="3"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        greeting: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+Das letzte!
+
+### 4.4. Den Workflow ausführen
+
+Führe dies mit dem `-resume`-Flag aus.
+
+```bash
+nextflow run hello-modules.nf -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-modules.nf` [friendly_coulomb] DSL2 - revision: 7aa2b9bc0f
+
+    [f6/cc0107] sayHello (1)       | 3 of 3, cached: 3 ✔
+    [3c/4058ba] convertToUpper (2) | 3 of 3, cached: 3 ✔
+    [1a/bc5901] collectGreetings   | 1 of 1, cached: 1 ✔
+    ```
+
+Dies sollte immer noch dieselbe Ausgabe wie zuvor produzieren.
+
+### Zusammenfassung
+
+Du weißt, wie du mehrere processes in einem Workflow modularisierst.
+
+Herzlichen Glückwunsch, du hast all diese Arbeit geleistet und absolut nichts hat sich daran geändert, wie die Pipeline funktioniert!
+
+Scherz beiseite, jetzt ist dein Code modularer, und wenn du dich entscheidest, eine andere Pipeline zu schreiben, die einen dieser processes aufruft, musst du nur eine kurze Import-Anweisung eingeben, um das relevante Modul zu verwenden.
+Das ist besser als den Code zu kopieren und einzufügen, denn wenn du dich später entscheidest, das Modul zu verbessern, werden alle deine Pipelines die Verbesserungen erben.
+
+### Was kommt als Nächstes?
+
+Mach eine kurze Pause, wenn du möchtest.
+
+Wenn du bereit bist, gehe zu [**Teil 5: Hallo Container**](./05_hello_containers.md), um zu lernen, wie du Container verwendest, um Softwareabhängigkeiten bequemer und reproduzierbarer zu verwalten.
+
+---
+
+## Quiz
+
+<quiz>
+Was ist ein Modul in Nextflow?
+- [ ] Eine Konfigurationsdatei
+- [x] Eine eigenständige Datei, die eine einzelne process-Definition enthält
+- [ ] Eine Workflow-Definition
+- [ ] Ein channel-Operator
+
+Mehr erfahren: [2. Ein Modul für `sayHello()` erstellen](#2-ein-modul-fur-sayhello-erstellen)
+</quiz>
+
+<quiz>
+Was ist die empfohlene Namenskonvention für Moduldateien?
+- [ ] `module_processName.nf`
+- [ ] `processName_module.nf`
+- [x] `processName.nf`
+- [ ] `mod_processName.nf`
+</quiz>
+
+<quiz>
+Wo sollten Moduldateien gespeichert werden?
+- [ ] Im selben Verzeichnis wie der Workflow
+- [ ] In einem `bin/`-Verzeichnis
+- [x] In einem `modules/`-Verzeichnis
+- [ ] In einem `lib/`-Verzeichnis
+
+Mehr erfahren: [1. Ein Verzeichnis zum Speichern von Modulen erstellen](#1-ein-verzeichnis-zum-speichern-von-modulen-erstellen)
+</quiz>
+
+<quiz>
+Was ist die korrekte Syntax, um ein Modul zu importieren?
+
+- [ ] `#!groovy import { SAYHELLO } from './modules/sayhello.nf'`
+- [ ] `#!groovy require { SAYHELLO } from './modules/sayhello.nf'`
+- [x] `#!groovy include { SAYHELLO } from './modules/sayhello.nf'`
+- [ ] `#!groovy load { SAYHELLO } from './modules/sayhello.nf'`
+
+Mehr erfahren: [2.3. Eine Import-Deklaration hinzufügen](#23-eine-import-deklaration-vor-dem-workflow-block-hinzufugen)
+</quiz>
+
+<quiz>
+Was passiert mit der `-resume`-Funktionalität bei der Verwendung von Modulen?
+- [ ] Sie funktioniert nicht mehr
+- [ ] Sie erfordert zusätzliche Konfiguration
+- [x] Sie funktioniert genauso wie zuvor
+- [ ] Sie funktioniert nur für lokale Module
+</quiz>
+
+<quiz>
+Was sind die Vorteile der Verwendung von Modulen? (Wähle alle zutreffenden aus)
+- [x] Wiederverwendbarkeit von Code über Workflows hinweg
+- [x] Einfachere Wartung
+- [x] Bessere Organisation von Workflow-Code
+- [ ] Schnellere Ausführungsgeschwindigkeit
+</quiz>

--- a/docs/de/docs/hello_nextflow/05_hello_containers.md
+++ b/docs/de/docs/hello_nextflow/05_hello_containers.md
@@ -1,0 +1,1028 @@
+# Teil 5: Hello Containers
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/5PyOWjKnNmg?si=QinuAnFwFj-Z8CrO&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Sieh dir [die ganze Playlist](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) auf dem Nextflow YouTube-Kanal an.
+
+:green_book: Das Videotranskript ist [hier](./transcripts/05_hello_containers.md) verfügbar.
+///
+
+In den Teilen 1-4 dieses Kurses hast du gelernt, wie du die grundlegenden Bausteine von Nextflow verwendest, um einen einfachen Workflow zu erstellen, der Text verarbeiten, die Ausführung bei mehreren Eingaben parallelisieren und die Ergebnisse zur weiteren Verarbeitung sammeln kann.
+
+Du warst jedoch auf grundlegende UNIX-Tools beschränkt, die in deiner Umgebung verfügbar sind.
+Reale Aufgaben erfordern oft verschiedene Tools und Pakete, die standardmäßig nicht enthalten sind.
+Normalerweise müsstest du diese Tools installieren, ihre Abhängigkeiten verwalten und eventuelle Konflikte lösen.
+
+Das ist alles sehr mühsam und nervig, daher zeigen wir dir, wie du **Container** verwendest, um dieses Problem viel bequemer zu lösen.
+
+Ein **Container** ist eine leichtgewichtige, eigenständige, ausführbare Softwareeinheit, die aus einem Container-**Image** erstellt wird und alles enthält, was zum Ausführen einer Anwendung benötigt wird, einschließlich Code, Systembibliotheken und Einstellungen.
+Wie du dir vorstellen kannst, wird das sehr hilfreich sein, um deine Pipelines reproduzierbarer zu machen.
+
+Beachte, dass wir dies mit [Docker](https://www.docker.com/get-started/) lehren, aber Nextflow unterstützt auch [mehrere andere Container-Technologien](https://www.nextflow.io/docs/latest/container.html#).
+
+??? info "Wie du von diesem Abschnitt aus beginnst"
+
+    Dieser Abschnitt des Kurses setzt voraus, dass du die Teile 1-4 des [Hello Nextflow](./index.md)-Kurses abgeschlossen hast und eine vollständig funktionierende Pipeline hast.
+
+    Wenn du den Kurs von diesem Punkt aus beginnst, musst du das `modules`-Verzeichnis aus den Lösungen kopieren:
+
+    ```bash
+    cp -r solutions/4-hello-modules/modules .
+    ```
+
+---
+
+## 0. Aufwärmen: `hello-containers.nf` ausführen
+
+Wir werden das Workflow-Script `hello-containers.nf` als Ausgangspunkt verwenden.
+Es entspricht dem Script, das durch Durcharbeiten von Teil 4 dieses Kurses entstanden ist, außer dass wir die Ausgabeziele geändert haben:
+
+```groovy title="hello-containers.nf" linenums="37" hl_lines="3 7 11 15"
+output {
+    first_output {
+        path 'hello_containers'
+        mode 'copy'
+    }
+    uppercased {
+        path 'hello_containers'
+        mode 'copy'
+    }
+    collected {
+        path 'hello_containers'
+        mode 'copy'
+    }
+    batch_report {
+        path 'hello_containers'
+        mode 'copy'
+    }
+}
+```
+
+Um sicherzustellen, dass alles funktioniert, führe das Script einmal aus, bevor du Änderungen vornimmst:
+
+```bash
+nextflow run hello-containers.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-containers.nf` [nice_escher] DSL2 - revision: d5dfdc9872
+
+    executor > local (7)
+    [5a/ec1fa1] sayHello (2) [100%] 3 of 3 ✔
+    [30/32b5b8] convertToUpper (3) [100%] 3 of 3 ✔
+    [d3/be01bc] collectGreetings [100%] 1 of 1 ✔
+
+    ```
+
+Wie zuvor findest du die Ausgabedateien in dem im `output`-Block angegebenen Verzeichnis (`results/hello_containers/`).
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    results/hello_containers/
+    ├── Bonjour-output.txt
+    ├── COLLECTED-batch-output.txt
+    ├── Hello-output.txt
+    ├── Holà-output.txt
+    ├── batch-report.txt
+    ├── UPPER-Bonjour-output.txt
+    ├── UPPER-Hello-output.txt
+    └── UPPER-Holà-output.txt
+    ```
+
+Wenn das bei dir funktioniert hat, bist du bereit zu lernen, wie man Container verwendet.
+
+---
+
+## 1. Einen Container 'manuell' verwenden
+
+Was wir tun möchten, ist einen Schritt zu unserem Workflow hinzuzufügen, der einen Container zur Ausführung verwendet.
+
+Allerdings werden wir zuerst einige grundlegende Konzepte und Operationen durchgehen, um dein Verständnis davon zu festigen, was Container sind, bevor wir sie in Nextflow verwenden.
+
+### 1.1. Das Container-Image herunterladen
+
+Um einen Container zu verwenden, lädst du normalerweise ein Container-Image von einer Container-Registry herunter oder _pullst_ es, und führst dann das Container-Image aus, um eine Container-Instanz zu erstellen.
+
+Die allgemeine Syntax ist wie folgt:
+
+```bash title="Syntax"
+docker pull '<container>'
+```
+
+Der `docker pull`-Teil ist die Anweisung an das Container-System, ein Container-Image aus einem Repository zu pullen.
+
+Der `'<container>'`-Teil ist die URI-Adresse des Container-Images.
+
+Als Beispiel pullen wir ein Container-Image, das [cowpy](https://github.com/jeffbuttars/cowpy) enthält, eine Python-Implementierung eines Tools namens `cowsay`, das ASCII-Kunst generiert, um beliebige Texteingaben auf lustige Weise anzuzeigen.
+
+```txt title="Beispiel"
+ ________________________
+< Are we having fun yet? >
+ ------------------------
+    \                                  ___-------___
+     \                             _-~~             ~~-_
+      \                         _-~                    /~-_
+             /^\__/^\         /~  \                   /    \
+           /|  O|| O|        /      \_______________/        \
+          | |___||__|      /       /                \          \
+          |          \    /      /                    \          \
+          |   (_______) /______/                        \_________ \
+          |         / /         \                      /            \
+           \         \^\\         \                  /               \     /
+             \         ||           \______________/      _-_       //\__//
+               \       ||------_-~~-_ ------------- \ --/~   ~\    || __/
+                 ~-----||====/~     |==================|       |/~~~~~
+                  (_(__/  ./     /                    \_\      \.
+                         (_(___/                         \_____)_)
+```
+
+Es gibt verschiedene Repositories, in denen du veröffentlichte Container finden kannst.
+Wir haben den [Seqera Containers](https://seqera.io/containers/)-Service verwendet, um dieses Docker-Container-Image aus dem `cowpy`-Conda-Paket zu generieren: `'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'`.
+
+Führe den vollständigen Pull-Befehl aus:
+
+```bash
+docker pull 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    1.1.5--3db457ae1977a273: Pulling from library/cowpy
+    dafa2b0c44d2: Pull complete
+    dec6b097362e: Pull complete
+    f88da01cff0b: Pull complete
+    4f4fb700ef54: Pull complete
+    92dc97a3ef36: Pull complete
+    403f74b0f85e: Pull complete
+    10b8c00c10a5: Pull complete
+    17dc7ea432cc: Pull complete
+    bb36d6c3110d: Pull complete
+    0ea1a16bbe82: Pull complete
+    030a47592a0a: Pull complete
+    c23bdb422167: Pull complete
+    e1686ff32a11: Pull complete
+    Digest: sha256:1ebc0043e8cafa61203bf42d29fd05bd14e7b4298e5e8cf986504c15f5aa4160
+    Status: Downloaded newer image for community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273
+    community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273
+    ```
+
+Wenn du das Image noch nie heruntergeladen hast, kann dies eine Minute dauern.
+Sobald es fertig ist, hast du eine lokale Kopie des Container-Images.
+
+### 1.2. Den Container verwenden, um `cowpy` als einmaligen Befehl auszuführen
+
+Eine sehr häufige Art, wie Leute Container verwenden, ist sie direkt auszuführen, _d.h._ nicht-interaktiv.
+Das ist großartig für einmalige Befehle.
+
+Die allgemeine Syntax ist wie folgt:
+
+```bash title="Syntax"
+docker run --rm '<container>' [tool command]
+```
+
+Der `docker run --rm '<container>'`-Teil ist die Anweisung an das Container-System, eine Container-Instanz aus einem Container-Image zu starten und einen Befehl darin auszuführen.
+Das `--rm`-Flag teilt dem System mit, die Container-Instanz nach Abschluss des Befehls herunterzufahren.
+
+Die `[tool command]`-Syntax hängt vom verwendeten Tool und der Einrichtung des Containers ab.
+Beginnen wir einfach mit `cowpy`.
+
+Vollständig zusammengestellt sieht der Container-Ausführungsbefehl so aus; führe ihn aus.
+
+```bash
+docker run --rm 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273' cowpy
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    ______________________________________________________
+    < Cowacter, eyes:default, tongue:False, thoughts:False >
+    ------------------------------------------------------
+        \   ^__^
+          \  (oo)\_______
+            (__)\       )\/\
+              ||----w |
+              ||     ||
+    ```
+
+Das System hat den Container gestartet, den `cowpy`-Befehl mit seinen Parametern ausgeführt, die Ausgabe an die Konsole gesendet und schließlich die Container-Instanz heruntergefahren.
+
+### 1.3. Den Container verwenden, um `cowpy` interaktiv auszuführen
+
+Du kannst einen Container auch interaktiv ausführen, was dir eine Shell-Eingabeaufforderung innerhalb des Containers gibt und es dir ermöglicht, mit dem Befehl zu experimentieren.
+
+#### 1.3.1. Den Container starten
+
+Um interaktiv auszuführen, fügen wir einfach `-it` zum `docker run`-Befehl hinzu.
+Optional können wir die Shell angeben, die wir innerhalb des Containers verwenden möchten, indem wir z.B. `/bin/bash` an den Befehl anhängen.
+
+```bash
+docker run --rm -it 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273' /bin/bash
+```
+
+Beachte, dass sich deine Eingabeaufforderung zu etwas wie `(base) root@b645838b3314:/tmp#` ändert, was anzeigt, dass du dich jetzt innerhalb des Containers befindest.
+
+Du kannst dies überprüfen, indem du `ls /` ausführst, um den Verzeichnisinhalt vom Wurzelverzeichnis des Dateisystems aufzulisten:
+
+```bash
+ls /
+```
+
+??? abstract "Befehlsausgabe"
+
+    ```console
+    bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
+    ```
+
+Wir verwenden hier `ls` anstelle von `tree`, weil das `tree`-Tool in diesem Container nicht verfügbar ist.
+Du kannst sehen, dass das Dateisystem innerhalb des Containers sich vom Dateisystem auf deinem Host-System unterscheidet.
+
+Eine Einschränkung dessen, was wir gerade getan haben, ist, dass der Container standardmäßig vollständig vom Host-System isoliert ist.
+Das bedeutet, dass der Container auf keine Dateien auf dem Host-System zugreifen kann, es sei denn, du erlaubst es ausdrücklich.
+
+Wir zeigen dir gleich, wie das geht.
+
+#### 1.3.2. Die gewünschten Tool-Befehle ausführen
+
+Jetzt, da du dich innerhalb des Containers befindest, kannst du den `cowpy`-Befehl direkt ausführen und ihm einige Parameter geben.
+Zum Beispiel sagt die Tool-Dokumentation, dass wir den Charakter ('Cowacter') mit `-c` ändern können.
+
+```bash
+cowpy "Hello Containers" -c tux
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    __________________
+    < Hello Containers >
+    ------------------
+      \
+        \
+            .--.
+          |o_o |
+          |:_/ |
+          //   \ \
+        (|     | )
+        /'\_   _/`\
+        \___)=(___/
+    ```
+
+Jetzt zeigt die Ausgabe den Linux-Pinguin Tux anstelle der Standard-Kuh, weil wir den Parameter `-c tux` angegeben haben.
+
+Da du dich innerhalb des Containers befindest, kannst du den `cowpy`-Befehl beliebig oft ausführen und die Eingabeparameter variieren, ohne dich mit Docker-Befehlen befassen zu müssen.
+
+!!! Tipp
+
+    Verwende das '-c'-Flag, um einen anderen Charakter auszuwählen, einschließlich:
+    `beavis`, `cheese`, `daemon`, `dragonandcow`, `ghostbusters`, `kitty`, `moose`, `milk`, `stegosaurus`, `turkey`, `turtle`, `tux`
+
+Das ist cool. Noch cooler wäre es, wenn wir unsere `greetings.csv` als Eingabe verwenden könnten.
+Aber da wir keinen Zugriff auf das Dateisystem haben, können wir das nicht.
+
+Lass uns das beheben.
+
+#### 1.3.3. Den Container verlassen
+
+Um den Container zu verlassen, kannst du `exit` an der Eingabeaufforderung eingeben oder die Tastenkombination ++ctrl+d++ verwenden.
+
+```bash
+exit
+```
+
+Deine Eingabeaufforderung sollte jetzt wieder so aussehen wie vor dem Starten des Containers.
+
+#### 1.3.4. Daten in den Container einbinden
+
+Wie bereits erwähnt, ist der Container standardmäßig vom Host-System isoliert.
+
+Um dem Container den Zugriff auf das Host-Dateisystem zu ermöglichen, kannst du ein **Volume** vom Host-System in den Container **einbinden** (mounten), indem du die folgende Syntax verwendest:
+
+```bash title="Syntax"
+-v <outside_path>:<inside_path>
+```
+
+In unserem Fall wird `<outside_path>` das aktuelle Arbeitsverzeichnis sein, also können wir einfach einen Punkt (`.`) verwenden, und `<inside_path>` ist nur ein Alias, den wir erfinden; nennen wir es `/my_project` (der innere Pfad muss absolut sein).
+
+Um ein Volume einzubinden, ersetzen wir die Pfade und fügen das Volume-Mounting-Argument zum Docker-Run-Befehl wie folgt hinzu:
+
+```bash
+docker run --rm -it -v .:/my_project 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273' /bin/bash
+```
+
+Dies bindet das aktuelle Arbeitsverzeichnis als Volume ein, das unter `/my_project` innerhalb des Containers zugänglich sein wird.
+
+Du kannst überprüfen, ob es funktioniert, indem du den Inhalt von `/my_project` auflistest:
+
+```bash
+ls /my_project
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    data               hello-config.nf      hello-modules.nf   hello-world.nf  nextflow.config  solutions         work
+    hello-channels.nf  hello-containers.nf  hello-workflow.nf  modules         results          test-params.json
+    ```
+
+Du kannst jetzt den Inhalt des Arbeitsverzeichnisses von innerhalb des Containers sehen, einschließlich der `greetings.csv`-Datei unter `data/`.
+
+Dies hat effektiv einen Tunnel durch die Containerwand etabliert, den du verwenden kannst, um auf diesen Teil deines Dateisystems zuzugreifen.
+
+#### 1.3.5. Die eingebundenen Daten verwenden
+
+Jetzt, da wir das Arbeitsverzeichnis in den Container eingebunden haben, können wir den `cowpy`-Befehl verwenden, um den Inhalt der `greetings.csv`-Datei anzuzeigen.
+
+Dazu verwenden wir `cat /my_project/data/greetings.csv | `, um den Inhalt der CSV-Datei an den `cowpy`-Befehl zu übergeben.
+
+```bash
+cat /my_project/data/greetings.csv | cowpy -c turkey
+```
+
+??? success "Befehlsausgabe"
+
+    ```console title="data/greetings.csv"
+     ____________________
+    / Hello,English,123  \
+    | Bonjour,French,456 |
+    \ Holà,Spanish,789   /
+    --------------------
+      \                                  ,+*^^*+___+++_
+      \                           ,*^^^^              )
+        \                       _+*                     ^**+_
+        \                    +^       _ _++*+_+++_,         )
+                  _+^^*+_    (     ,+*^ ^          \+_        )
+                {       )  (    ,(    ,_+--+--,      ^)      ^\
+                { (\@)    } f   ,(  ,+-^ __*_*_  ^^\_   ^\       )
+              {:;-/    (_+*-+^^^^^+*+*<_ _++_)_    )    )      /
+              ( /  (    (        ,___    ^*+_+* )   <    <      \
+              U _/     )    *--<  ) ^\-----++__)   )    )       )
+                (      )  _(^)^^))  )  )\^^^^^))^*+/    /       /
+              (      /  (_))_^)) )  )  ))^^^^^))^^^)__/     +^^
+            (     ,/    (^))^))  )  ) ))^^^^^^^))^^)       _)
+              *+__+*       (_))^)  ) ) ))^^^^^^))^^^^^)____*^
+              \             \_)^)_)) ))^^^^^^^^^^))^^^^)
+              (_             ^\__^^^^^^^^^^^^))^^^^^^^)
+                ^\___            ^\__^^^^^^))^^^^^^^^)\\
+                      ^^^^^\uuu/^^\uuu/^^^^\^\^\^\^\^\^\^\
+                        ___) >____) >___   ^\_\_\_\_\_\_\)
+                        ^^^//\\_^^//\\_^       ^(\_\_\_\)
+                          ^^^ ^^ ^^^ ^
+    ```
+
+Dies erzeugt die gewünschte ASCII-Kunst eines Truthahns, der unsere Beispiel-Grüße aufsagt!
+Nur dass hier der Truthahn die vollständigen Zeilen wiederholt anstatt nur die Grüße.
+Wir wissen bereits, dass unser Nextflow-Workflow das besser machen wird!
+
+Experimentiere gerne mit diesem Befehl.
+Wenn du fertig bist, verlasse den Container wie zuvor:
+
+```bash
+exit
+```
+
+Du befindest dich wieder in deiner normalen Shell.
+
+### Erkenntnisse
+
+Du weißt, wie man einen Container pullt und ihn entweder einmalig oder interaktiv ausführt. Du weißt auch, wie du deine Daten von innerhalb deines Containers zugänglich machst, was es dir ermöglicht, jedes Tool, das dich interessiert, mit echten Daten auszuprobieren, ohne Software auf deinem System installieren zu müssen.
+
+### Was kommt als Nächstes?
+
+Lerne, wie man Container für die Ausführung von Nextflow-Prozessen verwendet.
+
+---
+
+## 2. Container in Nextflow verwenden
+
+Nextflow hat eingebaute Unterstützung für die Ausführung von Prozessen innerhalb von Containern, damit du Tools ausführen kannst, die nicht in deiner Rechenumgebung installiert sind.
+Das bedeutet, dass du jedes beliebige Container-Image verwenden kannst, um deine Prozesse auszuführen, und Nextflow kümmert sich um das Pullen des Images, das Einbinden der Daten und das Ausführen des Prozesses darin.
+
+Um dies zu demonstrieren, werden wir einen `cowpy`-Schritt zur Pipeline hinzufügen, die wir entwickelt haben, nach dem `collectGreetings`-Schritt.
+
+<figure class="excalidraw">
+--8<-- "docs/nextflow_run/img/hello-pipeline-cowpy.svg"
+</figure>
+
+Muh, wenn du bereit bist einzutauchen!
+
+### 2.1. Ein `cowpy`-Modul schreiben
+
+Zuerst erstellen wir das `cowpy`-Prozess-Modul.
+
+#### 2.1.1. Eine Datei-Vorlage für das neue Modul erstellen
+
+Erstelle eine leere Datei für das Modul namens `cowpy.nf`.
+
+```bash
+touch modules/cowpy.nf
+```
+
+Das gibt uns einen Platz für den Prozess-Code.
+
+#### 2.1.2. Den `cowpy`-Prozess-Code in die Modul-Datei kopieren
+
+Wir können unseren `cowpy`-Prozess nach den anderen Prozessen modellieren, die wir zuvor geschrieben haben.
+
+```groovy title="modules/cowpy.nf" linenums="1"
+#!/usr/bin/env nextflow
+
+// Generate ASCII art with cowpy
+process cowpy {
+
+    input:
+    path input_file
+    val character
+
+    output:
+    path "cowpy-${input_file}"
+
+    script:
+    """
+    cat ${input_file} | cowpy -c "${character}" > cowpy-${input_file}
+    """
+
+}
+```
+
+Der Prozess erwartet eine `input_file`, die die Grüße enthält, sowie einen `character`-Wert.
+
+Die Ausgabe wird eine neue Textdatei sein, die die vom `cowpy`-Tool generierte ASCII-Kunst enthält.
+
+### 2.2. cowpy zum Workflow hinzufügen
+
+Jetzt müssen wir das Modul importieren und den Prozess aufrufen.
+
+#### 2.2.1. Den `cowpy`-Prozess in `hello-containers.nf` importieren
+
+Füge die Import-Deklaration über dem Workflow-Block ein und fülle sie entsprechend aus.
+
+=== "Nachher"
+
+    ```groovy title="hello-containers.nf" linenums="3" hl_lines="5"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+    include { collectGreetings } from './modules/collectGreetings.nf'
+    include { cowpy } from './modules/cowpy.nf'
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-containers.nf" linenums="3"
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+    include { collectGreetings } from './modules/collectGreetings.nf'
+    ```
+
+Jetzt ist das `cowpy`-Modul für die Verwendung im Workflow verfügbar.
+
+#### 2.2.2. Einen Aufruf des `cowpy`-Prozesses im Workflow hinzufügen
+
+Verbinden wir den `cowpy()`-Prozess mit der Ausgabe des `collectGreetings()`-Prozesses, der, wie du dich vielleicht erinnerst, zwei Ausgaben produziert:
+
+- `collectGreetings.out.outfile` enthält die Ausgabedatei <--_was wir wollen_
+- `collectGreetings.out.report` enthält die Berichtsdatei mit der Anzahl der Grüße pro Batch
+
+Nimm im Workflow-Block folgende Code-Änderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-containers.nf" linenums="19" hl_lines="12-13"
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emit a greeting
+        sayHello(greeting_ch)
+        // convert the greeting to uppercase
+        convertToUpper(sayHello.out)
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect(), params.batch)
+        // generate ASCII art of the greetings with cowpy
+        cowpy(collectGreetings.out.outfile, params.character)
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-containers.nf" linenums="19"
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emit a greeting
+        sayHello(greeting_ch)
+        // convert the greeting to uppercase
+        convertToUpper(sayHello.out)
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect(), params.batch)
+    ```
+
+Beachte, dass wir einen neuen CLI-Parameter, `params.character`, deklariert haben, um anzugeben, welcher Charakter die Grüße sagen soll.
+
+#### 2.2.3. Den `character`-Parameter zum `params`-Block hinzufügen
+
+Dies ist technisch optional, aber es ist die empfohlene Praxis und eine Gelegenheit, einen Standardwert für den Charakter festzulegen, während wir dabei sind.
+
+=== "Nachher"
+
+    ```groovy title="hello-containers.nf" linenums="9" hl_lines="7"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+        character: String = 'turkey'
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-containers.nf" linenums="9"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+    }
+    ```
+
+Jetzt können wir faul sein und das Tippen des character-Parameters in unseren Befehlszeilen überspringen.
+
+#### 2.2.4. Die Workflow-Ausgaben aktualisieren
+
+Wir müssen die Workflow-Ausgaben aktualisieren, um die Ausgabe des `cowpy`-Prozesses zu veröffentlichen.
+
+##### 2.2.4.1. Den `publish:`-Abschnitt aktualisieren
+
+Nimm im `workflow`-Block folgende Code-Änderung vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-containers.nf" linenums="34" hl_lines="6"
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out.outfile
+        batch_report = collectGreetings.out.report
+        cowpy_art = cowpy.out
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-containers.nf" linenums="34"
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out.outfile
+        batch_report = collectGreetings.out.report
+    ```
+
+Der `cowpy`-Prozess produziert nur eine Ausgabe, also können wir uns darauf auf die übliche Weise beziehen, indem wir `.out` anhängen.
+
+Aber für jetzt beenden wir die Aktualisierung der Workflow-Level-Ausgaben.
+
+##### 2.2.4.2. Den `output`-Block aktualisieren
+
+Wir müssen die finale `cowpy_art`-Ausgabe zum `output`-Block hinzufügen. Während wir dabei sind, bearbeiten wir auch die Veröffentlichungsziele, da unsere Pipeline jetzt vollständig ist und wir wissen, welche Ausgaben uns wirklich wichtig sind.
+
+Nimm im `output`-Block folgende Code-Änderungen vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-containers.nf" linenums="42" hl_lines="3 7 11 15 18-21"
+    output {
+        first_output {
+            path 'hello_containers/intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_containers/intermediates'
+            mode 'copy'
+        }
+        collected {
+            path 'hello_containers/intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path 'hello_containers'
+            mode 'copy'
+        }
+        cowpy_art {
+            path 'hello_containers'
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-containers.nf" linenums="42" hl_lines="3 7 11 15"
+    output {
+        first_output {
+            path 'hello_containers'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_containers'
+            mode 'copy'
+        }
+        collected {
+            path 'hello_containers'
+            mode 'copy'
+        }
+        batch_report {
+            path 'hello_containers'
+            mode 'copy'
+        }
+    }
+    ```
+
+Jetzt werden die veröffentlichten Ausgaben etwas besser organisiert sein.
+
+#### 2.2.5. Den Workflow ausführen
+
+Nur zur Zusammenfassung, das ist, was wir anstreben:
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_pipeline_complete.svg"
+</figure>
+
+Denkst du, es wird funktionieren?
+
+Lass uns die vorherigen veröffentlichten Ausgaben löschen, um einen sauberen Stand zu haben, und den Workflow mit dem `-resume`-Flag ausführen.
+
+```bash
+rm -r hello_containers/
+nextflow run hello-containers.nf -resume
+```
+
+??? failure "Befehlsausgabe (zur Klarheit bearbeitet)"
+
+    ```console hl_lines="10 13 20-21 26-27"
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-containers.nf` [lonely_woese] DSL2 - revision: abf1dccf7f
+
+    executor >  local (1)
+    [c9/f5c686] sayHello (3)       [100%] 3 of 3, cached: 3 ✔
+    [ef/3135a8] convertToUpper (3) [100%] 3 of 3, cached: 3 ✔
+    [7f/f435e3] collectGreetings   [100%] 1 of 1, cached: 1 ✔
+    [9b/02e776] cowpy              [  0%] 0 of 1 ✘
+    ERROR ~ Error executing process > 'cowpy'
+
+    Caused by:
+      Process `cowpy` terminated with an error exit status (127)
+
+
+    Command executed:
+
+      cat COLLECTED-batch-output.txt | cowpy -c "turkey" > cowpy-COLLECTED-batch-output.txt
+
+    Command exit status:
+      127
+
+    Command output:
+      (empty)
+
+    Command error:
+      .command.sh: line 2: cowpy: command not found
+
+    Work dir:
+      /workspaces/training/hello-nextflow/work/9b/02e7761db848f82db3c3e59ff3a9b6
+
+    Tip: when you have fixed the problem you can continue the execution adding the option `-resume` to the run command line
+
+    -- Check '.nextflow.log' file for details
+    ERROR ~ Cannot access first() element from an empty List
+
+    -- Check '.nextflow.log' file for details
+    ```
+
+Oh nein, es gibt einen Fehler!
+Der Fehlercode `error exit status (127)` bedeutet, dass die angeforderte ausführbare Datei nicht gefunden wurde.
+
+Das ergibt Sinn, da wir das `cowpy`-Tool aufrufen, aber wir haben noch keinen Container angegeben (ups).
+
+### 2.3. Einen Container verwenden, um den `cowpy`-Prozess auszuführen
+
+Wir müssen einen Container angeben und Nextflow anweisen, ihn für den `cowpy()`-Prozess zu verwenden.
+
+#### 2.3.1. Einen Container für `cowpy` angeben
+
+Wir können dasselbe Image verwenden, das wir direkt im ersten Abschnitt dieses Tutorials verwendet haben.
+
+Bearbeite das `cowpy.nf`-Modul, um die `container`-Direktive zur Prozessdefinition wie folgt hinzuzufügen:
+
+=== "Nachher"
+
+    ```groovy title="modules/cowpy.nf" linenums="4" hl_lines="3"
+    process cowpy {
+
+        container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+
+        input:
+        path input_file
+        val character
+
+        output:
+        path "cowpy-${input_file}"
+
+        script:
+        """
+        cat ${input_file} | cowpy -c "${character}" > cowpy-${input_file}
+        """
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="modules/cowpy.nf" linenums="4"
+    process cowpy {
+
+        input:
+        path input_file
+        val character
+
+        output:
+        path "cowpy-${input_file}"
+
+        script:
+        """
+        cat ${input_file} | cowpy -c "${character}" > cowpy-${input_file}
+        """
+    }
+    ```
+
+Dies teilt Nextflow mit, dass _wenn die Verwendung von Docker aktiviert ist_, es das hier angegebene Container-Image verwenden soll, um den Prozess auszuführen.
+
+#### 2.3.2. Die Verwendung von Docker über die `nextflow.config`-Datei aktivieren
+
+Beachte, dass wir sagten _'wenn die Verwendung von Docker aktiviert ist'_. Standardmäßig ist sie es nicht, also müssen wir Nextflow mitteilen, dass es Docker verwenden darf.
+Dazu werden wir das Thema des nächsten und letzten Teils dieses Kurses (Teil 6) leicht vorwegnehmen, der die Konfiguration behandelt.
+
+Eine der Hauptmöglichkeiten, die Nextflow für die Konfiguration der Workflow-Ausführung bietet, ist die Verwendung einer `nextflow.config`-Datei.
+Wenn eine solche Datei im aktuellen Verzeichnis vorhanden ist, lädt Nextflow sie automatisch und wendet die enthaltene Konfiguration an.
+
+Wir haben eine `nextflow.config`-Datei mit einer einzigen Codezeile bereitgestellt, die Docker explizit deaktiviert: `docker.enabled = false`.
+
+Jetzt ändern wir das auf `true`, um Docker zu aktivieren:
+
+=== "Nachher"
+
+    ```console title="nextflow.config" linenums="1" hl_lines="1"
+    docker.enabled = true
+    ```
+
+=== "Vorher"
+
+    ```console title="nextflow.config" linenums="1" hl_lines="1"
+    docker.enabled = false
+    ```
+
+!!! Tipp
+
+    Es ist möglich, die Docker-Ausführung über die Befehlszeile pro Ausführung mit dem Parameter `-with-docker <container>` zu aktivieren.
+    Das erlaubt uns jedoch nur, einen Container für den gesamten Workflow anzugeben, während der gerade gezeigte Ansatz es uns ermöglicht, einen anderen Container pro Prozess anzugeben.
+    Das ist besser für Modularität, Code-Wartung und Reproduzierbarkeit.
+
+#### 2.3.3. Den Workflow mit aktiviertem Docker ausführen
+
+Führe den Workflow mit dem `-resume`-Flag aus:
+
+```bash
+nextflow run hello-containers.nf -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-containers.nf` [drunk_perlman] DSL2 - revision: abf1dccf7f
+
+    executor >  local (1)
+    [c9/f5c686] sayHello (3)       [100%] 3 of 3, cached: 3 ✔
+    [ef/3135a8] convertToUpper (3) [100%] 3 of 3, cached: 3 ✔
+    [7f/f435e3] collectGreetings   [100%] 1 of 1, cached: 1 ✔
+    [98/656c6c] cowpy              [100%] 1 of 1 ✔
+    ```
+
+Diesmal funktioniert es tatsächlich!
+Wie üblich findest du die Workflow-Ausgaben im entsprechenden Ergebnisverzeichnis, obwohl sie diesmal etwas übersichtlicher organisiert sind, mit nur dem Bericht und der finalen Ausgabe auf der obersten Ebene, und alle Zwischendateien in einem Unterverzeichnis verstaut.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    results/hello_containers/
+    ├── cowpy-COLLECTED-batch-output.txt
+    ├── intermediates
+    │   ├── Bonjour-output.txt
+    │   ├── COLLECTED-batch-output.txt
+    │   ├── Hello-output.txt
+    │   ├── Holà-output.txt
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    └── batch-report.txt
+    ```
+
+Die finale ASCII-Kunst-Ausgabe befindet sich im Verzeichnis `results/hello_containers/`, unter dem Namen `cowpy-COLLECTED-batch-output.txt`.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="results/hello_containers/cowpy-COLLECTED-batch-output.txt"
+    _________
+    / HOLà    \
+    | HELLO   |
+    \ BONJOUR /
+    ---------
+      \                                  ,+*^^*+___+++_
+      \                           ,*^^^^              )
+        \                       _+*                     ^**+_
+        \                    +^       _ _++*+_+++_,         )
+                  _+^^*+_    (     ,+*^ ^          \+_        )
+                {       )  (    ,(    ,_+--+--,      ^)      ^\
+                { (\@)    } f   ,(  ,+-^ __*_*_  ^^\_   ^\       )
+              {:;-/    (_+*-+^^^^^+*+*<_ _++_)_    )    )      /
+              ( /  (    (        ,___    ^*+_+* )   <    <      \
+              U _/     )    *--<  ) ^\-----++__)   )    )       )
+                (      )  _(^)^^))  )  )\^^^^^))^*+/    /       /
+              (      /  (_))_^)) )  )  ))^^^^^))^^^)__/     +^^
+            (     ,/    (^))^))  )  ) ))^^^^^^^))^^)       _)
+              *+__+*       (_))^)  ) ) ))^^^^^^))^^^^^)____*^
+              \             \_)^)_)) ))^^^^^^^^^^))^^^^)
+              (_             ^\__^^^^^^^^^^^^))^^^^^^^)
+                ^\___            ^\__^^^^^^))^^^^^^^^)\\
+                      ^^^^^\uuu/^^\uuu/^^^^\^\^\^\^\^\^\^\
+                        ___) >____) >___   ^\_\_\_\_\_\_\)
+                        ^^^//\\_^^//\\_^       ^(\_\_\_\)
+                          ^^^ ^^ ^^^ ^
+    ```
+
+Und da ist er, unser wunderschöner Truthahn, der die Grüße wie gewünscht sagt.
+
+#### 2.3.4. Untersuchen, wie Nextflow die containerisierte Aufgabe gestartet hat
+
+Als letzten Abschluss dieses Abschnitts werfen wir einen Blick auf das Work-Unterverzeichnis für einen der `cowpy`-Prozessaufrufe, um etwas mehr Einblick zu bekommen, wie Nextflow unter der Haube mit Containern arbeitet.
+
+Überprüfe die Ausgabe deines `nextflow run`-Befehls, um den Pfad zum Work-Unterverzeichnis für den `cowpy`-Prozess zu finden.
+Wenn wir uns ansehen, was wir für die oben gezeigte Ausführung erhalten haben, beginnt die Konsolenprotokollzeile für den `cowpy`-Prozess mit `[98/656c6c]`.
+Das entspricht dem folgenden abgekürzten Verzeichnispfad: `work/98/656c6c`.
+
+In diesem Verzeichnis findest du die `.command.run`-Datei, die alle Befehle enthält, die Nextflow in deinem Namen während der Ausführung der Pipeline ausgeführt hat.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="work/98/656c6c90cce1667c094d880f4b6dcc/.command.run"
+    #!/bin/bash
+    ### ---
+    ### name: 'cowpy'
+    ### container: 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+    ### outputs:
+    ### - 'cowpy-COLLECTED-batch-output.txt'
+    ### ...
+    set -e
+    set -u
+    NXF_DEBUG=${NXF_DEBUG:=0}; [[ $NXF_DEBUG > 1 ]] && set -x
+    NXF_ENTRY=${1:-nxf_main}
+
+    ...
+
+    nxf_launch() {
+        docker run -i --cpu-shares 1024 -e "NXF_TASK_WORKDIR" -v /workspaces/training/hello-nextflow/work:/workspaces/training/hello-nextflow/work -w "$NXF_TASK_WORKDIR" --name $NXF_BOXID community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273 /bin/bash -ue /workspaces/training/hello-nextflow/work/98/656c6c90cce1667c094d880f4b6dcc/.command.sh
+    }
+
+    ...
+    ```
+
+Wenn du in dieser Datei nach `nxf_launch` suchst, solltest du so etwas sehen:
+
+```console
+nxf_launch() {
+    docker run -i --cpu-shares 1024 -e "NXF_TASK_WORKDIR" -v /workspaces/training/hello-nextflow/work:/workspaces/training/hello-nextflow/work -w "$NXF_TASK_WORKDIR" --name $NXF_BOXID community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273 /bin/bash -ue /workspaces/training/hello-nextflow/work/98/656c6c90cce1667c094d880f4b6dcc/.command.sh
+}
+```
+
+Wie du sehen kannst, verwendet Nextflow den `docker run`-Befehl, um den Prozessaufruf zu starten.
+Es bindet auch das entsprechende Work-Unterverzeichnis in den Container ein, setzt das Arbeitsverzeichnis innerhalb des Containers entsprechend und führt unser templated Bash-Script in der `.command.sh`-Datei aus.
+
+All die harte Arbeit, die wir im ersten Abschnitt manuell erledigen mussten? Nextflow erledigt das für uns hinter den Kulissen!
+
+```txt
+ _______________________
+< Hurray for robots...! >
+ -----------------------
+                               ,-----.
+                               |     |
+                            ,--|     |-.
+                     __,----|  |     | |
+                   ,;::     |  `_____' |
+                   `._______|    i^i   |
+                            `----| |---'| .
+                       ,-------._| |== ||//
+                       |       |_|P`.  /'/
+                       `-------' 'Y Y/'/'
+                                 .==\ /_\
+   ^__^                         /   /'|  `i
+   (oo)\_______               /'   /  |   |
+   (__)\       )\/\         /'    /   |   `i
+       ||----w |           ___,;`----'.___L_,-'`\__
+       ||     ||          i_____;----\.____i""\____\
+```
+
+### Erkenntnisse
+
+Du weißt, wie man Container in Nextflow verwendet, um Prozesse auszuführen.
+
+### Was kommt als Nächstes?
+
+Mach eine Pause!
+
+Wenn du bereit bist, gehe zu [**Teil 6: Hello Config**](./06_hello_config.md) weiter, um zu lernen, wie du die Ausführung deiner Pipeline an deine Infrastruktur anpasst sowie die Konfiguration von Eingaben und Parametern verwaltest.
+
+Es ist der allerletzte Teil, und dann bist du mit diesem Kurs fertig!
+
+---
+
+## Quiz
+
+<quiz>
+Was ist ein Container?
+- [ ] Eine Art virtuelle Maschine
+- [ ] Ein Dateikomprimierungsformat
+- [x] Eine leichtgewichtige, eigenständige ausführbare Einheit, die alles enthält, was zum Ausführen einer Anwendung benötigt wird
+- [ ] Ein Netzwerkprotokoll
+</quiz>
+
+<quiz>
+Was ist der Unterschied zwischen einem Container-Image und einer Container-Instanz?
+- [ ] Sie sind dasselbe
+- [x] Ein Image ist eine Vorlage; eine Instanz ist ein laufender Container, der aus diesem Image erstellt wurde
+- [ ] Eine Instanz ist eine Vorlage; ein Image ist ein laufender Container
+- [ ] Images sind für Docker; Instanzen sind für Singularity
+</quiz>
+
+<quiz>
+Was macht das `-v`-Flag in einem `docker run`-Befehl?
+- [ ] Aktiviert ausführliche Ausgabe
+- [ ] Validiert den Container
+- [x] Bindet ein Volume vom Host-System in den Container ein
+- [ ] Gibt die Version des Containers an
+
+Mehr erfahren: [1.3.4. Daten in den Container einbinden](#134-daten-in-den-container-einbinden)
+</quiz>
+
+<quiz>
+Warum musst du Volumes einbinden, wenn du Container verwendest?
+- [ ] Um die Container-Leistung zu verbessern
+- [ ] Um Speicherplatz zu sparen
+- [x] Weil Container standardmäßig vom Host-Dateisystem isoliert sind
+- [ ] Um Netzwerke zu aktivieren
+
+Mehr erfahren: [1.3.4. Daten in den Container einbinden](#134-daten-in-den-container-einbinden)
+</quiz>
+
+<quiz>
+Wie gibst du einen Container für einen Nextflow-Prozess an?
+- [ ] `docker 'container-uri'`
+- [ ] `image 'container-uri'`
+- [x] `container 'container-uri'`
+- [ ] `use 'container-uri'`
+
+Mehr erfahren: [2.3.1. Einen Container für cowpy angeben](#231-einen-container-für-cowpy-angeben)
+</quiz>
+
+<quiz>
+Welche `nextflow.config`-Einstellung aktiviert Docker für deinen Workflow?
+- [ ] `#!groovy process.docker = true`
+- [x] `#!groovy docker.enabled = true`
+- [ ] `#!groovy container.engine = 'docker'`
+- [ ] `#!groovy docker.activate = true`
+
+Mehr erfahren: [2.3.2. Die Verwendung von Docker über die `nextflow.config`-Datei aktivieren](#232-die-verwendung-von-docker-über-die-nextflowconfig-datei-aktivieren)
+</quiz>
+
+<quiz>
+Was handhabt Nextflow automatisch, wenn ein Prozess in einem Container ausgeführt wird? (Wähle alle zutreffenden aus)
+- [x] Das Container-Image bei Bedarf pullen
+- [x] Das Work-Verzeichnis einbinden
+- [x] Das Prozess-Script innerhalb des Containers ausführen
+- [x] Die Container-Instanz nach der Ausführung bereinigen
+
+Mehr erfahren: [2.3.4. Untersuchen, wie Nextflow die containerisierte Aufgabe gestartet hat](#234-untersuchen-wie-nextflow-die-containerisierte-aufgabe-gestartet-hat)
+</quiz>

--- a/docs/de/docs/hello_nextflow/06_hello_config.md
+++ b/docs/de/docs/hello_nextflow/06_hello_config.md
@@ -1,0 +1,1417 @@
+# Teil 6: Hello Config
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/IuDO2HeKvXk?si=tnXTi6mRkITY0zW_&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Sieh dir [die ganze Playlist](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik) auf dem Nextflow YouTube-Kanal an.
+
+:green_book: Das Videotranskript ist [hier](./transcripts/06_hello_config.md) verfügbar.
+///
+
+Dieser Abschnitt wird untersuchen, wie du die Konfiguration deiner Nextflow-Pipeline einrichtest und verwaltest, damit du ihr Verhalten anpassen, sie an verschiedene Umgebungen anpassen und die Ressourcennutzung optimieren kannst, _ohne eine einzige Zeile des Workflow-Codes selbst zu ändern_.
+
+Es gibt mehrere Möglichkeiten, dies zu tun, die kombiniert werden können und gemäß der [hier](https://www.nextflow.io/docs/latest/config.html) beschriebenen Vorrangordnung interpretiert werden.
+
+In diesem Teil des Kurses zeigen wir dir den einfachsten und häufigsten Konfigurationsdatei-Mechanismus, die `nextflow.config`-Datei, die du bereits in Teil 5: Hello Containers kennengelernt hast.
+
+Wir gehen wesentliche Komponenten der Nextflow-Konfiguration durch, wie Prozess-Direktiven, Executors, Profile und Parameterdateien.
+Indem du lernst, diese Konfigurationsoptionen effektiv zu nutzen, kannst du die Flexibilität, Skalierbarkeit und Leistung deiner Pipelines verbessern.
+
+??? info "Wie du von diesem Abschnitt aus beginnst"
+
+    Dieser Abschnitt des Kurses setzt voraus, dass du die Teile 1-5 des [Hello Nextflow](./index.md)-Kurses abgeschlossen hast und eine vollständig funktionierende Pipeline hast.
+
+    Wenn du den Kurs von diesem Punkt aus beginnst, musst du das `modules`-Verzeichnis und die `nextflow.config`-Datei aus den Lösungen kopieren:
+
+    ```bash
+    cp -r solutions/5-hello-containers/modules .
+    cp solutions/5-hello-containers/nextflow.config .
+    ```
+
+    Die `nextflow.config`-Datei enthält die Zeile `docker.enabled = true`, die die Verwendung von Docker-Containern aktiviert.
+
+    Wenn du mit der Hello-Pipeline nicht vertraut bist oder eine Auffrischung brauchst, sieh dir [diese Infoseite](../info/hello_pipeline.md) an.
+
+---
+
+## 0. Aufwärmen: `hello-config.nf` ausführen
+
+Wir werden das Workflow-Script `hello-config.nf` als Ausgangspunkt verwenden.
+Es entspricht dem Script, das durch Durcharbeiten von Teil 5 dieses Kurses entstanden ist, außer dass wir die Ausgabeziele geändert haben:
+
+```groovy title="hello-config.nf" linenums="37" hl_lines="3 7 11 15"
+output {
+    first_output {
+        path 'hello_config/intermediates'
+        mode 'copy'
+    }
+    uppercased {
+        path 'hello_config/intermediates'
+        mode 'copy'
+    }
+    collected {
+        path 'hello_config/intermediates'
+        mode 'copy'
+    }
+    batch_report {
+        path 'hello_config'
+        mode 'copy'
+    }
+    cowpy_art {
+        path 'hello_config'
+        mode 'copy'
+    }
+}
+```
+
+Um sicherzustellen, dass alles funktioniert, führe das Script einmal aus, bevor du Änderungen vornimmst:
+
+```bash
+nextflow run hello-config.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+     N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [nice_escher] DSL2 - revision: d5dfdc9872
+
+    executor > local (7)
+    [6a/bc46a6] sayHello (2) [100%] 3 of 3 ✔
+    [33/67bc48] convertToUpper (3) [100%] 3 of 3 ✔
+    [b5/de03ba] collectGreetings [100%] 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Wie zuvor findest du die Ausgabedateien in dem im `output`-Block angegebenen Verzeichnis (`results/hello_config/`).
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    results/hello_config/
+    ├── cowpy-COLLECTED-batch-output.txt
+    ├── intermediates
+    │   ├── Bonjour-output.txt
+    │   ├── COLLECTED-batch-output.txt
+    │   ├── Hello-output.txt
+    │   ├── Holà-output.txt
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    └── batch-report.txt
+    ```
+
+Die finale ASCII-Kunst-Ausgabe befindet sich im Verzeichnis `results/hello_config/`, unter dem Namen `cowpy-COLLECTED-batch-output.txt`.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="results/hello_config/cowpy-COLLECTED-batch-output.txt"
+    _________
+    / HOLà    \
+    | HELLO   |
+    \ BONJOUR /
+    ---------
+      \                                  ,+*^^*+___+++_
+      \                           ,*^^^^              )
+        \                       _+*                     ^**+_
+        \                    +^       _ _++*+_+++_,         )
+                  _+^^*+_    (     ,+*^ ^          \+_        )
+                {       )  (    ,(    ,_+--+--,      ^)      ^\
+                { (\@)    } f   ,(  ,+-^ __*_*_  ^^\_   ^\       )
+              {:;-/    (_+*-+^^^^^+*+*<_ _++_)_    )    )      /
+              ( /  (    (        ,___    ^*+_+* )   <    <      \
+              U _/     )    *--<  ) ^\-----++__)   )    )       )
+                (      )  _(^)^^))  )  )\^^^^^))^*+/    /       /
+              (      /  (_))_^)) )  )  ))^^^^^))^^^)__/     +^^
+            (     ,/    (^))^))  )  ) ))^^^^^^^))^^)       _)
+              *+__+*       (_))^)  ) ) ))^^^^^^))^^^^^)____*^
+              \             \_)^)_)) ))^^^^^^^^^^))^^^^)
+              (_             ^\__^^^^^^^^^^^^))^^^^^^^)
+                ^\___            ^\__^^^^^^))^^^^^^^^)\\
+                      ^^^^^\uuu/^^\uuu/^^^^\^\^\^\^\^\^\^\
+                        ___) >____) >___   ^\_\_\_\_\_\_\)
+                        ^^^//\\_^^//\\_^       ^(\_\_\_\)
+                          ^^^ ^^ ^^^ ^
+    ```
+
+Wenn das bei dir funktioniert hat, bist du bereit zu lernen, wie man Pipelines konfiguriert.
+
+---
+
+## 1. Workflow-Eingabeparameter verwalten
+
+Wir beginnen mit einem Aspekt der Konfiguration, der einfach eine Erweiterung dessen ist, womit wir bisher gearbeitet haben: die Verwaltung von Eingabeparametern.
+
+Derzeit ist unser Workflow so eingerichtet, dass er mehrere Parameterwerte über die Befehlszeile akzeptiert, wobei Standardwerte in einem `params`-Block im Workflow-Script selbst festgelegt sind.
+Möglicherweise möchtest du diese Standardwerte jedoch überschreiben, ohne entweder Parameter in der Befehlszeile angeben oder die ursprüngliche Script-Datei ändern zu müssen.
+
+Es gibt mehrere Möglichkeiten, das zu tun; wir zeigen dir drei grundlegende Wege, die sehr häufig verwendet werden.
+
+### 1.1. Standardwerte in `nextflow.config` verschieben
+
+Dies ist der einfachste Ansatz, obwohl er möglicherweise am wenigsten flexibel ist, da die Haupt-`nextflow.config`-Datei nicht etwas ist, das du für jeden Lauf bearbeiten möchtest.
+Aber es hat den Vorteil, die Belange des _Deklarierens_ der Parameter im Workflow (was definitiv dorthin gehört) vom Bereitstellen von _Standardwerten_ zu trennen, die eher in einer Konfigurationsdatei zu Hause sind.
+
+Lass uns das in zwei Schritten tun.
+
+#### 1.1.1. Einen `params`-Block in der Konfigurationsdatei erstellen
+
+Nimm folgende Code-Änderungen in der `nextflow.config`-Datei vor:
+
+=== "Nachher"
+
+    ```groovy title="nextflow.config" linenums="1" hl_lines="3-10"
+    docker.enabled = true
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input = 'data/greetings.csv'
+        batch = 'batch'
+        character = 'turkey'
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="nextflow.config" linenums="1"
+    docker.enabled = true
+    ```
+
+Beachte, dass wir den `params`-Block nicht einfach vom Workflow in die Konfigurationsdatei kopiert haben.
+Die Syntax ist etwas anders.
+In der Workflow-Datei sind das typisierte Deklarationen.
+In der Konfiguration sind das Wertzuweisungen.
+
+Technisch gesehen reicht dies aus, um die Standardwerte zu überschreiben, die noch in der Workflow-Datei angegeben sind.
+Du könntest zum Beispiel den Charakter ändern und den Workflow ausführen, um dich zu vergewissern, dass der in der Konfigurationsdatei festgelegte Wert den in der Workflow-Datei festgelegten überschreibt.
+
+Aber im Sinne der vollständigen Verlagerung der Konfiguration in die Konfigurationsdatei, entfernen wir diese Werte vollständig aus der Workflow-Datei.
+
+#### 1.1.2. Die Werte aus dem `params`-Block in der Workflow-Datei entfernen
+
+Nimm folgende Code-Änderungen an der `hello-config.nf`-Workflow-Datei vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-config.nf" linenums="9" hl_lines="5-7"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path
+        batch: String
+        character: String
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-config.nf" linenums="9" hl_lines="5-7"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path = 'data/greetings.csv'
+        batch: String = 'batch'
+        character: String = 'turkey'
+    }
+    ```
+
+Jetzt setzt die Workflow-Datei selbst keine Standardwerte für diese Parameter.
+
+#### 1.1.3. Die Pipeline ausführen
+
+Lass uns testen, dass es korrekt funktioniert.
+
+```bash
+nextflow run hello-config.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [disturbed_einstein] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Dies produziert dieselbe Ausgabe wie zuvor.
+
+Die finale ASCII-Kunst-Ausgabe befindet sich im Verzeichnis `results/hello_config/`, unter dem Namen `cowpy-COLLECTED-batch-output.txt`, wie zuvor.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="results/hello_config/cowpy-COLLECTED-batch-output.txt"
+    _________
+    / HOLà    \
+    | HELLO   |
+    \ BONJOUR /
+    ---------
+      \                                  ,+*^^*+___+++_
+      \                           ,*^^^^              )
+        \                       _+*                     ^**+_
+        \                    +^       _ _++*+_+++_,         )
+                  _+^^*+_    (     ,+*^ ^          \+_        )
+                {       )  (    ,(    ,_+--+--,      ^)      ^\
+                { (\@)    } f   ,(  ,+-^ __*_*_  ^^\_   ^\       )
+              {:;-/    (_+*-+^^^^^+*+*<_ _++_)_    )    )      /
+              ( /  (    (        ,___    ^*+_+* )   <    <      \
+              U _/     )    *--<  ) ^\-----++__)   )    )       )
+                (      )  _(^)^^))  )  )\^^^^^))^*+/    /       /
+              (      /  (_))_^)) )  )  ))^^^^^))^^^)__/     +^^
+            (     ,/    (^))^))  )  ) ))^^^^^^^))^^)       _)
+              *+__+*       (_))^)  ) ) ))^^^^^^))^^^^^)____*^
+              \             \_)^)_)) ))^^^^^^^^^^))^^^^)
+              (_             ^\__^^^^^^^^^^^^))^^^^^^^)
+                ^\___            ^\__^^^^^^))^^^^^^^^)\\
+                      ^^^^^\uuu/^^\uuu/^^^^\^\^\^\^\^\^\^\
+                        ___) >____) >___   ^\_\_\_\_\_\_\)
+                        ^^^//\\_^^//\\_^       ^(\_\_\_\)
+                          ^^^ ^^ ^^^ ^
+    ```
+
+Funktional hat diese Verschiebung nichts geändert, aber konzeptionell ist es etwas sauberer, die Standardwerte in der Konfigurationsdatei zu haben.
+
+### 1.2. Eine laufspezifische Konfigurationsdatei verwenden
+
+Das ist großartig, aber manchmal möchtest du vielleicht einige temporäre Experimente mit anderen Standardwerten durchführen, ohne die Hauptkonfigurationsdatei zu ändern.
+Du kannst das tun, indem du eine neue `nextflow.config`-Datei in einem Unterverzeichnis erstellst, das du als Arbeitsverzeichnis für deine Experimente verwendest.
+
+#### 1.2.1. Das Arbeitsverzeichnis mit einer leeren Konfiguration erstellen
+
+Beginnen wir mit dem Erstellen eines neuen Verzeichnisses und wechseln hinein:
+
+```bash
+mkdir -p tux-run
+cd tux-run
+```
+
+Dann erstelle eine leere Konfigurationsdatei in diesem Verzeichnis:
+
+```bash
+touch nextflow.config
+```
+
+Dies erzeugt eine leere Datei.
+
+#### 1.2.2. Die experimentelle Konfiguration einrichten
+
+Öffne jetzt die neue Datei und füge die Parameter hinzu, die du anpassen möchtest:
+
+```groovy title="tux-run/nextflow.config" linenums="1"
+params {
+    input = '../data/greetings.csv'
+    batch = 'experiment'
+    character = 'tux'
+}
+```
+
+Beachte, dass der Pfad zur Eingabedatei die Verzeichnisstruktur widerspiegeln muss.
+
+#### 1.2.3. Die Pipeline ausführen
+
+Wir können jetzt unsere Pipeline aus unserem neuen Arbeitsverzeichnis ausführen.
+Stelle sicher, dass du den Pfad entsprechend anpasst!
+
+```bash
+nextflow run ../hello-config.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `../hello-config.nf` [trusting_escher] DSL2 - revision: 356df0818d
+
+    executor >  local (8)
+    [59/b66913] sayHello (2)       [100%] 3 of 3 ✔
+    [ad/f06364] convertToUpper (3) [100%] 3 of 3 ✔
+    [10/714895] collectGreetings   [100%] 1 of 1 ✔
+    [88/3ece98] cowpy              [100%] 1 of 1 ✔
+    ```
+
+Dies erstellt einen neuen Satz von Verzeichnissen unter `tux-run/` einschließlich `tux-run/work/` und `tux-run/results/`.
+
+Bei diesem Lauf kombiniert Nextflow die `nextflow.config` in unserem aktuellen Verzeichnis mit der `nextflow.config` im Stammverzeichnis der Pipeline und überschreibt dadurch den Standard-Charakter (turkey) mit dem tux-Charakter.
+
+Die finale Ausgabedatei sollte den tux-Charakter enthalten, der die Grüße sagt.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="tux-run/results/hello_config/cowpy-COLLECTED-experiment-output.txt"
+    _________
+    / HELLO   \
+    | BONJOUR |
+    \ HOLà    /
+    ---------
+      \
+        \
+            .--.
+          |o_o |
+          |:_/ |
+          //   \ \
+        (|     | )
+        /'\_   _/`\
+        \___)=(___/
+
+    ```
+
+Das war's; jetzt hast du einen Bereich zum Experimentieren, ohne deine 'normale' Konfiguration zu ändern.
+
+!!! Warnung
+
+    Stelle sicher, dass du zum vorherigen Verzeichnis zurückwechselst, bevor du zum nächsten Abschnitt übergehst!
+
+    ```bash
+    cd ..
+    ```
+
+Schauen wir uns jetzt eine weitere nützliche Möglichkeit an, Parameterwerte festzulegen.
+
+### 1.3. Eine Parameterdatei verwenden
+
+Der Unterverzeichnis-Ansatz funktioniert gut zum Experimentieren, erfordert aber etwas Einrichtung und dass du Pfade entsprechend anpasst.
+Es gibt einen einfacheren Ansatz, wenn du deine Pipeline mit einem bestimmten Satz von Werten ausführen möchtest, oder es jemand anderem mit minimalem Aufwand ermöglichen möchtest.
+
+Nextflow ermöglicht es uns, Parameter über eine Parameterdatei im YAML- oder JSON-Format anzugeben, was es sehr bequem macht, alternative Sätze von Standardwerten sowie laufspezifische Parameterwerte zu verwalten und zu verteilen.
+
+#### 1.3.1. Die Beispiel-Parameterdatei untersuchen
+
+Um dies zu demonstrieren, stellen wir eine Beispiel-Parameterdatei im aktuellen Verzeichnis bereit, genannt `test-params.yaml`:
+
+```yaml title="test-params.yaml" linenums="1"
+{
+  input: "greetings.csv"
+  batch: "yaml"
+  character: "stegosaurus"
+}
+```
+
+Diese Parameterdatei enthält ein Schlüssel-Wert-Paar für jede der Eingaben, die wir angeben möchten.
+Beachte die Verwendung von Doppelpunkten (`:`) anstelle von Gleichheitszeichen (`=`), wenn du die Syntax mit der Konfigurationsdatei vergleichst.
+Die Config-Datei ist in Groovy geschrieben, während die Parameterdatei in YAML geschrieben ist.
+
+!!! info
+
+    Wir stellen auch eine JSON-Version der Parameterdatei als Beispiel bereit, aber wir werden hier nicht damit arbeiten.
+    Probiere sie gerne selbst aus.
+
+#### 1.3.2. Die Pipeline ausführen
+
+Um den Workflow mit dieser Parameterdatei auszuführen, füge einfach `-params-file <filename>` zum Basisbefehl hinzu.
+
+```bash
+nextflow run hello-config.nf -params-file test-params.yaml
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [disturbed_sammet] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Die finale Ausgabedatei sollte den stegosaurus-Charakter enthalten, der die Grüße sagt.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="results/hello_config/cowpy-COLLECTED-yaml-output.txt"
+    _________
+    / HELLO   \
+    | HOLà    |
+    \ BONJOUR /
+    ---------
+    \                             .       .
+    \                           / `.   .' "
+      \                  .---.  <    > <    >  .---.
+      \                 |    \  \ - ~ ~ - /  /    |
+            _____          ..-~             ~-..-~
+            |     |   \~~~\.'                    `./~~~/
+          ---------   \__/                        \__/
+          .'  O    \     /               /       \  "
+        (_____,    `._.'               |         }  \/~~~/
+          `----.          /       }     |        /    \__/
+                `-.      |       /      |       /      `. ,~~|
+                    ~-.__|      /_ - ~ ^|      /- _      `..-'
+                        |     /        |     /     ~-.     `-. _  _  _
+                        |_____|        |_____|         ~ - . _ _ _ _ _>
+    ```
+
+Die Verwendung einer Parameterdatei mag übertrieben erscheinen, wenn du nur wenige Parameter angeben musst, aber einige Pipelines erwarten Dutzende von Parametern.
+In diesen Fällen ermöglicht uns die Verwendung einer Parameterdatei, Parameterwerte zur Laufzeit bereitzustellen, ohne massive Befehlszeilen eingeben oder das Workflow-Script ändern zu müssen.
+
+Es macht es auch einfacher, Parametersätze an Kollegen zu verteilen oder als ergänzende Informationen für eine Veröffentlichung bereitzustellen.
+Das macht deine Arbeit reproduzierbarer für andere.
+
+### Erkenntnisse
+
+Du weißt, wie du die wichtigsten Konfigurationsoptionen für die Verwaltung von Workflow-Eingaben nutzen kannst.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du verwaltest, wo und wie deine Workflow-Ausgaben veröffentlicht werden.
+
+---
+
+## 2. Workflow-Ausgaben verwalten
+
+Bisher haben wir alle Pfade für Workflow-Level-Ausgabedeklarationen hartcodiert, und wie wir beim Hinzufügen mehrerer Ausgaben festgestellt haben, kann dabei etwas Wiederholung auftreten.
+
+Schauen wir uns einige gängige Möglichkeiten an, wie du dies flexibler konfigurieren kannst.
+
+### 2.1. Den `outputDir`-Verzeichnisnamen anpassen
+
+Für jedes Kapitel dieses Kurses haben wir Ausgaben in ein anderes Unterverzeichnis veröffentlicht, das in den Ausgabedefinitionen hartcodiert ist.
+
+Ändern wir das, um einen benutzerdefinierbaren Parameter zu verwenden.
+Wir könnten einen ganz neuen Parameter dafür erstellen, aber verwenden wir den `batch`-Parameter, da er direkt verfügbar ist.
+
+#### 2.1.1. Einen Wert für `outputDir` in der Konfigurationsdatei festlegen
+
+Der Pfad, den Nextflow zum Veröffentlichen von Ausgaben verwendet, wird durch die Option `outputDir` gesteuert.
+Um den Pfad für alle Ausgaben zu ändern, kannst du einen Wert für diese Option in der `nextflow.config`-Konfigurationsdatei festlegen.
+
+Füge folgenden Code zur `nextflow.config`-Datei hinzu:
+
+=== "Nachher"
+
+    ```groovy title="nextflow.config" linenums="9" hl_lines="10-13"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input = 'data/greetings.csv'
+        batch = 'batch'
+        character = 'turkey'
+    }
+
+    /*
+    * Output settings
+    */
+    outputDir = "results/${params.batch}"
+    ```
+
+=== "Vorher"
+
+    ```groovy title="nextflow.config" linenums="9"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input = 'data/greetings.csv'
+        batch = 'batch'
+        character = 'turkey'
+    }
+    ```
+
+Dies ersetzt den eingebauten Standardpfad, `results/`, durch `results/` plus den Wert des `batch`-Parameters als Unterverzeichnis.
+Du könntest auch den `results`-Teil ändern, wenn du möchtest.
+
+Für eine temporäre Änderung könntest du diese Option von der Befehlszeile aus mit dem Parameter `-output-dir` in deinem Befehl setzen (aber dann könntest du den `batch`-Parameterwert nicht verwenden).
+
+#### 2.1.2. Den wiederholten Teil des hartcodierten Pfads entfernen
+
+Wir haben immer noch ein Unterverzeichnis in den Ausgabeoptionen hartcodiert, also entfernen wir das jetzt.
+
+Nimm folgende Code-Änderungen in der Workflow-Datei vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-config.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path 'intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path 'intermediates'
+            mode 'copy'
+        }
+        collected {
+            path 'intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path ''
+            mode 'copy'
+        }
+        cowpy_art {
+            path ''
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-config.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path 'hello_config/intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path 'hello_config/intermediates'
+            mode 'copy'
+        }
+        collected {
+            path 'hello_config/intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path 'hello_config'
+            mode 'copy'
+        }
+        cowpy_art {
+            path 'hello_config'
+            mode 'copy'
+        }
+    }
+    ```
+
+Wir hätten auch einfach `${params.batch}` zu jedem Pfad hinzufügen können, anstatt den `outputDir`-Standard zu ändern, aber das ist prägnanter.
+
+#### 2.1.3. Die Pipeline ausführen
+
+Lass uns testen, dass es korrekt funktioniert, indem wir den Batch-Namen über die Befehlszeile auf `outdir` setzen.
+
+```bash
+nextflow run hello-config.nf --batch outdir
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [disturbed_einstein] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Dies produziert dieselbe Ausgabe wie zuvor, außer dass wir diesmal unsere Ausgaben unter `results/outdir/` finden.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    results/outdir/
+    ├── cowpy-COLLECTED-outdir-output.txt
+    ├── intermediates
+    │   ├── Bonjour-output.txt
+    │   ├── COLLECTED-outdir-output.txt
+    │   ├── Hello-output.txt
+    │   ├── Holà-output.txt
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    └── outdir-report.txt
+    ```
+
+Du kannst diesen Ansatz mit benutzerdefinierten Pfaddefinitionen kombinieren, um jede gewünschte Verzeichnishierarchie zu konstruieren.
+
+### 2.2. Ausgaben nach Prozess organisieren
+
+Eine beliebte Möglichkeit, Ausgaben weiter zu organisieren, ist es, sie nach Prozess zu ordnen, _d.h._ Unterverzeichnisse für jeden in der Pipeline ausgeführten Prozess zu erstellen.
+
+#### 2.2.1. Die Ausgabepfade durch eine Referenz auf Prozessnamen ersetzen
+
+Alles, was du tun musst, ist den Namen des Prozesses als `<task>.name` in der Ausgabepfad-Deklaration zu referenzieren.
+
+Nimm folgende Änderungen in der Workflow-Datei vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-config.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path { sayHello.name }
+            mode 'copy'
+        }
+        uppercased {
+            path { convertToUpper.name }
+            mode 'copy'
+        }
+        collected {
+            path { collectGreetings.name }
+            mode 'copy'
+        }
+        batch_report {
+            path { collectGreetings.name }
+            mode 'copy'
+        }
+        cowpy_art {
+            path { cowpy.name }
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-config.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path 'intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path 'intermediates'
+            mode 'copy'
+        }
+        collected {
+            path 'intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path ''
+            mode 'copy'
+        }
+        cowpy_art {
+            path ''
+            mode 'copy'
+        }
+    }
+    ```
+
+Dies entfernt die verbleibenden hartcodierten Elemente aus der Ausgabepfad-Konfiguration.
+
+#### 2.2.2. Die Pipeline ausführen
+
+Lass uns testen, dass es korrekt funktioniert, indem wir den Batch-Namen über die Befehlszeile auf `pnames` setzen.
+
+```bash
+nextflow run hello-config.nf --batch pnames
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [jovial_mcclintock] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Dies produziert dieselbe Ausgabe wie zuvor, außer dass wir diesmal unsere Ausgaben unter `results/pnames/` finden, und sie sind nach Prozess gruppiert.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    results/pnames/
+    ├── collectGreetings
+    │   ├── COLLECTED-pnames-output.txt
+    │   └── pnames-report.txt
+    ├── convertToUpper
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    ├── cowpy
+    │   └── cowpy-COLLECTED-pnames-output.txt
+    └── sayHello
+        ├── Bonjour-output.txt
+        ├── Hello-output.txt
+        └── Holà-output.txt
+    ```
+
+Beachte, dass wir hier die Unterscheidung zwischen `intermediates` gegenüber finalen Ausgaben auf der obersten Ebene aufgehoben haben.
+Du könntest natürlich diese Ansätze mischen, zum Beispiel indem du den Pfad der ersten Ausgabe als `intermediates/${sayHello.process}` setzt.
+
+### 2.3. Den Veröffentlichungsmodus auf Workflow-Ebene festlegen
+
+Schließlich können wir im Sinne der Reduzierung von repetitivem Code die pro-Ausgabe-`mode`-Deklarationen durch eine einzelne Zeile in der Konfiguration ersetzen.
+
+#### 2.3.1. `workflow.output.mode` zur Konfigurationsdatei hinzufügen
+
+Füge folgenden Code zur `nextflow.config`-Datei hinzu:
+
+=== "Nachher"
+
+    ```groovy title="nextflow.config" linenums="2" hl_lines="5"
+    /*
+    * Output settings
+    */
+    outputDir = "results/${params.batch}"
+    workflow.output.mode = 'copy'
+    ```
+
+=== "Vorher"
+
+    ```groovy title="nextflow.config" linenums="12"
+    /*
+    * Output settings
+    */
+    outputDir = "results/${params.batch}"
+    ```
+
+Genau wie bei der `outputDir`-Option würde es ausreichen, `workflow.output.mode` einen Wert in der Konfigurationsdatei zu geben, um das zu überschreiben, was in der Workflow-Datei festgelegt ist, aber entfernen wir den unnötigen Code trotzdem.
+
+#### 2.3.2. Den Ausgabemodus aus der Workflow-Datei entfernen
+
+Nimm folgende Änderungen in der Workflow-Datei vor:
+
+=== "Nachher"
+
+    ```groovy title="hello-config.nf" linenums="42"
+    output {
+        first_output {
+            path { sayHello.process }
+        }
+        uppercased {
+            path { convertToUpper.process }
+        }
+        collected {
+            path { collectGreetings.process }
+        }
+        batch_report {
+            path { collectGreetings.process }
+        }
+        cowpy_art {
+            path { cowpy.process }
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="hello-config.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path { sayHello.process }
+            mode 'copy'
+        }
+        uppercased {
+            path { convertToUpper.process }
+            mode 'copy'
+        }
+        collected {
+            path { collectGreetings.process }
+            mode 'copy'
+        }
+        batch_report {
+            path { collectGreetings.process }
+            mode 'copy'
+        }
+        cowpy_art {
+            path { cowpy.process }
+            mode 'copy'
+        }
+    }
+    ```
+
+Das ist doch prägnanter, oder?
+
+#### 2.3.3. Die Pipeline ausführen
+
+Lass uns testen, dass es korrekt funktioniert, indem wir den Batch-Namen über die Befehlszeile auf `outmode` setzen.
+
+```bash
+nextflow run hello-config.nf --batch outmode
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [rowdy_sagan] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Dies produziert dieselbe Ausgabe wie zuvor, außer dass wir diesmal unsere Ausgaben unter `results/outmode/` finden.
+Sie sind alle noch echte Kopien, keine Symlinks.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    results/outmode/
+    ├── collectGreetings
+    │   ├── COLLECTED-outmode-output.txt
+    │   └── outmode-report.txt
+    ├── convertToUpper
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    ├── cowpy
+    │   └── cowpy-COLLECTED-outmode-output.txt
+    └── sayHello
+        ├── Bonjour-output.txt
+        ├── Hello-output.txt
+        └── Holà-output.txt
+    ```
+
+Der Hauptgrund, warum du möglicherweise immer noch die pro-Ausgabe-Methode zum Festlegen des Modus verwenden möchtest, ist, wenn du innerhalb desselben Workflows mischen möchtest, _d.h._ einige Ausgaben kopieren und einige als Symlinks haben möchtest.
+
+Es gibt viele andere Optionen, die du auf diese Weise anpassen kannst, aber hoffentlich gibt dir dies einen Eindruck von der Bandbreite der Optionen und wie du sie effektiv nutzen kannst, um deinen Präferenzen gerecht zu werden.
+
+### Erkenntnisse
+
+Du weißt, wie du die Benennung und Struktur der Verzeichnisse steuerst, in denen deine Ausgaben veröffentlicht werden, sowie den Workflow-Ausgabe-Veröffentlichungsmodus.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du deine Workflow-Konfiguration an deine Rechenumgebung anpasst, beginnend mit der Software-Paketierungstechnologie.
+
+---
+
+## 3. Eine Software-Paketierungstechnologie auswählen
+
+Bisher haben wir uns Konfigurationselemente angesehen, die steuern, wie Eingaben hineingehen und wo Ausgaben herauskommen. Jetzt ist es an der Zeit, uns genauer auf die Anpassung deiner Workflow-Konfiguration an deine Rechenumgebung zu konzentrieren.
+
+Der erste Schritt auf diesem Weg ist die Angabe, woher die Softwarepakete kommen, die in jedem Schritt ausgeführt werden.
+Sind sie bereits in der lokalen Rechenumgebung installiert?
+Müssen wir Images abrufen und über ein Container-System ausführen?
+Oder müssen wir Conda-Pakete abrufen und eine lokale Conda-Umgebung erstellen?
+
+Im allerersten Teil dieses Kurses (Teile 1-4) haben wir einfach lokal installierte Software in unserem Workflow verwendet.
+Dann haben wir in Teil 5 Docker-Container und die `nextflow.config`-Datei eingeführt, die wir verwendet haben, um die Verwendung von Docker-Containern zu aktivieren.
+
+Lass uns jetzt sehen, wie wir eine alternative Software-Paketierungsoption über die `nextflow.config`-Datei konfigurieren können.
+
+### 3.1. Docker deaktivieren und Conda in der Config-Datei aktivieren
+
+Stellen wir uns vor, wir arbeiten auf einem HPC-Cluster und der Administrator erlaubt die Verwendung von Docker aus Sicherheitsgründen nicht.
+Glücklicherweise unterstützt Nextflow mehrere andere Container-Technologien wie Singularity (das auf HPC weiter verbreitet ist) sowie Software-Paketmanager wie Conda.
+
+Wir können unsere Konfigurationsdatei ändern, um Conda anstelle von Docker zu verwenden.
+Dazu ändern wir den Wert von `docker.enabled` auf `false` und fügen eine Direktive hinzu, die die Verwendung von Conda aktiviert:
+
+=== "Nachher"
+
+    ```groovy title="nextflow.config" linenums="1" hl_lines="1-2"
+    docker.enabled = false
+    conda.enabled = true
+    ```
+
+=== "Vorher"
+
+    ```groovy title="nextflow.config" linenums="1" hl_lines="1"
+    docker.enabled = true
+    ```
+
+Dies ermöglicht es Nextflow, Conda-Umgebungen für Prozesse zu erstellen und zu nutzen, die Conda-Pakete angegeben haben.
+Das bedeutet, dass wir jetzt eines davon zu unserem `cowpy`-Prozess hinzufügen müssen!
+
+### 3.2. Ein Conda-Paket in der Prozessdefinition angeben
+
+Wir haben bereits die URI für ein Conda-Paket abgerufen, das das `cowpy`-Tool enthält: `conda-forge::cowpy==1.1.5`
+
+Jetzt fügen wir die URI zur `cowpy`-Prozessdefinition hinzu, indem wir die `conda`-Direktive verwenden:
+
+=== "Nachher"
+
+    ```groovy title="modules/cowpy.nf" linenums="4" hl_lines="4"
+    process cowpy {
+
+        container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+        conda 'conda-forge::cowpy==1.1.5'
+
+        input:
+    ```
+
+=== "Vorher"
+
+    ```groovy title="modules/cowpy.nf" linenums="4"
+    process cowpy {
+
+        container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+
+        input:
+    ```
+
+Um klar zu sein, wir _ersetzen_ nicht die `docker`-Direktive, wir _fügen_ eine alternative Option hinzu.
+
+!!! Tipp
+
+    Es gibt einige verschiedene Möglichkeiten, die URI für ein bestimmtes Conda-Paket zu erhalten.
+    Wir empfehlen die Verwendung der [Seqera Containers](https://seqera.io/containers/)-Suchabfrage, die dir eine URI gibt, die du kopieren und einfügen kannst, auch wenn du nicht vorhast, einen Container daraus zu erstellen.
+
+### 3.3. Den Workflow ausführen, um zu überprüfen, dass er Conda verwenden kann
+
+Probieren wir es aus.
+
+```bash
+nextflow run hello-config.nf --batch conda
+```
+
+??? success "Befehlsausgabe"
+
+    ```console title="Output"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [trusting_lovelace] DSL2 - revision: 028a841db1
+
+    executor >  local (8)
+    [ee/4ca1f2] sayHello (3)       | 3 of 3 ✔
+    [20/2596a7] convertToUpper (1) | 3 of 3 ✔
+    [b3/e15de5] collectGreetings   | 1 of 1 ✔
+    [c5/af5f88] cowpy              | 1 of 1 ✔
+    ```
+
+Dies sollte ohne Probleme funktionieren und dieselben Ausgaben wie zuvor unter `results/conda` produzieren.
+
+Hinter den Kulissen hat Nextflow die Conda-Pakete abgerufen und die Umgebung erstellt, was normalerweise etwas Arbeit erfordert; es ist also schön, dass wir das nicht selbst tun müssen!
+
+!!! Hinweis
+
+    Dies läuft schnell, weil das `cowpy`-Paket ziemlich klein ist, aber wenn du mit großen Paketen arbeitest, kann es beim ersten Mal etwas länger dauern als üblich, und du könntest sehen, dass die Konsolenausgabe für eine Minute oder so 'hängen bleibt', bevor sie abgeschlossen wird.
+    Das ist normal und liegt an der zusätzlichen Arbeit, die Nextflow beim ersten Mal erledigt, wenn du ein neues Paket verwendest.
+
+Aus unserer Sicht sieht es so aus, als würde es genauso funktionieren wie mit Docker, obwohl die Mechanik im Backend etwas anders ist.
+
+Das bedeutet, dass wir bereit sind, mit Conda-Umgebungen zu arbeiten, wenn nötig.
+
+??? info "Docker und Conda mischen"
+
+    Da diese Direktiven pro Prozess zugewiesen werden, ist es möglich, 'zu mischen', _d.h._ einige Prozesse in deinem Workflow mit Docker und andere mit Conda auszuführen, zum Beispiel wenn die Recheninfrastruktur, die du verwendest, beides unterstützt.
+    In diesem Fall würdest du sowohl Docker als auch Conda in deiner Konfigurationsdatei aktivieren.
+    Wenn beide für einen bestimmten Prozess verfügbar sind, wird Nextflow Container priorisieren.
+
+    Und wie bereits erwähnt, unterstützt Nextflow mehrere andere Software-Paketierungs- und Container-Technologien, du bist also nicht nur auf diese beiden beschränkt.
+
+### Erkenntnisse
+
+Du weißt, wie du konfigurierst, welches Softwarepaket jeder Prozess verwenden soll, und wie du zwischen Technologien wechseln kannst.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du die Ausführungsplattform änderst, die Nextflow verwendet, um die eigentliche Arbeit zu erledigen.
+
+---
+
+## 4. Eine Ausführungsplattform auswählen
+
+Bis jetzt haben wir unsere Pipeline mit dem lokalen Executor ausgeführt.
+Dieser führt jede Aufgabe auf der Maschine aus, auf der Nextflow läuft.
+Wenn Nextflow startet, schaut es sich die verfügbaren CPUs und den Speicher an.
+Wenn die Ressourcen der zur Ausführung bereiten Aufgaben die verfügbaren Ressourcen übersteigen, hält Nextflow die letzten Aufgaben von der Ausführung zurück, bis eine oder mehrere der früheren Aufgaben abgeschlossen sind und die notwendigen Ressourcen freigeben.
+
+Der lokale Executor ist bequem und effizient, aber er ist auf diese einzelne Maschine beschränkt. Bei sehr großen Arbeitslasten könntest du feststellen, dass deine lokale Maschine ein Engpass ist, entweder weil du eine einzelne Aufgabe hast, die mehr Ressourcen erfordert als verfügbar sind, oder weil du so viele Aufgaben hast, dass das Warten auf eine einzelne Maschine zu lange dauern würde.
+
+Nextflow unterstützt [viele verschiedene Ausführungs-Backends](https://www.nextflow.io/docs/latest/executor.html), einschließlich HPC-Scheduler (Slurm, LSF, SGE, PBS, Moab, OAR, Bridge, HTCondor und andere) sowie Cloud-Ausführungs-Backends wie (AWS Batch, Google Cloud Batch, Azure Batch, Kubernetes und mehr).
+
+### 4.1. Ein anderes Backend anvisieren
+
+Die Wahl des Executors wird durch eine Prozess-Direktive namens `executor` festgelegt.
+Standardmäßig ist sie auf `local` gesetzt, daher ist die folgende Konfiguration impliziert:
+
+```groovy title="Eingebaute Konfiguration"
+process {
+    executor = 'local'
+}
+```
+
+Um den Executor auf ein anderes Backend zu setzen, gibst du einfach den gewünschten Executor mit einer ähnlichen Syntax an, wie oben für Ressourcenzuweisungen beschrieben (siehe [Dokumentation](https://www.nextflow.io/docs/latest/executor.html) für alle Optionen).
+
+```groovy title="nextflow.config"
+process {
+    executor = 'slurm'
+}
+```
+
+!!! Warnung
+
+    Wir können dies in der Trainingsumgebung nicht tatsächlich testen, weil sie nicht für die Verbindung mit einem HPC eingerichtet ist.
+
+### 4.2. Mit backend-spezifischer Syntax für Ausführungsparameter umgehen
+
+Die meisten Hochleistungsrechenplattformen erlauben (und erfordern manchmal), dass du bestimmte Parameter wie Ressourcenzuweisungsanfragen und -beschränkungen (z.B. Anzahl der CPUs und Speicher) und den Namen der zu verwendenden Job-Warteschlange angibst.
+
+Leider verwendet jedes dieser Systeme unterschiedliche Technologien, Syntaxen und Konfigurationen, um zu definieren, wie ein Job definiert und an den entsprechenden Scheduler übermittelt werden soll.
+
+??? abstract "Beispiele"
+
+    Zum Beispiel muss derselbe Job, der 8 CPUs und 4GB RAM benötigt und in der Warteschlange "my-science-work" ausgeführt werden soll, je nach Backend auf unterschiedliche Weise ausgedrückt werden.
+
+    ```bash title="Config für SLURM / Übermittlung mit sbatch"
+    #SBATCH -o /path/to/my/task/directory/my-task-1.log
+    #SBATCH --no-requeue
+    #SBATCH -c 8
+    #SBATCH --mem 4096M
+    #SBATCH -p my-science-work
+    ```
+
+    ```bash title="Config für PBS / Übermittlung mit qsub"
+    #PBS -o /path/to/my/task/directory/my-task-1.log
+    #PBS -j oe
+    #PBS -q my-science-work
+    #PBS -l nodes=1:ppn=5
+    #PBS -l mem=4gb
+    ```
+
+    ```bash title="Config für SGE / Übermittlung mit qsub"
+    #$ -o /path/to/my/task/directory/my-task-1.log
+    #$ -j y
+    #$ -terse
+    #$ -notify
+    #$ -q my-science-work
+    #$ -l slots=5
+    #$ -l h_rss=4096M,mem_free=4096M
+    ```
+
+Glücklicherweise vereinfacht Nextflow all das.
+Es bietet eine standardisierte Syntax, damit du die relevanten Eigenschaften wie `cpus`, `memory` und `queue` (siehe Dokumentation für andere Eigenschaften) nur einmal angeben kannst.
+Dann wird Nextflow zur Laufzeit diese Einstellungen verwenden, um die entsprechenden backend-spezifischen Scripts basierend auf der Executor-Einstellung zu generieren.
+
+Wir werden diese standardisierte Syntax im nächsten Abschnitt behandeln.
+
+### Erkenntnisse
+
+Du weißt jetzt, wie du den Executor änderst, um verschiedene Arten von Recheninfrastruktur zu nutzen.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du Ressourcenzuweisungen und -beschränkungen in Nextflow evaluierst und ausdrückst.
+
+---
+
+## 5. Rechenressourcen-Zuweisungen steuern
+
+Die meisten Hochleistungsrechenplattformen erlauben (und erfordern manchmal), dass du bestimmte Ressourcenzuweisungsparameter wie Anzahl der CPUs und Speicher angibst.
+
+Standardmäßig verwendet Nextflow eine einzelne CPU und 2GB Speicher für jeden Prozess.
+Die entsprechenden Prozess-Direktiven heißen `cpus` und `memory`, daher ist die folgende Konfiguration impliziert:
+
+```groovy title="Eingebaute Konfiguration" linenums="1"
+process {
+    cpus = 1
+    memory = 2.GB
+}
+```
+
+Du kannst diese Werte ändern, entweder für alle Prozesse oder für bestimmte benannte Prozesse, indem du zusätzliche Prozess-Direktiven in deiner Konfigurationsdatei verwendest.
+Nextflow wird sie in die entsprechenden Anweisungen für den gewählten Executor übersetzen.
+
+Aber woher weißt du, welche Werte du verwenden sollst?
+
+### 5.1. Den Workflow ausführen, um einen Ressourcennutzungsbericht zu generieren
+
+Wenn du nicht im Voraus weißt, wie viel CPU und Speicher deine Prozesse wahrscheinlich benötigen werden, kannst du ein Ressourcen-Profiling durchführen, das heißt, du führst den Workflow mit einigen Standard-Zuweisungen aus, zeichnest auf, wie viel jeder Prozess verwendet hat, und schätzt von dort aus, wie du die Basis-Zuweisungen anpassen solltest.
+
+Praktischerweise enthält Nextflow eingebaute Tools dafür und wird auf Anfrage gerne einen Bericht für dich erstellen.
+
+Dazu füge `-with-report <filename>.html` zu deiner Befehlszeile hinzu.
+
+```bash
+nextflow run hello-config.nf -with-report report-config-1.html
+```
+
+Der Bericht ist eine HTML-Datei, die du herunterladen und in deinem Browser öffnen kannst. Du kannst auch mit der rechten Maustaste darauf klicken im Datei-Explorer auf der linken Seite und auf `Show preview` klicken, um ihn in der Trainingsumgebung anzuzeigen.
+
+Nimm dir ein paar Minuten, um den Bericht durchzusehen und zu schauen, ob du einige Möglichkeiten zur Anpassung der Ressourcen identifizieren kannst.
+Klicke unbedingt auf die Tabs, die die Nutzungsergebnisse als Prozentsatz dessen zeigen, was zugewiesen wurde.
+Es gibt [Dokumentation](https://www.nextflow.io/docs/latest/reports.html), die alle verfügbaren Funktionen beschreibt.
+
+### 5.2. Ressourcenzuweisungen für alle Prozesse festlegen
+
+Das Profiling zeigt, dass die Prozesse in unserem Trainings-Workflow sehr leichtgewichtig sind, also reduzieren wir die Standard-Speicherzuweisung auf 1GB pro Prozess.
+
+Füge Folgendes zu deiner `nextflow.config`-Datei hinzu, vor dem Pipeline-Parameter-Abschnitt:
+
+```groovy title="nextflow.config" linenums="4"
+/*
+* Process settings
+*/
+process {
+    memory = 1.GB
+}
+```
+
+Das wird helfen, den Rechenverbrauch zu reduzieren.
+
+### 5.3. Ressourcenzuweisungen für einen bestimmten Prozess festlegen
+
+Gleichzeitig werden wir so tun, als ob der `cowpy`-Prozess mehr Ressourcen benötigt als die anderen, nur um zu demonstrieren, wie man Zuweisungen für einen einzelnen Prozess anpasst.
+
+=== "Nachher"
+
+    ```groovy title="nextflow.config" linenums="4" hl_lines="6-9"
+    /*
+    * Process settings
+    */
+    process {
+        memory = 1.GB
+        withName: 'cowpy' {
+            memory = 2.GB
+            cpus = 2
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="nextflow.config" linenums="4"
+    /*
+    * Process settings
+    */
+    process {
+        memory = 1.GB
+    }
+    ```
+
+Mit dieser Konfiguration werden alle Prozesse 1GB Speicher und eine einzelne CPU (der implizierte Standard) anfordern, außer dem `cowpy`-Prozess, der 2GB und 2 CPUs anfordern wird.
+
+!!! Tipp
+
+    Wenn du eine Maschine mit wenigen CPUs hast und eine hohe Anzahl pro Prozess zuweist, könntest du sehen, dass Prozessaufrufe hintereinander in die Warteschlange gestellt werden.
+    Das liegt daran, dass Nextflow sicherstellt, dass wir nicht mehr CPUs anfordern als verfügbar sind.
+
+### 5.4. Den Workflow mit der aktualisierten Konfiguration ausführen
+
+Probieren wir das aus, indem wir einen anderen Dateinamen für den Profiling-Bericht angeben, damit wir die Leistung vor und nach den Konfigurationsänderungen vergleichen können.
+
+```bash
+nextflow run hello-config.nf -with-report report-config-2.html
+```
+
+Du wirst wahrscheinlich keinen echten Unterschied bemerken, da dies eine so kleine Arbeitslast ist, aber das ist der Ansatz, den du verwenden würdest, um die Leistung und Ressourcenanforderungen eines realen Workflows zu analysieren.
+
+Es ist sehr nützlich, wenn deine Prozesse unterschiedliche Ressourcenanforderungen haben. Es ermöglicht dir, die Ressourcenzuweisungen, die du für jeden Prozess einrichtest, basierend auf tatsächlichen Daten richtig zu dimensionieren, nicht auf Vermutungen.
+
+!!! Tipp
+
+    Dies ist nur ein kleiner Vorgeschmack dessen, was du tun kannst, um deine Ressourcennutzung zu optimieren.
+    Nextflow selbst hat eine wirklich raffinierte [dynamische Wiederholungslogik](https://www.nextflow.io/docs/latest/process.html#dynamic-task-resources) eingebaut, um Jobs, die aufgrund von Ressourcenbeschränkungen fehlschlagen, automatisch zu wiederholen.
+    Zusätzlich bietet die Seqera Platform KI-gestützte Tools zur automatischen Optimierung deiner Ressourcenzuweisungen.
+
+### 5.5. Ressourcenlimits hinzufügen
+
+Abhängig davon, welchen Rechen-Executor und welche Recheninfrastruktur du verwendest, kann es Einschränkungen geben, was du zuweisen kannst (oder musst).
+Zum Beispiel kann dein Cluster erfordern, dass du innerhalb bestimmter Grenzen bleibst.
+
+Du kannst die `resourceLimits`-Direktive verwenden, um die relevanten Beschränkungen festzulegen. Die Syntax sieht so aus, wenn sie allein in einem Process-Block steht:
+
+```groovy title="Syntax-Beispiel"
+process {
+    resourceLimits = [
+        memory: 750.GB,
+        cpus: 200,
+        time: 30.d
+    ]
+}
+```
+
+Nextflow wird diese Werte in die entsprechenden Anweisungen übersetzen, abhängig vom Executor, den du angegeben hast.
+
+Wir werden das nicht ausführen, da wir in der Trainingsumgebung keinen Zugang zu relevanter Infrastruktur haben.
+Wenn du jedoch versuchen würdest, den Workflow mit Ressourcenzuweisungen auszuführen, die diese Limits überschreiten, und dann den `sbatch`-Befehl in der `.command.run`-Script-Datei nachschlagen würdest, würdest du sehen, dass die Anfragen, die tatsächlich an den Executor gesendet werden, bei den durch `resourceLimits` angegebenen Werten gedeckelt sind.
+
+??? info "Institutionelle Referenzkonfigurationen"
+
+    Das nf-core-Projekt hat eine [Sammlung von Konfigurationsdateien](https://nf-co.re/configs/) zusammengestellt, die von verschiedenen Institutionen weltweit geteilt werden und eine breite Palette von HPC- und Cloud-Executors abdecken.
+
+    Diese geteilten Configs sind sowohl für Personen wertvoll, die dort arbeiten und daher einfach die Konfiguration ihrer Institution direkt nutzen können, als auch als Modell für Personen, die eine Konfiguration für ihre eigene Infrastruktur entwickeln möchten.
+
+### Erkenntnisse
+
+Du weißt, wie du einen Profiling-Bericht erstellst, um die Ressourcennutzung zu bewerten, und wie du Ressourcenzuweisungen für alle Prozesse und/oder für einzelne Prozesse änderst sowie Ressourcenbeschränkungen für die Ausführung auf HPC festlegst.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du voreingestellte Konfigurationsprofile einrichtest und zur Laufzeit zwischen ihnen wechselst.
+
+---
+
+## 6. Profile verwenden, um zwischen voreingestellten Konfigurationen zu wechseln
+
+Wir haben dir eine Reihe von Möglichkeiten gezeigt, wie du deine Pipeline-Konfiguration anpassen kannst, abhängig vom Projekt, an dem du arbeitest, oder der Rechenumgebung, die du verwendest.
+
+Möglicherweise möchtest du zwischen alternativen Einstellungen wechseln, abhängig davon, welche Recheninfrastruktur du verwendest. Zum Beispiel könntest du lokal auf deinem Laptop entwickeln und kleine Tests durchführen, dann vollständige Arbeitslasten auf HPC oder Cloud ausführen.
+
+Nextflow ermöglicht es dir, beliebig viele Profile einzurichten, die verschiedene Konfigurationen beschreiben, die du dann zur Laufzeit mit einem Befehlszeilenargument auswählen kannst, anstatt die Konfigurationsdatei selbst ändern zu müssen.
+
+### 6.1. Profile für den Wechsel zwischen lokaler Entwicklung und Ausführung auf HPC erstellen
+
+Lass uns zwei alternative Profile einrichten; eines für die Ausführung kleiner Lasten auf einem normalen Computer, wo wir Docker-Container verwenden werden, und eines für die Ausführung auf einem Universitäts-HPC mit einem Slurm-Scheduler, wo wir Conda-Pakete verwenden werden.
+
+#### 6.1.1. Die Profile einrichten
+
+Füge Folgendes zu deiner `nextflow.config`-Datei hinzu, nach dem Pipeline-Parameter-Abschnitt, aber vor den Ausgabe-Einstellungen:
+
+```groovy title="nextflow.config" linenums="24"
+/*
+* Profiles
+*/
+profiles {
+    my_laptop {
+        process.executor = 'local'
+        docker.enabled = true
+    }
+    univ_hpc {
+        process.executor = 'slurm'
+        conda.enabled = true
+        process.resourceLimits = [
+            memory: 750.GB,
+            cpus: 200,
+            time: 30.d
+        ]
+    }
+}
+```
+
+Du siehst, dass wir für das Universitäts-HPC auch Ressourcenbeschränkungen angeben.
+
+#### 6.1.2. Den Workflow mit einem Profil ausführen
+
+Um ein Profil in unserer Nextflow-Befehlszeile anzugeben, verwenden wir das Argument `-profile`.
+
+Versuchen wir, den Workflow mit der `my_laptop`-Konfiguration auszuführen.
+
+```bash
+nextflow run hello-config.nf -profile my_laptop
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [gigantic_brazil] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [58/da9437] sayHello (3)       | 3 of 3 ✔
+    [35/9cbe77] convertToUpper (2) | 3 of 3 ✔
+    [67/857d05] collectGreetings   | 1 of 1 ✔
+    [37/7b51b5] cowpy              | 1 of 1 ✔
+    ```
+
+Wie du sehen kannst, ermöglicht uns das, zur Laufzeit sehr bequem zwischen Konfigurationen zu wechseln.
+
+!!! Warnung
+
+    Das `univ_hpc`-Profil wird in der Trainingsumgebung nicht richtig funktionieren, da wir keinen Zugang zu einem Slurm-Scheduler haben.
+
+Wenn wir in Zukunft andere Konfigurationselemente finden, die immer mit diesen zusammen auftreten, können wir sie einfach zu den entsprechenden Profilen hinzufügen.
+Wir können auch zusätzliche Profile erstellen, wenn es andere Konfigurationselemente gibt, die wir zusammenfassen möchten.
+
+### 6.2. Ein Profil mit Testparametern erstellen
+
+Profile sind nicht nur für Infrastrukturkonfiguration.
+Wir können sie auch verwenden, um Standardwerte für Workflow-Parameter festzulegen, um es anderen zu erleichtern, den Workflow auszuprobieren, ohne selbst geeignete Eingabewerte sammeln zu müssen.
+Du kannst dies als Alternative zur Verwendung einer Parameterdatei betrachten.
+
+#### 6.2.1. Das Profil einrichten
+
+Die Syntax zum Ausdrücken von Standardwerten in diesem Kontext sieht so aus, für ein Profil, das wir `test` nennen:
+
+```groovy title="Syntax-Beispiel"
+    test {
+        params.<parameter1>
+        params.<parameter2>
+        ...
+    }
+```
+
+Wenn wir ein Testprofil für unseren Workflow hinzufügen, wird der `profiles`-Block zu:
+
+```groovy title="nextflow.config" linenums="24"
+/*
+* Profiles
+*/
+profiles {
+    my_laptop {
+        process.executor = 'local'
+        docker.enabled = true
+    }
+    univ_hpc {
+        process.executor = 'slurm'
+        conda.enabled = true
+        process.resourceLimits = [
+            memory: 750.GB,
+            cpus: 200,
+            time: 30.d
+        ]
+    }
+    test {
+        params.greeting = 'greetings.csv'
+        params.batch = 'test'
+        params.character = 'dragonandcow'
+    }
+}
+```
+
+Genau wie bei technischen Konfigurationsprofilen kannst du mehrere verschiedene Profile einrichten, die Parameter unter beliebigen Namen angeben.
+
+#### 6.2.2. Den Workflow lokal mit dem Testprofil ausführen
+
+Praktischerweise schließen sich Profile nicht gegenseitig aus, sodass wir mehrere Profile in unserer Befehlszeile mit der folgenden Syntax angeben können: `-profile <profile1>,<profile2>` (für beliebig viele Profile).
+
+Wenn du Profile kombinierst, die Werte für dieselben Konfigurationselemente festlegen und in derselben Konfigurationsdatei beschrieben sind, wird Nextflow den Konflikt lösen, indem es den Wert verwendet, den es zuletzt gelesen hat (_d.h._ was später in der Datei kommt).
+Wenn die widersprüchlichen Einstellungen in verschiedenen Konfigurationsquellen festgelegt sind, gilt die Standard-[Vorrangordnung](https://www.nextflow.io/docs/latest/config.html).
+
+Versuchen wir, das Testprofil zu unserem vorherigen Befehl hinzuzufügen:
+
+```bash
+nextflow run hello-config.nf -profile my_laptop,test
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `hello-config.nf` [jovial_coulomb] DSL2 - revision: 46a6763141
+
+    executor >  local (8)
+    [9b/687cdc] sayHello (2)       | 3 of 3 ✔
+    [ca/552187] convertToUpper (3) | 3 of 3 ✔
+    [e8/83e306] collectGreetings   | 1 of 1 ✔
+    [fd/e84fa9] cowpy              | 1 of 1 ✔
+    ```
+
+Dies wird Docker wo möglich verwenden und Ausgaben unter `results/test` produzieren, und diesmal ist der Charakter das komische Duo `dragonandcow`.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="results/test/"
+     _________
+    / HOLà    \
+    | HELLO   |
+    \ BONJOUR /
+    ---------
+    ...
+    ```
+
+### Erkenntnisse
+
+Du weißt, wie du Profile erstellst, um einfach zwischen voreingestellten Konfigurationsoptionen zur Laufzeit zu wechseln.
+
+### Was kommt als Nächstes?
+
+Herzlichen Glückwunsch, du hast Hello Nextflow abgeschlossen!
+
+Mach eine Pause und klopfe dir auf die Schulter. Du hast heute viel gelernt und bist nun bereit, die Welt der Nextflow-Workflow-Entwicklung zu erkunden.
+
+Gehe zu [**Nächste Schritte**](./next_steps.md) weiter, um zu sehen, was du als Nächstes tun kannst.

--- a/docs/de/docs/hello_nextflow/index.md
+++ b/docs/de/docs/hello_nextflow/index.md
@@ -1,0 +1,60 @@
+---
+title: Hello Nextflow
+hide:
+  - toc
+page_type: index_page
+index_type: course
+additional_information:
+  technical_requirements: true
+  learning_objectives:
+    - Starten und Verwalten der Ausführung von Nextflow-Workflows
+    - Finden und Interpretieren von Ausgaben (Ergebnissen) und Log-Dateien, die von Nextflow generiert werden
+    - Beheben grundlegender Probleme
+    - Erstellen eines einfachen mehrstufigen Workflows aus Nextflow-Kernkomponenten
+    - Unterscheiden zwischen wesentlichen Arten von channel factories und Operatoren und deren effektive Nutzung in einem einfachen Workflow
+    - Konfigurieren der Pipeline-Ausführung für gängige Rechenplattformen einschließlich HPC und Cloud
+    - Anwenden von Best Practices für Reproduzierbarkeit, Portabilität und Code-Wiederverwendung, die Pipelines FAIR machen, einschließlich Code-Modularität und Software-Container
+  audience_prerequisites:
+    - "**Zielgruppe:** Dieser Kurs ist für Lernende konzipiert, die komplett neu bei Nextflow sind und eigene Pipelines entwickeln möchten."
+    - "**Fähigkeiten:** Grundlegende Vertrautheit mit der Befehlszeile, grundlegenden Scripting-Konzepten und gängigen Dateiformaten wird vorausgesetzt."
+    - "**Fachgebiet:** Die Übungen sind alle fachgebietsunabhängig, daher ist kein wissenschaftliches Vorwissen erforderlich."
+  videos_playlist: https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik
+---
+
+# Hello Nextflow
+
+**Hello Nextflow ist eine praxisorientierte Einführung in den Aufbau reproduzierbarer und skalierbarer Datenanalyse-Workflows.**
+
+Durch praktische Beispiele und geführte Übungen lernst du die Grundlagen der Pipeline-Entwicklung mit Nextflow, einschließlich der Definition von Prozessen, deren Verbindung zu Pipelines, der Verwaltung von Dateien und Software-Abhängigkeiten, der mühelosen Parallelisierung der Ausführung und des Ausführens von Workflows in verschiedenen Rechenumgebungen.
+
+Du wirst die Fähigkeiten und das Selbstvertrauen mitnehmen, um eigene Workflows mit Nextflow zu entwickeln und auszuführen.
+
+<!-- additional_information -->
+
+## Kursübersicht
+
+Dieser Kurs ist praxisorientiert konzipiert, mit zielgerichteten Übungen, die Informationen schrittweise einführen.
+
+Du wirst eine einfache Nextflow-Pipeline entwickeln, die einige Texteingaben nimmt, einige Transformationsschritte ausführt und eine einzelne Textdatei mit einem ASCII-Bild einer Figur ausgibt, die den transformierten Text sagt.
+
+### Lektionsplan
+
+Um dich nicht mit Konzepten und Code zu überfordern, haben wir dies in sechs Teile aufgeteilt, die sich jeweils auf bestimmte Aspekte der Pipeline-Entwicklung mit Nextflow konzentrieren.
+
+| Kurskapitel                                          | Zusammenfassung                                                                                                          | Geschätzte Dauer |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| [Teil 1: Hello World](./01_hello_world.md)           | Grundlegende Komponenten und Prinzipien beim Zusammenstellen und Ausführen eines Nextflow-Workflows                      | 30 Min.          |
+| [Teil 2: Hello Channels](./02_hello_channels.md)     | Verwendung von channels und Operatoren zur Verarbeitung von Eingaben und müheloser Parallelisierung                      | 45 Min.          |
+| [Teil 3: Hello Workflow](./03_hello_workflow.md)     | Verwendung von channels zum Verketten mehrerer Schritte und Handhabung des Datentransfers zwischen Schritten             | 60 Min.          |
+| [Teil 4: Hello Modules](./04_hello_modules.md)       | Anwendung von Code-Modularitätsprinzipien zur Erhöhung der Wiederverwendbarkeit und Verringerung des Wartungsaufwands    | 20 Min.          |
+| [Teil 5: Hello Containers](./05_hello_containers.md) | Verwendung von Containern als Mechanismus zur Verwaltung von Software-Abhängigkeiten und Erhöhung der Reproduzierbarkeit | 60 Min.          |
+| [Teil 6: Hello Config](./06_hello_config.md)         | Anpassung des Pipeline-Verhaltens und Optimierung der Nutzung in verschiedenen Rechenumgebungen                          | 60 Min.          |
+
+Am Ende dieses Kurses wirst du gut vorbereitet sein, um die nächsten Schritte auf deiner Reise zur Entwicklung reproduzierbarer Workflows für deine wissenschaftlichen Rechenanforderungen anzugehen.
+
+Bereit, den Kurs zu starten?
+
+[Los geht's :material-arrow-right:](00_orientation.md){ .md-button .md-button--primary }
+
+<!-- Clearfix for float -->
+<div style="content: ''; clear: both; display: table;"></div>

--- a/docs/de/docs/hello_nextflow/next_steps.md
+++ b/docs/de/docs/hello_nextflow/next_steps.md
@@ -1,0 +1,64 @@
+# Kurszusammenfassung
+
+Herzlichen Glückwunsch zum Abschluss des Hello Nextflow-Trainingskurses!
+
+<div class="video-wrapper">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/xHOcx_4Ancg?si=Lp8hS8RdaMwbp5j5&amp;list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+/// caption
+:fontawesome-brands-youtube:{ .youtube } Siehe die [ganze Playlist auf dem Nextflow YouTube-Kanal](https://www.youtube.com/playlist?list=PLPZ8WHdZGxmXiHf8B26oB_fTfoKQdhlik).
+
+:green_book: Du kannst das [Video-Transkript](./transcripts/07_next_steps.md) neben dem Video lesen.
+///
+
+## Deine Reise
+
+Du hast mit einem sehr einfachen Workflow begonnen, der einen fest codierten Befehl ausführte.
+Im Laufe von sechs Teilen hast du diesen einfachen Workflow in eine modulare mehrstufige Pipeline verwandelt, die wichtige Funktionen von Nextflow nutzt, einschließlich channels, Operatoren, integrierter Container-Unterstützung und Konfigurationsoptionen.
+
+### Was du gebaut hast
+
+- Die endgültige Form des Hello-Workflows nimmt als Eingabe eine CSV-Datei mit Textbegrüßungen.
+- Die vier Schritte sind als Nextflow-Prozesse implementiert (`sayHello`, `convertToUpper`, `collectGreetings` und `cowpy`), die in separaten Moduldateien gespeichert sind.
+- Die Ergebnisse werden in einem Verzeichnis namens `results/` veröffentlicht.
+- Die endgültige Ausgabe der Pipeline ist eine einfache Textdatei mit ASCII-Kunst einer Figur, die die in Großbuchstaben konvertierten Begrüßungen sagt.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_pipeline_complete.svg"
+</figure>
+
+1. **`sayHello`:** Schreibt jede Begrüßung in ihre eigene Ausgabedatei (_z.B._ "Hello-output.txt")
+2. **`convertToUpper`:** Konvertiert jede Begrüßung in Großbuchstaben (_z.B._ "HELLO")
+3. **`collectGreetings`:** Sammelt alle Großbuchstaben-Begrüßungen in einer einzigen Batch-Datei
+4. **`cowpy`:** Generiert ASCII-Kunst mit dem `cowpy`-Tool
+
+Die Workflow-Konfiguration unterstützt die flexible und reproduzierbare Bereitstellung von Eingaben und Parametern.
+
+### Erworbene Fähigkeiten
+
+Durch diesen praxisorientierten Kurs hast du gelernt, wie du:
+
+- Nextflow-Kernkomponenten beschreiben und nutzen kannst, um einen einfachen mehrstufigen Workflow zu erstellen
+- Weiterführende Konzepte wie Operatoren und channel factories beschreiben kannst
+- Einen Nextflow-Workflow lokal starten kannst
+- Ausgaben (Ergebnisse) und Log-Dateien, die von Nextflow generiert werden, finden und interpretieren kannst
+- Grundlegende Probleme beheben kannst
+
+Du bist jetzt mit dem Grundwissen ausgestattet, um eigene Pipelines in Nextflow zu entwickeln.
+
+## Nächste Schritte zum Aufbau deiner Fähigkeiten
+
+Hier sind unsere Top-3-Vorschläge, was du als Nächstes tun solltest:
+
+- Wende Nextflow auf einen wissenschaftlichen Analyse-Anwendungsfall an mit [Nextflow für die Wissenschaft](../nf4_science/index.md)
+- Starte mit nf-core mit [Hello nf-core](../../hello_nf-core/index.md)
+- Erkunde fortgeschrittenere Nextflow-Funktionen mit den [Side Quests](../side_quests/index.md)
+
+Schließlich empfehlen wir dir, einen Blick auf [**Seqera Platform**](https://seqera.io/) zu werfen, eine Cloud-basierte Plattform, die von den Entwicklern von Nextflow entwickelt wurde und es noch einfacher macht, deine Workflows zu starten und zu verwalten, sowie deine Daten zu verwalten und Analysen interaktiv in jeder Umgebung auszuführen.
+
+## Feedback-Umfrage
+
+Bevor du weitermachst, nimm dir bitte eine Minute Zeit, um die Kursumfrage auszufüllen! Dein Feedback hilft uns, unsere Trainingsmaterialien für alle zu verbessern.
+
+[Zur Umfrage :material-arrow-right:](survey.md){ .md-button .md-button--primary }

--- a/docs/de/docs/hello_nextflow/survey.md
+++ b/docs/de/docs/hello_nextflow/survey.md
@@ -1,0 +1,7 @@
+# Feedback-Umfrage
+
+Bevor du weitermachst, fülle bitte diese kurze 5-Fragen-Umfrage aus, um das Training zu bewerten, Feedback zu deiner Erfahrung zu teilen und uns mitzuteilen, was wir noch tun könnten, um dir auf deiner Nextflow-Reise zu helfen.
+
+Das sollte weniger als eine Minute dauern. Vielen Dank, dass du uns hilfst, unsere Trainingsmaterialien für alle zu verbessern!
+
+<div data-tf-live="01JMHYE82Z92J2Q6Q3Z7QJ1BFW"></div><script src="//embed.typeform.com/next/embed.js"></script>

--- a/docs/de/docs/help.md
+++ b/docs/de/docs/help.md
@@ -1,0 +1,75 @@
+---
+title: Hilfe erhalten
+description: Hilfreiche Ressourcen bei Problemen mit dem Nextflow-Training
+hide:
+  - toc
+  - footer
+---
+
+# Hilfe erhalten
+
+Egal ob du Schwierigkeiten beim Einstieg hast, mittendrin nicht weiterkommst oder eine Anschlussfrage hast - zögere nicht, dich zu melden! Unser Community-Team ist hier, um zu helfen, und die Nextflow-Community insgesamt ist sehr aktiv, inklusiv und hilfsbereit.
+
+Hier sind die wichtigsten verfügbaren Optionen, je nachdem, wonach du suchst.
+
+<div class="grid cards" markdown>
+
+- :material-forum-outline:{ .lg .middle } **Community-Forum**
+
+  ***
+
+  Unser Community-Forum hat eine Kategorie, die dem Training gewidmet ist. Das ist ein großartiger Ort, um Fragen zu stellen oder Probleme zu melden, die du mit dem Training hast. Möglicherweise findest du sogar heraus, dass deine Frage bereits gestellt - und beantwortet wurde!
+
+  [Zum Trainingsforum:material-arrow-right:](https://community.seqera.io/c/training/39){ .md-button .md-button--primary .mt-1 }
+
+- :material-slack:{ .lg .middle } **Slack-Kanal**
+
+  ***
+
+  Wenn du auf Slack bist, kannst du uns gerne im Trainingskanal im Nextflow Slack Workspace kontaktieren. Der Nextflow Slack ist ein großartiger Ort, um mit anderen Entwicklern zu chatten und sich mit der Nextflow-Community im Allgemeinen auszutauschen.
+
+  [Dem Nextflow Slack beitreten :material-arrow-right:](https://www.nextflow.io/slack-invite.html){ .md-button .md-button--primary .mt-1 }
+
+- :material-github:{ .lg .middle } **GitHub Issues**
+
+  ***
+
+  Wenn du einen Fehler in den Trainingsmaterialien entdeckst, melde ihn bitte, indem du ein Issue im GitHub-Repository eröffnest. Ob es sich um einen Tippfehler, ein Formatierungsproblem oder einen tatsächlichen Bug handelt, der den Code betrifft - lass es uns wissen, damit wir es beheben können! Wir freuen uns auch über direkte PRs.
+
+  [Ein Issue melden:material-arrow-right:](https://github.com/nextflow-io/training/issues){ .md-button .md-button--primary .mt-1 }
+
+- :octicons-comment-ai-16:{ .lg .middle } **Seqera AI-Assistent**
+
+  ***
+
+  Seqera AI ist ein KI-Assistent, der auf Nextflow- und nf-core-Ressourcen trainiert wurde. Er kann dir helfen, deinen Code zu debuggen, Nextflow-Konzepte zu erklären und schneller nach Dokumentation zu suchen. Stell es dir wie einen Tutor vor, der rund um die Uhr verfügbar ist, während du die Kurse durcharbeitest.
+
+  [Seqera AI fragen:material-arrow-right:](https://github.com/nextflow-io/training/issues){ .md-button .md-button--primary .mt-1 }
+
+- :material-book-open-variant:{ .lg .middle } **Nextflow-Dokumentation**
+
+  ***
+
+  Die offizielle Dokumentation ist der ultimative Leitfaden zu allen Sprachfunktionen und Konfigurationsoptionen. Nutze sie parallel zu diesem Training, um tiefer in spezifische Themen einzutauchen, erweiterte Funktionen zu erkunden und detaillierte Syntaxreferenzen zu finden.
+
+  [Die Dokumentation durchsuchen:material-arrow-right:](https://www.nextflow.io/docs/latest){ .md-button .md-button--primary .mt-1 }
+
+- :material-account-hard-hat:{ .lg .middle } **Professioneller Support**
+
+  ***
+
+  Nextflow ist eine kostenlose, quelloffene Software, die von [Seqera](https://seqera.io/) entwickelt wird, einem Unternehmen mit Hauptsitz in Spanien und Niederlassungen in Großbritannien und den USA. Wir bieten professionelle Support-Dienste für Nextflow an, einschließlich maßgeschneiderter Schulungen.
+
+  [Kontakt aufnehmen:material-arrow-right:](https://seqera.io/demo/){ .md-button .md-button--primary .mt-1 }
+
+</div>
+
+---
+
+<div markdown class="homepage_logos">
+
+![Seqera](assets/img/seqera_logo.png#only-light)
+
+![Seqera](assets/img/seqera_logo_dark.png#only-dark)
+
+</div>

--- a/docs/de/docs/index.md
+++ b/docs/de/docs/index.md
@@ -1,0 +1,168 @@
+---
+title: Nextflow Training
+description: Willkommen im Nextflow Community-Trainingsportal!
+hide:
+  - toc
+  - footer
+---
+
+# Nextflow Training
+
+<div class="grid cards" markdown>
+
+- :material-book-open-variant:{ .lg .middle } **Selbstlernkurse**
+
+  ***
+
+  **Willkommen im Nextflow Community-Trainingsportal!**
+
+  Die unten aufgeführten Trainingskurse sind als Selbstlernressource konzipiert.
+  Du kannst sie jederzeit eigenständig durcharbeiten, entweder in der webbasierten Umgebung, die wir über Github Codespaces bereitstellen, oder in deiner eigenen Umgebung.
+
+  [Kurse erkunden :material-arrow-right:](#katalog-der-nextflow-trainingskurse){ .md-button .md-button--primary .mt-1 }
+
+- :material-information-outline:{ .lg .middle } **Zusätzliche Informationen**
+
+  ***
+
+  ??? warning "Versionskompatibilität"
+
+      <!-- Any update to this content needs to be copied to the local installation page -->
+      **Ab Januar 2026 erfordern alle unsere Nextflow-Trainingskurse Nextflow Version 25.10.2 oder höher mit aktivierter strikter Syntax, sofern nicht anders angegeben.**
+
+      Weitere Informationen zu Versionsanforderungen und strikter Syntax findest du im [Nextflow-Dokumentations-Migrationshandbuch](https://nextflow.io/docs/latest/strict-syntax.html).
+
+      Ältere Versionen des Trainingsmaterials, die früherer Syntax entsprechen, sind über den Versionsauswähler in der Menüleiste dieser Webseite verfügbar.
+
+  ??? terminal "Umgebungsoptionen"
+
+      Wir bieten eine webbasierte Trainingsumgebung an, in der alles vorinstalliert ist, was du für das Training benötigst. Diese ist über Github Codespaces verfügbar (erfordert ein kostenloses GitHub-Konto).
+
+      [![In GitHub Codespaces öffnen](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
+
+      Wenn dies nicht deinen Anforderungen entspricht, siehe die anderen [Umgebungsoptionen](./envsetup/index.md).
+
+  ??? learning "Trainingsveranstaltungen"
+
+      Wenn du lieber an einem Nextflow-Training im Rahmen einer strukturierten Veranstaltung teilnehmen möchtest, gibt es viele Möglichkeiten dazu. Wir empfehlen, die folgenden Optionen zu prüfen:
+
+      - **[Training Weeks]()** werden vierteljährlich vom Community-Team organisiert
+      - **[Seqera Events](https://seqera.io/events/)** beinhalten Präsenztrainings, die von Seqera organisiert werden (suche nach 'Seqera Sessions' und 'Nextflow Summit')
+      - **[Nextflow Ambassadors]()** organisieren Veranstaltungen für ihre lokale Community
+      - **[nf-core events](https://nf-co.re/events)** beinhalten Community-Hackathons
+
+  ??? people "Informationen für Trainer"
+
+      Wenn du als Dozent eigene Trainings durchführst, kannst du unsere Materialien gerne direkt aus dem Trainingsportal verwenden, solange du die entsprechende Quellenangabe machst. Siehe 'Credits und Beiträge' unten für Details.
+
+      Außerdem würden wir gerne von dir erfahren, wie wir deine Trainingsarbeit besser unterstützen können! Bitte kontaktiere uns unter [community@seqera.io](mailto:community@seqera.io) oder im Community-Forum (siehe Seite [Hilfe](help.md)).
+
+  ??? licensing "Open-Source-Lizenz und Beitragsrichtlinien"
+
+      [![Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)](assets/img/cc_by-nc-sa.svg){ align=right }](https://creativecommons.org/licenses/by-nc-sa/4.0/)
+
+      Dieses Trainingsmaterial wird von [Seqera](https://seqera.io) entwickelt und gepflegt und unter einer Open-Source-Lizenz ([CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/)) zum Nutzen der Community veröffentlicht. Wenn du dieses Material auf eine Weise nutzen möchtest, die außerhalb des Geltungsbereichs der Lizenz liegt (beachte die Einschränkungen bei kommerzieller Nutzung und Weiterverbreitung), kontaktiere uns bitte unter [community@seqera.io](mailto:community@seqera.io), um deine Anfrage zu besprechen.
+
+      Wir freuen uns über Verbesserungen, Korrekturen und Fehlermeldungen aus der Community. Jede Seite hat ein :material-file-edit-outline: Symbol oben rechts, das zum Code-Repository verlinkt, wo du Probleme melden oder Änderungen am Trainingsmaterial per Pull Request vorschlagen kannst. Siehe die `README.md` im Repository für weitere Details.
+
+</div>
+
+## Katalog der Nextflow-Trainingskurse
+
+<div class="grid cards" markdown>
+
+- :material-walk:{ .lg .middle } **Einführungskurse**
+
+  ***
+
+  ### :material-compass:{.nextflow-primary} Nextflow für Einsteiger {.mt-1}
+
+  Fachbereichsunabhängige Kurse für alle, die komplett neu bei Nextflow sind. Jeder Kurs besteht aus einer Reihe von Trainingsmodulen, die Lernenden helfen sollen, ihre Fähigkeiten schrittweise aufzubauen.
+
+  ??? courses "**Hello Nextflow:** Lerne, eigene Pipelines zu entwickeln"
+
+      Dieser Kurs behandelt die Kernkomponenten der Nextflow-Sprache ausführlich genug, um einfache, aber voll funktionsfähige Pipelines zu entwickeln, plus Schlüsselelemente des Pipeline-Designs, der Entwicklung und der Konfigurationspraktiken.
+
+      [Hello Nextflow Training starten :material-arrow-right:](hello_nextflow/index.md){ .md-button .md-button--secondary }
+
+  ??? courses "**Nextflow Run:** Lerne, bestehende Pipelines auszuführen"
+
+      Eine kompakte Einführung in die Ausführung und Konfiguration von Nextflow-Pipelines, basierend auf dem Hello Nextflow-Entwicklerkurs, aber mit weniger Fokus auf Code. Behandelt Ausführung, Ausgaben, grundlegende Codestruktur und Konfiguration für verschiedene Rechenumgebungen.
+
+      [Nextflow Run Training starten :material-arrow-right:](nextflow_run/index.md){ .md-button .md-button--secondary }
+
+  ***
+
+  ### :material-microscope:{.nextflow-primary} Nextflow für die Wissenschaft {.mt-1}
+
+  Lerne, die in 'Hello Nextflow' vorgestellten Konzepte und Komponenten auf spezifische wissenschaftliche Anwendungsfälle anzuwenden.
+
+  ??? courses "**Nextflow für Genomik** (Variantenanalyse)"
+
+      Für Forscher, die lernen möchten, eigene Genomik-Pipelines zu entwickeln. Der Kurs verwendet einen Anwendungsfall zur Variantenanalyse, um zu demonstrieren, wie man eine einfache, aber funktionale Genomik-Pipeline entwickelt.
+
+      [Nextflow für Genomik Training starten :material-arrow-right:](nf4_science/genomics/){ .md-button .md-button--secondary }
+
+  ??? courses "**Nextflow für RNAseq** (Bulk-RNAseq)"
+
+      Für Forscher, die lernen möchten, eigene RNAseq-Pipelines zu entwickeln. Der Kurs verwendet einen Bulk-RNAseq-Verarbeitungs-Anwendungsfall, um zu demonstrieren, wie man eine einfache, aber funktionale RNAseq-Pipeline entwickelt.
+
+      [Nextflow für RNAseq Training starten :material-arrow-right:](nf4_science/rnaseq/){ .md-button .md-button--secondary }
+
+  ??? courses "**Nextflow für Bildgebung** (Spatial Omics)"
+
+      Für Forscher in der Bildgebung und Spatial Omics, die lernen möchten, Analyse-Pipelines auszuführen und anzupassen. Der Kurs verwendet die nf-core/molkart-Pipeline, um eine biologisch relevante Pipeline bereitzustellen und zu demonstrieren, wie man Nextflow-Pipelines und Workflows ausführt, konfiguriert und Eingaben verwaltet.
+
+      [Nextflow für Bildgebung Training starten :material-arrow-right:](nf4_science/imaging/){ .md-button .md-button--secondary }
+
+- :material-run:{ .lg .middle } **Fortgeschrittenenkurse**
+
+  ***
+
+  ### :material-bridge:{.nextflow-primary} Von Nextflow zu nf-core {.mt-1}
+
+  Lerne, Code und Best Practices aus dem [nf-core](https://nf-co.re/) Community-Projekt zu nutzen.
+
+  Diese Kurse helfen dir, von den Nextflow-Grundlagen zu den nf-core Best Practices zu gelangen.
+  Verstehe, wie und warum die nf-core-Community Pipelines entwickelt, und wie du beitragen und diese Techniken wiederverwenden kannst.
+
+  ??? courses "**Hello nf-core:** Erste Schritte mit nf-core"
+
+      Für Entwickler, die lernen möchten, [nf-core](https://nf-co.re/)-konforme Pipelines auszuführen und zu entwickeln. Der Kurs behandelt die Struktur von nf-core-Pipelines ausführlich genug, um einfache, aber voll funktionsfähige Pipelines zu entwickeln, die dem nf-core-Template und den Entwicklungs-Best-Practices folgen, sowie bestehende nf-core-Module zu verwenden.
+
+      [Hello nf-core Training starten :material-arrow-right:](hello_nf-core/index.md){ .md-button .md-button--secondary }
+
+  ***
+
+  ### :material-rocket-launch:{.nextflow-primary} Fortgeschrittenes Nextflow-Training {.mt-1}
+
+  Lerne fortgeschrittene Konzepte und Mechanismen für die Entwicklung und Bereitstellung von Nextflow-Pipelines zur Lösung realer Anwendungsfälle.
+
+  ??? courses "**Side Quests:** Vertiefungen zu eigenständigen Themen"
+
+      Eigenständige Minikurse für Nextflow-Entwickler, die ihr Repertoire erweitern und/oder ihre Fähigkeiten zu bestimmten Themen vertiefen möchten. Sie werden linear präsentiert, können aber in beliebiger Reihenfolge absolviert werden (siehe Abhängigkeiten in jeder Minikurs-Übersicht).
+
+      [Side Quests durchstöbern :material-arrow-right:](side_quests/){ .md-button .md-button--secondary }
+
+  ??? courses "**Training Collections:** Empfohlene Lernpfade durch die Side Quests"
+
+      Training Collections kombinieren mehrere Side Quests, um eine umfassende Lernerfahrung zu einem bestimmten Thema oder Anwendungsfall zu bieten.
+
+      [Training Collections durchstöbern :material-arrow-right:](training_collections/){ .md-button .md-button--secondary }
+
+</div>
+
+!!! info "Auf der Suche nach archivierten Trainingsmaterialien?"
+
+    Ältere Trainingsmaterialien (Fundamentals Training, Advanced Training und andere experimentelle Kurse) wurden aus dem Trainingsportal entfernt, da sie nicht mit der strikten Nextflow 3.0-Syntax kompatibel sind.
+    Wenn du Zugriff auf diese Materialien benötigst, sind sie in der [Git-Historie](https://github.com/nextflow-io/training) vor Januar 2026 verfügbar.
+
+---
+
+<div markdown class="homepage_logos">
+
+![Seqera](assets/img/seqera_logo.png#only-light)
+
+![Seqera](assets/img/seqera_logo_dark.png#only-dark)
+
+</div>

--- a/docs/de/docs/nextflow_run/00_orientation.md
+++ b/docs/de/docs/nextflow_run/00_orientation.md
@@ -1,0 +1,120 @@
+# Erste Schritte
+
+## Eine Trainingsumgebung starten
+
+Um die vorgefertigte Umgebung zu verwenden, die wir auf GitHub Codespaces bereitstellen, klicke auf die Schaltfläche "Open in GitHub Codespaces" unten. Für andere Optionen siehe [Umgebungsoptionen](../envsetup/index.md).
+
+Wir empfehlen, die Trainingsumgebung in einem neuen Browser-Tab oder -Fenster zu öffnen (verwende Rechtsklick, Strg-Klick oder Cmd-Klick je nach Gerät), damit du weiterlesen kannst, während die Umgebung lädt.
+Du musst diese Anleitung parallel geöffnet halten, um den Kurs durchzuarbeiten.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
+
+### Grundlagen der Umgebung
+
+Diese Trainingsumgebung enthält alle Software, den Code und die Daten, die zum Durcharbeiten des Kurses notwendig sind, sodass du nichts selbst installieren musst.
+
+Der Codespace ist mit einer VSCode-Oberfläche eingerichtet, die einen Dateisystem-Explorer, einen Code-Editor und eine Terminal-Shell enthält.
+Alle Anweisungen während des Kurses (z.B. 'öffne die Datei', 'bearbeite den Code' oder 'führe diesen Befehl aus') beziehen sich auf diese drei Teile der VSCode-Oberfläche, sofern nicht anders angegeben.
+
+Wenn du diesen Kurs selbstständig durcharbeitest, mache dich bitte mit den [Grundlagen der Umgebung](../envsetup/01_setup.md) für weitere Details vertraut.
+
+### Versionsanforderungen
+
+Dieses Training ist für Nextflow 25.10.2 oder später **mit aktiviertem v2-Syntax-Parser** konzipiert.
+Wenn du eine lokale oder benutzerdefinierte Umgebung verwendest, stelle bitte sicher, dass du die richtigen Einstellungen wie [hier](../info/nxf_versions.md) dokumentiert verwendest.
+
+## Bereit zum Arbeiten
+
+Sobald dein Codespace läuft, musst du zwei Dinge tun, bevor du in das Training eintauchst: dein Arbeitsverzeichnis für diesen speziellen Kurs festlegen und dir die bereitgestellten Materialien ansehen.
+
+### Das Arbeitsverzeichnis festlegen
+
+Standardmäßig öffnet sich der Codespace mit dem Arbeitsverzeichnis am Stamm aller Trainingskurse, aber für diesen Kurs werden wir im Verzeichnis `nextflow-run/` arbeiten.
+
+Wechsle jetzt das Verzeichnis, indem du diesen Befehl im Terminal ausführst:
+
+```bash
+cd nextflow-run/
+```
+
+Du kannst VSCode so einstellen, dass es sich auf dieses Verzeichnis konzentriert, sodass nur die relevanten Dateien in der Datei-Explorer-Seitenleiste angezeigt werden:
+
+```bash
+code .
+```
+
+!!! Tipp
+
+    Wenn du aus irgendeinem Grund dieses Verzeichnis verlässt (z.B. dein Codespace geht in den Schlafmodus), kannst du immer den vollständigen Pfad verwenden, um dorthin zurückzukehren, vorausgesetzt du arbeitest in der GitHub Codespaces-Trainingsumgebung:
+
+    ```bash
+    cd /workspaces/training/nextflow-run
+    ```
+
+Schauen wir uns jetzt den Inhalt an.
+
+### Die bereitgestellten Materialien erkunden
+
+Du kannst den Inhalt dieses Verzeichnisses erkunden, indem du den Datei-Explorer auf der linken Seite des Trainingsarbeitsbereichs verwendest.
+Alternativ kannst du den Befehl `tree` verwenden.
+
+Während des gesamten Kurses verwenden wir die Ausgabe von `tree`, um Verzeichnisstruktur und -inhalt in lesbarer Form darzustellen, manchmal mit kleineren Anpassungen zur Klarheit.
+
+Hier generieren wir ein Inhaltsverzeichnis bis zur zweiten Ebene:
+
+```bash
+tree . -L 2
+```
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    .
+    ├── 1-hello.nf
+    ├── 2a-inputs.nf
+    ├── 2b-multistep.nf
+    ├── 2c-modules.nf
+    ├── 2d-container.nf
+    ├── 3-main.nf
+    ├── data
+    │   └── greetings.csv
+    ├── modules
+    │   ├── collectGreetings.nf
+    │   ├── convertToUpper.nf
+    │   ├── cowpy.nf
+    │   └── sayHello.nf
+    ├── nextflow.config
+    ├── solutions
+    │   ├── 3-main.nf
+    │   ├── modules
+    │   └── nextflow.config
+    ├── test-params.json
+    └── test-params.yaml
+    ```
+
+Klicke auf das farbige Feld, um den Abschnitt zu erweitern und seinen Inhalt anzuzeigen.
+Wir verwenden solche einklappbaren Abschnitte, um erwartete Befehlsausgaben sowie Verzeichnis- und Dateiinhalte kompakt darzustellen.
+
+- **Die `.nf`-Dateien** sind Workflow-Scripts, die basierend darauf nummeriert sind, in welchem Teil des Kurses sie verwendet werden.
+
+- **Die Datei `nextflow.config`** ist eine Konfigurationsdatei, die minimale Umgebungseigenschaften festlegt.
+  Du kannst sie vorerst ignorieren.
+
+- **Die Datei `greetings.csv`** unter `data/` enthält Eingabedaten, die wir im größten Teil des Kurses verwenden werden. Sie wird in Teil 2 (Pipelines ausführen) beschrieben, wenn wir sie zum ersten Mal einführen.
+
+- **Die `test-params.*`-Dateien** sind Konfigurationsdateien, die wir in Teil 3 (Konfiguration) verwenden werden. Du kannst sie vorerst ignorieren.
+
+- **Das `solutions`-Verzeichnis** enthält den Endzustand des Workflows und seiner Hilfsdateien (Config und Module), die sich aus dem Abschluss des Kurses ergeben.
+  Sie sind als Referenz gedacht, um deine Arbeit zu überprüfen und eventuelle Probleme zu beheben.
+
+## Bereitschafts-Checkliste
+
+Denkst du, du bist bereit einzutauchen?
+
+- [ ] Ich verstehe das Ziel dieses Kurses und seine Voraussetzungen
+- [ ] Meine Umgebung ist eingerichtet und läuft
+- [ ] Ich habe mein Arbeitsverzeichnis entsprechend festgelegt
+
+Wenn du alle Kästchen abhaken kannst, bist du startklar.
+
+**Um zu [Teil 1: Grundlegende Operationen](./01_basics.md) fortzufahren, klicke auf den Pfeil in der unteren rechten Ecke dieser Seite.**

--- a/docs/de/docs/nextflow_run/01_basics.md
+++ b/docs/de/docs/nextflow_run/01_basics.md
@@ -1,0 +1,734 @@
+# Teil 1: Grundlegende Operationen
+
+Im ersten Teil des Nextflow Run-Trainingskurses steigen wir mit einem sehr grundlegenden, fachunabhängigen Hello World-Beispiel in das Thema ein, das wir verwenden werden, um wesentliche Operationen zu demonstrieren und auf die entsprechenden Nextflow-Code-Komponenten hinzuweisen.
+
+??? info "Was ist ein Hello World-Beispiel?"
+
+    Ein "Hello World!" ist ein minimalistisches Beispiel, das die grundlegende Syntax und Struktur einer Programmiersprache oder eines Software-Frameworks demonstrieren soll.
+    Das Beispiel besteht typischerweise darin, die Phrase "Hello, World!" auf dem Ausgabegerät wie der Konsole oder dem Terminal auszugeben oder in eine Datei zu schreiben.
+
+---
+
+## 1. Ein Hello World direkt ausführen
+
+Demonstrieren wir dieses Konzept mit einem einfachen Befehl, den wir direkt im Terminal ausführen, um zu zeigen, was er tut, bevor wir ihn in Nextflow einpacken.
+
+!!! Tipp
+
+    Denke daran, dass du dich jetzt im Verzeichnis `nextflow-run/` befinden solltest, wie auf der Seite [Erste Schritte](00_orientation.md) beschrieben.
+
+### 1.1. Das Terminal "Hallo" sagen lassen
+
+Führe folgenden Befehl in deinem Terminal aus.
+
+```bash
+echo 'Hello World!'
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    Hello World!
+    ```
+
+Dies gibt den Text 'Hello World' direkt im Terminal aus.
+
+### 1.2. Die Ausgabe in eine Datei schreiben
+
+Beim Ausführen von Pipelines geht es hauptsächlich darum, Daten aus Dateien zu lesen und Ergebnisse in andere Dateien zu schreiben, also modifizieren wir den Befehl so, dass die Textausgabe in eine Datei geschrieben wird, um das Beispiel etwas relevanter zu machen.
+
+```bash
+echo 'Hello World!' > output.txt
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+
+    ```
+
+Dies gibt nichts im Terminal aus.
+
+### 1.3. Die Ausgabe finden
+
+Der Text 'Hello World' sollte jetzt in der Ausgabedatei sein, die wir angegeben haben, namens `output.txt`.
+Du kannst sie im Datei-Explorer öffnen oder von der Befehlszeile aus mit dem `cat`-Tool zum Beispiel.
+
+??? abstract "Dateiinhalt"
+
+    ```console title="output.txt" linenums="1"
+    Hello World!
+    ```
+
+Das ist es, was wir mit unserem allerersten Nextflow-Workflow replizieren werden.
+
+### Erkenntnisse
+
+Du weißt jetzt, wie man einen einfachen Befehl im Terminal ausführt, der etwas Text ausgibt, und optional, wie man ihn die Ausgabe in eine Datei schreiben lässt.
+
+### Was kommt als Nächstes?
+
+Finde heraus, was es braucht, um einen Nextflow-Workflow auszuführen, der dasselbe Ergebnis erzielt.
+
+---
+
+## 2. Den Workflow ausführen
+
+Wir stellen dir ein Workflow-Script namens `1-hello.nf` zur Verfügung, das einen Eingabe-Gruß über ein Befehlszeilenargument namens `--input` nimmt und eine Textdatei produziert, die diesen Gruß enthält.
+
+Wir werden uns den Code noch nicht ansehen; zuerst schauen wir uns an, wie es aussieht, ihn auszuführen.
+
+### 2.1. Den Workflow starten und die Ausführung überwachen
+
+Führe im Terminal folgenden Befehl aus:
+
+```bash
+nextflow run 1-hello.nf --input 'Hello World!'
+```
+
+??? success "Befehlsausgabe"
+
+    ```console hl_lines="6"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `1-hello.nf` [goofy_torvalds] DSL2 - revision: c33d41f479
+
+    executor >  local (1)
+    [a3/7be2fa] sayHello | 1 of 1 ✔
+    ```
+
+Wenn deine Konsolenausgabe ungefähr so aussieht, dann herzlichen Glückwunsch, du hast gerade deinen ersten Nextflow-Workflow ausgeführt!
+
+Die wichtigste Ausgabe hier ist die letzte Zeile, die in der obigen Ausgabe hervorgehoben ist:
+
+```console
+[a3/7be2fa] sayHello | 1 of 1 ✔
+```
+
+Das sagt uns, dass der `sayHello`-Prozess einmal erfolgreich ausgeführt wurde (`1 of 1 ✔`).
+
+Das ist großartig, aber du fragst dich vielleicht: wo ist die Ausgabe?
+
+### 2.2. Die Ausgabedatei im `results`-Verzeichnis finden
+
+Dieser Workflow ist so konfiguriert, dass er seine Ausgabe in ein results-Verzeichnis veröffentlicht.
+Wenn du dein aktuelles Verzeichnis anschaust, wirst du sehen, dass Nextflow beim Ausführen des Workflows ein neues Verzeichnis namens `results` erstellt hat, sowie ein Unterverzeichnis namens `1-hello` darunter, das eine Datei namens `output.txt` enthält.
+
+```console title="results/"
+results
+└── 1-hello
+    └── output.txt
+```
+
+Öffne die Datei; der Inhalt sollte mit dem String übereinstimmen, den du in der Befehlszeile angegeben hast.
+
+```console title="results/1-hello/output.txt" linenums="1"
+Hello World!
+```
+
+Das ist großartig, unser Workflow hat getan, was er sollte!
+
+Beachte jedoch, dass das 'veröffentlichte' Ergebnis eine Kopie (oder in einigen Fällen ein symbolischer Link) der tatsächlichen Ausgabe ist, die Nextflow produziert hat, als es den Workflow ausführte.
+
+Also werden wir jetzt unter die Haube schauen, um zu sehen, wo Nextflow die Arbeit tatsächlich ausgeführt hat.
+
+!!! Warnung
+
+    Nicht alle Workflows werden so eingerichtet sein, dass sie Ausgaben in ein results-Verzeichnis veröffentlichen, und/oder die Verzeichnisnamen und -struktur können unterschiedlich sein.
+    Etwas später in diesem Abschnitt zeigen wir dir, wie du herausfindest, wo dieses Verhalten festgelegt ist.
+
+### 2.3. Die ursprüngliche Ausgabe und Protokolle im `work/`-Verzeichnis finden
+
+Wenn du einen Workflow ausführst, erstellt Nextflow ein eigenes 'Aufgabenverzeichnis' für jeden einzelnen Aufruf jedes Prozesses im Workflow (=jeden Schritt in der Pipeline).
+Für jeden wird es die notwendigen Eingaben bereitstellen, die relevanten Anweisungen ausführen und Ausgaben und Protokolldateien in dieses eine Verzeichnis schreiben, das automatisch mit einem Hash benannt wird, um es einzigartig zu machen.
+
+Alle diese Aufgabenverzeichnisse leben unter einem Verzeichnis namens `work` in deinem aktuellen Verzeichnis (wo du den Befehl ausführst).
+
+Das mag verwirrend klingen, also schauen wir uns an, wie das in der Praxis aussieht.
+
+Wenn wir auf die Konsolenausgabe für den zuvor ausgeführten Workflow zurückgehen, hatten wir diese Zeile:
+
+```console
+[a3/7be2fa] sayHello | 1 of 1 ✔
+```
+
+Siehst du, wie die Zeile mit `[a3/7be2fa]` beginnt?
+Das ist eine abgekürzte Form des Aufgabenverzeichnispfads für diesen einen Prozessaufruf und sagt dir, wo du die Ausgabe des `sayHello`-Prozessaufrufs innerhalb des `work/`-Verzeichnispfads findest.
+
+Du kannst den vollständigen Pfad finden, indem du folgenden Befehl eingibst (ersetze `a3/7be2fa` durch das, was du in deinem eigenen Terminal siehst) und die Tab-Taste drückst, um den Pfad automatisch zu vervollständigen, oder ein Sternchen hinzufügst:
+
+```bash
+ls work/a3/7be2fa*
+```
+
+Dies sollte den vollständigen Verzeichnispfad ergeben: `work/a3/7be2fa7be2fad5e71e5f49998f795677fd68`
+
+Schauen wir uns an, was dort drin ist.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    work
+    └── a3
+        └── 7be2fad5e71e5f49998f795677fd68
+            ├── .command.begin
+            ├── .command.err
+            ├── .command.log
+            ├── .command.out
+            ├── .command.run
+            ├── .command.sh
+            ├── .exitcode
+            └── output.txt
+    ```
+
+??? question "Siehst du nicht dasselbe?"
+
+    Die genauen Unterverzeichnisnamen werden auf deinem System anders sein.
+
+    Wenn du den Inhalt des Aufgabenunterverzeichnisses im VSCode-Datei-Explorer durchsuchst, siehst du alle Dateien sofort.
+    Die Protokolldateien sind jedoch so eingestellt, dass sie im Terminal unsichtbar sind, also wenn du `ls` oder `tree` verwenden möchtest, um sie anzuzeigen, musst du die entsprechende Option zum Anzeigen unsichtbarer Dateien setzen.
+
+    ```bash
+    tree -a work
+    ```
+
+Du solltest sofort die `output.txt`-Datei erkennen, die tatsächlich die ursprüngliche Ausgabe des `sayHello`-Prozesses ist, die in das `results`-Verzeichnis veröffentlicht wurde.
+Wenn du sie öffnest, wirst du den `Hello World!`-Gruß wieder finden.
+
+```console title="work/a3/7be2fa7be2fad5e71e5f49998f795677fd68/output.txt"
+Hello World!
+```
+
+Was ist also mit all den anderen Dateien?
+
+Das sind die Hilfs- und Protokolldateien, die Nextflow als Teil der Aufgabenausführung geschrieben hat:
+
+- **`.command.begin`**: Sentinel-Datei, die erstellt wird, sobald die Aufgabe gestartet wird.
+- **`.command.err`**: Fehlermeldungen (`stderr`), die vom Prozessaufruf ausgegeben werden
+- **`.command.log`**: Vollständige Protokollausgabe, die vom Prozessaufruf ausgegeben wird
+- **`.command.out`**: Reguläre Ausgabe (`stdout`) vom Prozessaufruf
+- **`.command.run`**: Vollständiges Script, das von Nextflow ausgeführt wird, um den Prozessaufruf auszuführen
+- **`.command.sh`**: Der Befehl, der tatsächlich vom Prozessaufruf ausgeführt wurde
+- **`.exitcode`**: Der Exit-Code, der aus dem Befehl resultiert
+
+Die `.command.sh`-Datei ist besonders nützlich, weil sie dir den Hauptbefehl zeigt, den Nextflow ausgeführt hat, ohne die gesamte Buchführung und Aufgaben-/Umgebungseinrichtung.
+
+```console title="work/a3/7be2fa7be2fad5e71e5f49998f795677fd68/command.sh"
+#!/bin/bash -ue
+echo 'Hello World!' > output.txt
+
+```
+
+Das bestätigt also, dass der Workflow denselben Befehl zusammengestellt hat, den wir zuvor direkt auf der Befehlszeile ausgeführt haben.
+
+Wenn etwas schief geht und du Fehler beheben musst, kann es nützlich sein, das `command.sh`-Script anzusehen, um genau zu überprüfen, welchen Befehl Nextflow basierend auf den Workflow-Anweisungen, Variableninterpolation usw. zusammengestellt hat.
+
+### 2.4. Den Workflow mit verschiedenen Grüßen erneut ausführen
+
+Versuche, den Workflow einige Male mit verschiedenen Werten für das `--input`-Argument erneut auszuführen, und schaue dann die Aufgabenverzeichnisse an.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console
+    work
+    ├── 0f
+    │   └── 52b7e07b0e274a80843fca48ed21b8
+    │       ├── .command.begin
+    │       ├── .command.err
+    │       ├── .command.log
+    │       ├── .command.out
+    │       ├── .command.run
+    │       ├── .command.sh
+    │       ├── .exitcode
+    │       └── output.txt
+    ├── 67
+    │   ├── 134e6317f90726c6c17ad53234a32b
+    │   │   ├── ...
+    │   │   └── output.txt
+    │   └── e029f2e75305874a9ab263d21ebc2c
+    │       ├── ...
+    │       └── output.txt
+    ...
+    ```
+
+Du siehst, dass für jeden Lauf ein neues Unterverzeichnis mit einem vollständigen Satz von Ausgabe- und Protokolldateien erstellt wurde.
+
+Im Gegensatz dazu, wenn du das `results`-Verzeichnis anschaust, gibt es immer noch nur einen Satz von Ergebnissen, und der Inhalt der Ausgabedatei entspricht dem, was du zuletzt ausgeführt hast.
+
+??? abstract "Verzeichnisinhalt"
+
+    ```console title="results/"
+    results
+    └── 1-hello
+        └── output.txt
+    ```
+
+Das zeigt dir, dass die veröffentlichten Ergebnisse durch nachfolgende Ausführungen überschrieben werden, während die Aufgabenverzeichnisse unter `work/` erhalten bleiben.
+
+### Erkenntnisse
+
+Du weißt, wie man ein einfaches Nextflow-Script ausführt, seine Ausführung überwacht und seine Ausgaben findet.
+
+### Was kommt als Nächstes?
+
+Lerne, wie man ein grundlegendes Nextflow-Script liest und identifiziert, wie seine Komponenten mit seiner Funktionalität zusammenhängen.
+
+---
+
+## 3. Das Hello World Workflow-Starter-Script untersuchen
+
+Was wir dort getan haben, war im Grunde, das Workflow-Script wie eine Black Box zu behandeln.
+Jetzt, da wir gesehen haben, was es tut, öffnen wir die Box und schauen hinein.
+
+Unser Ziel hier ist nicht, die Syntax von Nextflow-Code auswendig zu lernen, sondern eine grundlegende Intuition zu entwickeln, was die Hauptkomponenten sind und wie sie organisiert sind.
+
+### 3.1. Die Gesamtstruktur des Codes untersuchen
+
+Du findest das `1-hello.nf`-Script in deinem aktuellen Verzeichnis, das `nextflow-run` sein sollte. Öffne es im Editor-Bereich.
+
+??? full-code "Vollständige Code-Datei"
+
+    ```groovy title="1-hello.nf" linenums="1"
+    #!/usr/bin/env nextflow
+
+    /*
+    * Use echo to print 'Hello World!' to a file
+    */
+    process sayHello {
+
+        input:
+        val greeting
+
+        output:
+        path 'output.txt'
+
+        script:
+        """
+        echo '${greeting}' > output.txt
+        """
+    }
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: String
+    }
+
+    workflow {
+
+        main:
+        // emit a greeting
+        sayHello(params.input)
+
+        publish:
+        first_output = sayHello.out
+    }
+
+    output {
+        first_output {
+            path '1-hello'
+            mode 'copy'
+        }
+    }
+    ```
+
+Ein Nextflow-Workflow-Script enthält typischerweise eine oder mehrere **Prozess**-Definitionen, den **Workflow** selbst und einige optionale Blöcke wie **params** und **output**.
+
+Jeder **Prozess** beschreibt, welche Operation(en) der entsprechende Schritt in der Pipeline ausführen soll, während der **Workflow** die Datenflusslogik beschreibt, die die verschiedenen Schritte verbindet.
+
+Schauen wir uns zuerst den **Prozess**-Block genauer an, dann schauen wir uns den **Workflow**-Block an.
+
+### 3.2. Die `process`-Definition
+
+Der erste Code-Block beschreibt einen **Prozess**.
+Die Prozessdefinition beginnt mit dem Schlüsselwort `process`, gefolgt vom Prozessnamen und schließlich dem Prozess-Body, der durch geschweifte Klammern begrenzt wird.
+Der Prozess-Body muss einen Script-Block enthalten, der den auszuführenden Befehl angibt, der alles sein kann, was du in einem Befehlszeilen-Terminal ausführen könntest.
+
+```groovy title="1-hello.nf" linenums="3"
+/*
+* Use echo to print a greeting to a file
+*/
+process sayHello {
+
+    input:
+    val greeting
+
+    output:
+    path 'output.txt'
+
+    script:
+    """
+    echo '${greeting}' > output.txt
+    """
+}
+```
+
+Hier haben wir einen **Prozess** namens `sayHello`, der eine **Eingabe**-Variable namens `greeting` nimmt und seine **Ausgabe** in eine Datei namens `output.txt` schreibt.
+
+<figure class="excalidraw">
+--8<-- "docs/nextflow_run/img/sayhello_with_input.svg"
+</figure>
+
+Dies ist eine sehr minimale Prozessdefinition, die nur eine `input`-Definition, eine `output`-Definition und das auszuführende `script` enthält.
+
+Die `input`-Definition enthält den `val`-Qualifier, der Nextflow mitteilt, einen Wert irgendeiner Art zu erwarten (kann ein String, eine Zahl, was auch immer sein).
+
+Die `output`-Definition enthält den `path`-Qualifier, der Nextflow mitteilt, dass dies als Pfad behandelt werden soll (umfasst sowohl Verzeichnispfade als auch Dateien).
+
+### 3.3. Die `workflow`-Definition
+
+Der zweite Code-Block beschreibt den **Workflow** selbst.
+Die Workflow-Definition beginnt mit dem Schlüsselwort `workflow`, gefolgt von einem optionalen Namen, dann dem Workflow-Body, der durch geschweifte Klammern begrenzt wird.
+
+Hier haben wir einen **Workflow**, der aus einem `main:`-Block und einem `publish:`-Block besteht.
+Der `main:`-Block ist der Haupt-Body des Workflows und der `publish:`-Block listet die Ausgaben auf, die in das `results`-Verzeichnis veröffentlicht werden sollen.
+
+```groovy title="1-hello.nf" linenums="27"
+workflow {
+
+    main:
+    // emit a greeting
+    sayHello(params.input)
+
+    publish:
+    first_output = sayHello.out
+}
+```
+
+In diesem Fall enthält der `main:`-Block einen Aufruf des `sayHello`-Prozesses und gibt ihm eine Eingabe namens `params.input` als Gruß.
+
+Wie wir gleich ausführlicher besprechen werden, enthält `params.input` den Wert, den wir dem `--input`-Parameter in unserer Befehlszeile gegeben haben.
+
+Der `publish:`-Block listet die Ausgabe des `sayHello()`-Prozessaufrufs auf, die er als `sayHello.out` bezeichnet und den Namen `first_output` gibt (das kann alles sein, was der Workflow-Autor möchte).
+
+Dies ist eine sehr minimale **Workflow**-Definition.
+In einer realen Pipeline enthält der Workflow typischerweise mehrere Aufrufe von **Prozessen**, die durch **Channels** verbunden sind, und es können Standardwerte für die variablen Eingaben eingerichtet sein.
+
+Wir werden das in Teil 2 des Kurses behandeln.
+Für jetzt schauen wir uns genauer an, wie unser Workflow Eingaben und Ausgaben handhabt.
+
+### 3.4. Das `params`-System der Befehlszeilenparameter
+
+Das `params.input`, das wir dem `sayHello()`-Prozessaufruf geben, ist ein raffiniertes Stück Nextflow-Code und lohnt sich, eine extra Minute darüber zu verbringen.
+
+Wie oben erwähnt, übergeben wir so den Wert des `--input`-Befehlszeilenparameters an den `sayHello()`-Prozessaufruf.
+Tatsächlich reicht es aus, einfach `params.someParameterName` zu deklarieren, um dem Workflow einen Parameter namens `--someParameterName` von der Befehlszeile zu geben.
+
+Hier haben wir diese Parameterdeklaration formalisiert, indem wir einen `params`-Block eingerichtet haben, der den Typ der Eingabe angibt, die der Workflow erwartet (Nextflow 25.10.2 und später).
+
+```groovy title="1-hello.nf" linenums="20"
+/*
+ * Pipeline parameters
+ */
+params {
+    input: String
+}
+```
+
+Unterstützte Typen umfassen `String`, `Integer`, `Float`, `Boolean` und `Path`.
+
+!!! Tipp
+
+    Workflow-Parameter, die mit dem `params`-System deklariert werden, nehmen immer zwei Bindestriche auf der Befehlszeile (`--`).
+    Das unterscheidet sie von Nextflow-Level-Parametern, die nur einen Bindestrich nehmen (`-`).
+
+### 3.5. Die `publish`-Direktive
+
+Am anderen Ende des Workflows haben wir bereits einen Blick auf den `publish:`-Block geworfen.
+Das ist eine Hälfte des Ausgabehandhabungssystems; die andere Hälfte ist der `output`-Block, der sich unten befindet.
+
+```groovy title="1-hello.nf" linenums="37"
+output {
+    first_output {
+        path '1-hello'
+        mode 'copy'
+    }
+}
+```
+
+Das gibt an, dass die `first_output`-Ausgabe, die im `publish:`-Block aufgelistet ist, in ein Unterverzeichnis namens `1-hello` unter dem Standard-`results`-Ausgabeverzeichnis kopiert werden soll.
+
+Die Zeile `mode 'copy'` überschreibt das Standardverhalten des Systems, das darin besteht, einen symbolischen Link (oder Symlink) auf die ursprüngliche Datei im `work/`-Verzeichnis zu erstellen, anstatt einer richtigen Kopie.
+
+Es gibt mehr Optionen als hier angezeigt, um das Veröffentlichungsverhalten zu steuern; wir werden später einige behandeln.
+Du wirst auch sehen, dass wenn ein Workflow mehrere Ausgaben generiert, jede auf diese Weise im `output`-Block aufgelistet wird.
+
+??? info "Ältere Syntax zum Veröffentlichen von Ausgaben mit `publishDir`"
+
+    Bis vor kurzem war die etablierte Methode zum Veröffentlichen von Ausgaben, es auf der Ebene jedes einzelnen Prozesses mit einer `publishDir`-Direktive zu tun.
+
+    Du wirst dieses Code-Muster überall in älteren Nextflow-Pipelines und Prozessmodulen finden, daher ist es wichtig, davon zu wissen.
+
+    Anstatt einen `publish:`-Block im Workflow und einen `output`-Block auf oberster Ebene zu haben, würdest du eine `publishDir`-Zeile in der `sayHello`-Prozessdefinition sehen:
+
+    ```groovy title="Syntax-Beispiel" linenums="1" hl_lines="3"
+    process sayHello {
+
+        publishDir 'results/1-hello', mode: 'copy'
+
+        output:
+        path 'output.txt'
+
+        script:
+        """
+        echo 'Hello World!' > output.txt
+        """
+    }
+    ```
+
+    Wir empfehlen jedoch nicht, dies in neuer Arbeit zu verwenden, da es in zukünftigen Versionen der Nextflow-Sprache irgendwann nicht mehr erlaubt sein wird.
+
+### Erkenntnisse
+
+Du weißt jetzt, wie ein einfacher Nextflow-Workflow strukturiert ist und wie die grundlegenden Komponenten mit seiner Funktionalität zusammenhängen.
+
+### Was kommt als Nächstes?
+
+Lerne, deine Workflow-Ausführungen bequem zu verwalten.
+
+---
+
+## 4. Workflow-Ausführungen verwalten
+
+Zu wissen, wie man Workflows startet und Ausgaben abruft, ist großartig, aber du wirst schnell feststellen, dass es einige andere Aspekte des Workflow-Managements gibt, die dir das Leben erleichtern werden.
+
+Hier zeigen wir dir, wie du die `resume`-Funktion nutzt, wenn du denselben Workflow neu starten musst, wie du die Ausführungsprotokolle mit `nextflow log` überprüfst und wie du ältere Work-Verzeichnisse mit `nextflow clean` löschst.
+
+### 4.1. Einen Workflow mit `-resume` neu starten
+
+Manchmal möchtest du eine Pipeline erneut ausführen, die du zuvor bereits gestartet hast, ohne Arbeit zu wiederholen, die bereits erfolgreich abgeschlossen wurde.
+
+Nextflow hat eine Option namens `-resume`, die dir das ermöglicht.
+Konkret werden in diesem Modus alle Prozesse, die bereits mit exakt demselben Code, denselben Einstellungen und Eingaben ausgeführt wurden, übersprungen.
+Das bedeutet, Nextflow wird nur Prozesse ausführen, die du seit dem letzten Lauf hinzugefügt oder geändert hast, oder denen du neue Einstellungen oder Eingaben gibst.
+
+Es gibt zwei Hauptvorteile dabei:
+
+- Wenn du gerade dabei bist, eine Pipeline zu entwickeln, kannst du schneller iterieren, da du nur die Prozesse ausführen musst, an denen du aktiv arbeitest, um deine Änderungen zu testen.
+- Wenn du eine Pipeline in der Produktion ausführst und etwas schief geht, kannst du in vielen Fällen das Problem beheben und die Pipeline neu starten, und sie wird vom Punkt des Fehlers aus fortgesetzt, was dir viel Zeit und Rechenleistung sparen kann.
+
+Um es zu verwenden, füge einfach `-resume` zu deinem Befehl hinzu und führe ihn aus:
+
+```bash
+nextflow run 1-hello.nf --input 'Hello World!' -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console linenums="1"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `1-hello.nf` [tiny_noyce] DSL2 - revision: c33d41f479
+
+    [a3/7be2fa] sayHello | 1 of 1, cached: 1 ✔
+    ```
+
+Die Konsolenausgabe sollte vertraut aussehen, aber es gibt eine Sache, die ein bisschen anders ist als vorher.
+
+Suche nach dem `cached:`-Teil, der in der Prozessstatuszeile (Zeile 5) hinzugefügt wurde, was bedeutet, dass Nextflow erkannt hat, dass es diese Arbeit bereits erledigt hat, und einfach das Ergebnis des vorherigen erfolgreichen Laufs wiederverwendet hat.
+
+Du kannst auch sehen, dass der Work-Unterverzeichnis-Hash derselbe ist wie im vorherigen Lauf.
+Nextflow zeigt dir buchstäblich auf die vorherige Ausführung und sagt "Das habe ich schon dort drüben gemacht."
+
+!!! Tipp
+
+    Wenn du eine Pipeline mit `resume` erneut ausführst, überschreibt Nextflow keine Dateien, die außerhalb des Work-Verzeichnisses von Ausführungen veröffentlicht wurden, die zuvor erfolgreich ausgeführt wurden.
+
+### 4.2. Das Protokoll vergangener Ausführungen überprüfen
+
+Immer wenn du einen Nextflow-Workflow startest, wird eine Zeile in eine Protokolldatei namens `history` geschrieben, unter einem versteckten Verzeichnis namens `.nextflow` im aktuellen Arbeitsverzeichnis.
+
+??? abstract "Dateiinhalt"
+
+    ```txt title=".nextflow/history" linenums="1"
+    2025-07-04 19:27:09	1.8s	wise_watson	OK	3539118582ccde68dde471cc2c66295c	a02c9c46-c3c7-4085-9139-d1b9b5b194c8	nextflow run 1-hello.nf --input 'Hello World'
+    2025-07-04 19:27:20	2.9s	spontaneous_blackwell	OK	3539118582ccde68dde471cc2c66295c	59a5db23-d83c-4c02-a54e-37ddb73a337e	nextflow run 1-hello.nf --input Bonjour
+    ...
+    ```
+
+Diese Datei gibt dir den Zeitstempel, Laufnamen, Status, Revisions-ID, Sitzungs-ID und die vollständige Befehlszeile für jeden Nextflow-Lauf, der aus dem aktuellen Arbeitsverzeichnis gestartet wurde.
+
+Eine bequemere Möglichkeit, auf diese Informationen zuzugreifen, ist der Befehl `nextflow log`.
+
+```bash
+nextflow log
+```
+
+??? success "Befehlsausgabe"
+
+    ```console linenums="1"
+    TIMESTAMP               DURATION        RUN NAME                STATUS  REVISION ID     SESSION ID                              COMMAND
+    2025-07-04 19:27:09     1.8s            wise_watson             OK       3539118582     a02c9c46-c3c7-4085-9139-d1b9b5b194c8    nextflow run 1-hello.nf --input 'Hello World'
+    ...
+    ```
+
+Das gibt den Inhalt der Protokolldatei im Terminal aus, ergänzt durch eine Kopfzeile.
+
+Du wirst bemerken, dass sich die Sitzungs-ID ändert, wenn du einen neuen `nextflow run`-Befehl ausführst, AUSSER wenn du die `-resume`-Option verwendest.
+In diesem Fall bleibt die Sitzungs-ID gleich.
+
+Nextflow verwendet die Sitzungs-ID, um Lauf-Caching-Informationen unter dem `cache`-Verzeichnis zu gruppieren, das sich ebenfalls unter `.nextflow` befindet.
+
+### 4.3. Ältere Work-Verzeichnisse löschen
+
+Wenn du viele Pipelines ausführst, können sich sehr viele Dateien über viele Unterverzeichnisse ansammeln.
+Da die Unterverzeichnisse zufällig benannt sind, ist es schwierig, anhand ihrer Namen zu erkennen, welche älteren gegenüber neueren Läufen entsprechen.
+
+Glücklicherweise enthält Nextflow einen hilfreichen `clean`-Unterbefehl, der automatisch die Work-Unterverzeichnisse für vergangene Läufe löschen kann, die du nicht mehr benötigst.
+
+#### 4.3.1. Löschkriterien festlegen
+
+Es gibt mehrere [Optionen](https://www.nextflow.io/docs/latest/reference/cli.html#clean), um festzulegen, was gelöscht werden soll.
+
+Hier zeigen wir dir ein Beispiel, das alle Unterverzeichnisse von Läufen vor einem bestimmten Lauf löscht, der über seinen Laufnamen angegeben wird.
+
+Schau dir den letzten erfolgreichen Lauf an, bei dem du nicht `-resume` verwendet hast; in unserem Fall war der Laufname `backstabbing_swartz`.
+
+Der Laufname ist der maschinengenerierte zweiteilige String, der in eckigen Klammern in der `Launching (...)`-Konsolenausgabezeile angezeigt wird.
+Du kannst auch das Nextflow-Protokoll verwenden, um einen Lauf basierend auf seinem Zeitstempel und/oder seiner Befehlszeile nachzuschlagen.
+
+#### 4.3.2. Einen Probelauf durchführen
+
+Zuerst verwenden wir das Probelauf-Flag `-n`, um zu überprüfen, was bei dem Befehl gelöscht wird:
+
+```bash
+nextflow clean -before backstabbing_swartz -n
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    Would remove /workspaces/training/hello-nextflow/work/eb/1a5de36637b475afd88fca7f79e024
+    Would remove /workspaces/training/hello-nextflow/work/6b/19b0e002ea13486d3a0344c336c1d0
+    Would remove /workspaces/training/hello-nextflow/work/45/9a6dd7ab771f93003d040956282883
+    ```
+
+Deine Ausgabe wird andere Aufgabenverzeichnisnamen haben und möglicherweise eine andere Anzahl von Zeilen, aber sie sollte ähnlich wie das Beispiel aussehen.
+
+Wenn du keine Zeilen in der Ausgabe siehst, hast du entweder keinen gültigen Laufnamen angegeben oder es gibt keine vergangenen Läufe zum Löschen. Stelle sicher, dass du `backstabbing_swartz` im Beispielbefehl durch den entsprechenden letzten Laufnamen in deinem Protokoll änderst.
+
+#### 4.3.3. Mit dem Löschen fortfahren
+
+Wenn die Ausgabe wie erwartet aussieht und du mit dem Löschen fortfahren möchtest, führe den Befehl mit dem `-f`-Flag anstelle von `-n` erneut aus:
+
+```bash
+nextflow clean -before backstabbing_swartz -f
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    Removed /workspaces/training/hello-nextflow/work/eb/1a5de36637b475afd88fca7f79e024
+    Removed /workspaces/training/hello-nextflow/work/6b/19b0e002ea13486d3a0344c336c1d0
+    Removed /workspaces/training/hello-nextflow/work/45/9a6dd7ab771f93003d040956282883
+    ```
+
+Die Ausgabe sollte ähnlich wie vorher sein, aber jetzt sagt sie 'Removed' anstelle von 'Would remove'.
+Beachte, dass dies nicht die zweistelligen Unterverzeichnisse (wie `eb/` oben) entfernt, aber ihren Inhalt leert.
+
+!!! Warnung
+
+    Das Löschen von Work-Unterverzeichnissen von vergangenen Läufen entfernt sie aus Nextflows Cache und löscht alle Ausgaben, die in diesen Verzeichnissen gespeichert waren.
+    Das bedeutet, es bricht Nextflows Fähigkeit, die Ausführung fortzusetzen, ohne die entsprechenden Prozesse erneut auszuführen.
+
+    Du bist verantwortlich dafür, alle Ausgaben zu sichern, die dir wichtig sind! Das ist der Hauptgrund, warum wir den `copy`-Modus anstelle des `symlink`-Modus für die `publish`-Direktive bevorzugen.
+
+### Erkenntnisse
+
+Du weißt, wie du eine Pipeline neu startest, ohne Schritte zu wiederholen, die bereits identisch ausgeführt wurden, das Ausführungsprotokoll überprüfst und den `nextflow clean`-Befehl verwendest, um alte Work-Verzeichnisse zu bereinigen.
+
+### Was kommt als Nächstes?
+
+Mach eine kleine Pause! Du hast gerade die Bausteine der Nextflow-Syntax und grundlegende Nutzungsanweisungen aufgenommen.
+
+Im nächsten Abschnitt dieses Trainings werden wir uns vier sukzessiv realistischere Versionen der Hello World-Pipeline ansehen, die demonstrieren werden, wie Nextflow dir ermöglicht, mehrere Eingaben effizient zu verarbeiten, Workflows auszuführen, die aus mehreren miteinander verbundenen Schritten bestehen, modulare Code-Komponenten zu nutzen und Container für größere Reproduzierbarkeit und Portabilität zu verwenden.
+
+---
+
+## Quiz
+
+<quiz>
+Was repräsentiert `[a3/7be2fa]` in der Konsolenausgabezeile `[a3/7be2fa] SAYHELLO | 1 of 1 ✔`?
+- [ ] Die Prozess-Versionsnummer
+- [ ] Ein eindeutiger Lauf-Identifikator
+- [x] Der abgekürzte Pfad zum Work-Verzeichnis der Aufgabe
+- [ ] Die Prüfsumme der Ausgabedatei
+
+Mehr erfahren: [2.3. Die ursprüngliche Ausgabe und Protokolle im `work/`-Verzeichnis finden](#23-die-ursprungliche-ausgabe-und-protokolle-im-work-verzeichnis-finden)
+</quiz>
+
+<quiz>
+Was ist der Zweck der `.command.sh`-Datei in einem Aufgabenverzeichnis?
+- [ ] Sie speichert die Konfigurationseinstellungen der Aufgabe
+- [x] Sie zeigt den tatsächlichen Befehl, der vom Prozess ausgeführt wurde
+- [ ] Sie enthält Fehlermeldungen von fehlgeschlagenen Aufgaben
+- [ ] Sie listet Eingabedateien auf, die für die Aufgabe bereitgestellt wurden
+
+Mehr erfahren: [2.3. Die ursprüngliche Ausgabe und Protokolle im `work/`-Verzeichnis finden](#23-die-ursprungliche-ausgabe-und-protokolle-im-work-verzeichnis-finden)
+</quiz>
+
+<quiz>
+Was passiert mit veröffentlichten Ergebnissen, wenn du einen Workflow ohne `-resume` erneut ausführst?
+- [ ] Sie werden in separaten Verzeichnissen mit Zeitstempel aufbewahrt
+- [x] Sie werden von der neuen Ausführung überschrieben
+- [ ] Nextflow verhindert das Überschreiben und schlägt fehl
+- [ ] Sie werden automatisch gesichert
+
+Mehr erfahren: [2.4. Den Workflow mit verschiedenen Grüßen erneut ausführen](#24-den-workflow-mit-verschiedenen-grussen-erneut-ausfuhren)
+</quiz>
+
+<quiz>
+Was zeigt diese Konsolenausgabe an?
+
+```console
+[skipped  ] process > sayHello (1) [100%] 1 of 1, cached: 1 ✔
+```
+
+- [ ] Die Aufgabe ist fehlgeschlagen und wurde übersprungen
+- [ ] Die Aufgabe wartet in einer Warteschlange
+- [x] Nextflow hat Ergebnisse von einer vorherigen identischen Ausführung wiederverwendet
+- [ ] Die Aufgabe wurde manuell abgebrochen
+
+Mehr erfahren: [4.1. Einen Workflow mit `-resume` neu starten](#41-einen-workflow-mit--resume-neu-starten)
+</quiz>
+
+<quiz>
+Wo speichert Nextflow den Ausführungsverlauf, den der Befehl `nextflow log` anzeigt?
+- [ ] Im results-Verzeichnis
+- [ ] Im work-Verzeichnis
+- [x] In der `.nextflow/history`-Datei
+- [ ] In `nextflow.config`
+
+Mehr erfahren: [4.2. Das Protokoll vergangener Ausführungen überprüfen](#42-das-protokoll-vergangener-ausfuhrungen-uberprufen)
+</quiz>
+
+<quiz>
+Was ist der Zweck des `params`-Blocks in einer Workflow-Datei?
+- [ ] Um Prozess-Ressourcenanforderungen zu definieren
+- [ ] Um den Executor zu konfigurieren
+- [x] Um Workflow-Eingabeparameter zu deklarieren und zu typisieren
+- [ ] Um Ausgabe-Veröffentlichungsoptionen anzugeben
+
+Mehr erfahren: [3.4. Das params-System der Befehlszeilenparameter](#34-das-params-system-der-befehlszeilenparameter)
+</quiz>
+
+<quiz>
+Was macht `mode 'copy'` im `output`-Block des Workflows?
+- [ ] Erstellt ein Backup des work-Verzeichnisses
+- [x] Erstellt eine vollständige Kopie der Dateien anstelle von symbolischen Links
+- [ ] Kopiert das Workflow-Script zu results
+- [ ] Aktiviert inkrementelles Datei-Kopieren
+
+Mehr erfahren: [3.5. Die publish-Direktive](#35-die-publish-direktive)
+</quiz>
+
+<quiz>
+Was ist das empfohlene Flag für den `nextflow clean`-Befehl, bevor tatsächlich Dateien gelöscht werden?
+- [x] `-n` (Probelauf), um eine Vorschau dessen zu sehen, was gelöscht würde
+- [ ] `-v` (verbose), um detaillierte Ausgabe zu sehen
+- [ ] `-a` (all), um alle Verzeichnisse auszuwählen
+- [ ] `-q` (quiet), um Warnungen zu unterdrücken
+
+Mehr erfahren: [4.3. Ältere Work-Verzeichnisse löschen](#43-altere-work-verzeichnisse-loschen)
+</quiz>

--- a/docs/de/docs/nextflow_run/02_pipeline.md
+++ b/docs/de/docs/nextflow_run/02_pipeline.md
@@ -1,0 +1,1414 @@
+# Teil 2: Echte Pipelines ausführen
+
+In Teil 1 dieses Kurses (Grundlegende Operationen ausführen) haben wir mit einem Beispiel-Workflow begonnen, der nur minimale Funktionen hatte, um die Code-Komplexität gering zu halten.
+Zum Beispiel verwendete `1-hello.nf` einen Kommandozeilen-Parameter (`--input`), um jeweils einen einzelnen Wert zu übergeben.
+
+Allerdings verwenden die meisten realen Pipelines anspruchsvollere Funktionen, um eine effiziente Verarbeitung großer Datenmengen im großen Maßstab zu ermöglichen und mehrere Verarbeitungsschritte anzuwenden, die durch manchmal komplexe Logik miteinander verkettet sind.
+
+In diesem Teil des Trainings demonstrieren wir Schlüsselfunktionen realer Pipelines, indem wir erweiterte Versionen der ursprünglichen Hello World Pipeline ausprobieren.
+
+## 1. Eingabedaten aus einer Datei verarbeiten
+
+In einer realen Pipeline möchten wir typischerweise mehrere Datenpunkte (oder Datenreihen) verarbeiten, die in einer oder mehreren Eingabedateien enthalten sind.
+Und wo immer möglich, möchten wir die Verarbeitung unabhängiger Daten parallel ausführen, um die Wartezeit für die Analyse zu verkürzen.
+
+Um zu demonstrieren, wie Nextflow das macht, haben wir eine CSV-Datei namens `greetings.csv` vorbereitet, die mehrere Eingabe-Grüße enthält und die Art von spaltenbasierten Daten nachahmt, die du in einer echten Datenanalyse verarbeiten möchtest.
+Beachte, dass die Zahlen keine Bedeutung haben; sie dienen nur zur Veranschaulichung.
+
+```csv title="data/greetings.csv" linenums="1"
+Hello,English,123
+Bonjour,French,456
+Holà,Spanish,789
+```
+
+Wir haben auch eine verbesserte Version des ursprünglichen Workflows geschrieben, jetzt `2a-inputs.nf` genannt, die die CSV-Datei einliest, die Grüße extrahiert und jeden davon in eine separate Datei schreibt.
+
+<figure class="excalidraw">
+--8<-- "docs/nextflow_run/img/hello-pipeline-multi-inputs.svg"
+</figure>
+
+Lass uns zuerst den Workflow ausführen, und wir werden uns den relevanten Nextflow-Code danach ansehen.
+
+### 1.1. Den Workflow ausführen
+
+Führe den folgenden Befehl in deinem Terminal aus.
+
+```bash
+nextflow run 2a-inputs.nf --input data/greetings.csv
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `2a-inputs.nf` [mighty_sammet] DSL2 - revision: 29fb5352b3
+
+    executor >  local (3)
+    [8e/0eb066] sayHello (2) [100%] 3 of 3 ✔
+    ```
+
+Spannenderweise scheint dies anzuzeigen, dass '3 von 3' Aufrufe für den process gemacht wurden, was ermutigend ist, da es drei Datenzeilen in der CSV gab, die wir als Eingabe bereitgestellt haben.
+Dies deutet darauf hin, dass der `sayHello()` process dreimal aufgerufen wurde, einmal für jede Eingabezeile.
+
+### 1.2. Die veröffentlichten Ausgaben im `results`-Verzeichnis finden
+
+Schauen wir uns das 'results'-Verzeichnis an, um zu sehen, ob unser Workflow immer noch eine Kopie unserer Ausgaben dorthin schreibt.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console linenums="1" hl_lines="4-7"
+    results
+    ├── 1-hello
+    |   └── output.txt
+    └── 2a-inputs
+        ├── Bonjour-output.txt
+        ├── Hello-output.txt
+        └── Holà-output.txt
+    ```
+
+Ja! Wir sehen ein neues Verzeichnis namens `2a-inputs` mit drei Ausgabedateien mit unterschiedlichen Namen, praktischerweise.
+
+Du kannst jede davon öffnen, um dich zu vergewissern, dass sie den entsprechenden Gruß-String enthält.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/2a-inputs/Hello-output.txt"
+    Hello
+    ```
+
+    ```console title="results/2a-inputs/Bonjour-output.txt"
+    Bonjour
+    ```
+
+    ```console title="results/2a-inputs/Holà-output.txt"
+    Holà
+    ```
+
+Dies bestätigt, dass jeder Gruß in der Eingabedatei entsprechend verarbeitet wurde.
+
+### 1.3. Die ursprünglichen Ausgaben und Logs finden
+
+Du hast vielleicht bemerkt, dass die Konsolenausgabe oben nur auf ein task-Verzeichnis verwies.
+Bedeutet das, dass alle drei Aufrufe von `sayHello()` innerhalb dieses einen task-Verzeichnisses ausgeführt wurden?
+
+#### 1.3.1. Das im Terminal angegebene task-Verzeichnis untersuchen
+
+Schauen wir uns dieses `8e/0eb066` task-Verzeichnis an.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console title="8e/0eb066"
+    work/8e/0eb066071cdb4123906b7b4ea8b047/
+    └── Bonjour-output.txt
+    ```
+
+Wir finden nur die Ausgabe, die einem der Grüße entspricht (sowie die Hilfsdateien, wenn wir die Anzeige versteckter Dateien aktivieren).
+
+Was passiert hier also?
+
+Standardmäßig schreibt das ANSI-Logging-System die Statusinformationen für alle Aufrufe desselben process in dieselbe Zeile.
+Daher zeigte es uns nur einen der drei task-Verzeichnispfade (`8e/0eb066`) in der Konsolenausgabe.
+Es gibt zwei weitere, die dort nicht aufgeführt sind.
+
+#### 1.3.2. Das Terminal mehr Details anzeigen lassen
+
+Wir können das Logging-Verhalten ändern, um die vollständige Liste der process-Aufrufe zu sehen, indem wir `-ansi-log false` zum Befehl wie folgt hinzufügen:
+
+```bash
+nextflow run 2a-inputs.nf --input data/greetings.csv -ansi-log false
+```
+
+??? success "Befehlsausgabe"
+
+    ```console linenums="1"
+    N E X T F L O W  ~  version 25.10.2
+    Launching `2a-inputs.nf` [pedantic_hamilton] DSL2 - revision: 6bbc42e49f
+    [ab/1a8ece] Submitted process > sayHello (1)
+    [0d/2cae24] Submitted process > sayHello (2)
+    [b5/0df1d6] Submitted process > sayHello (3)
+    ```
+
+Diesmal sehen wir alle drei process-Ausführungen und ihre zugehörigen work-Unterverzeichnisse in der Ausgabe aufgelistet.
+Das Deaktivieren des ANSI-Loggings verhinderte auch, dass Nextflow Farben in der Terminal-Ausgabe verwendete.
+
+Beachte, dass die Art und Weise, wie der Status gemeldet wird, zwischen den beiden Logging-Modi etwas unterschiedlich ist.
+Im komprimierten Modus meldet Nextflow, ob Aufrufe erfolgreich abgeschlossen wurden oder nicht.
+In diesem erweiterten Modus meldet es nur, dass sie übermittelt wurden.
+
+Dies bestätigt, dass der `sayHello()` process dreimal aufgerufen wird, und für jeden wird ein separates task-Verzeichnis erstellt.
+
+Wenn wir in jedes der dort aufgelisteten task-Verzeichnisse schauen, können wir überprüfen, dass jedes einem der Grüße entspricht.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console title="ab/1a8ece"
+    work/ab/1a8ece307e53f03fce689dde904b64/
+    └── Hello-output.txt
+    ```
+
+    ```console title="0d/2cae24"
+    work/0d/2cae2481a53593bc607077c80c9466/
+    └── Bonjour-output.txt
+    ```
+
+    ```console title="b5/0df1d6"
+    work/b5/0df1d642353269909c2ce23fc2a8fa/
+    └── Holà-output.txt
+    ```
+
+Dies bestätigt, dass jeder process-Aufruf isoliert von allen anderen ausgeführt wird.
+Das hat viele Vorteile, einschließlich der Vermeidung von Kollisionen, wenn der process Zwischendateien mit nicht-eindeutigen Namen erzeugt.
+
+!!! tip "Tipp"
+
+    Bei einem komplexen Workflow oder einer großen Anzahl von Eingaben kann es etwas überwältigend werden, die vollständige Liste im Terminal ausgeben zu lassen, daher verwenden die Leute `-ansi-log false` normalerweise nicht im Routinebetrieb.
+
+### 1.4. Den Workflow-Code untersuchen
+
+Diese Version des Workflows ist also in der Lage, eine CSV-Datei mit Eingaben einzulesen, die Eingaben separat zu verarbeiten und die Ausgaben eindeutig zu benennen.
+
+Schauen wir uns an, was das im Workflow-Code ermöglicht.
+
+??? full-code "Vollständige Code-Datei"
+
+    ```groovy title="2a-inputs.nf" linenums="1" hl_lines="31-33 35"
+    #!/usr/bin/env nextflow
+
+    /*
+    * Use echo to print 'Hello World!' to a file
+    */
+    process sayHello {
+
+        input:
+        val greeting
+
+        output:
+        path "${greeting}-output.txt"
+
+        script:
+        """
+        echo '${greeting}' > '${greeting}-output.txt'
+        """
+    }
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path
+    }
+
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emit a greeting
+        sayHello(greeting_ch)
+
+        publish:
+        first_output = sayHello.out
+    }
+
+    output {
+        first_output {
+            path '2a-inputs'
+            mode 'copy'
+        }
+    }
+    ```
+
+Auch hier musst du die Code-Syntax nicht auswendig lernen, aber es ist gut zu lernen, Schlüsselkomponenten des Workflows zu erkennen, die wichtige Funktionalität bieten.
+
+#### 1.4.1. Die Eingabedaten aus der CSV laden
+
+Dies ist der interessanteste Teil: Wie haben wir von der Übernahme eines einzelnen Wertes von der Kommandozeile auf eine CSV-Datei umgestellt, sie geparst und die einzelnen Grüße verarbeitet, die sie enthält?
+
+In Nextflow machen wir das mit einem **channel**: einem Konstrukt, das entwickelt wurde, um Eingaben effizient zu handhaben und sie von einem Schritt zum nächsten in mehrstufigen Workflows zu transportieren, während es eingebaute Parallelität und viele zusätzliche Vorteile bietet.
+
+Lass es uns aufschlüsseln.
+
+```groovy title="2a-inputs.nf" linenums="29" hl_lines="3-5"
+    main:
+    // create a channel for inputs from a CSV file
+    greeting_ch = channel.fromPath(params.input)
+                        .splitCsv()
+                        .map { line -> line[0] }
+    // emit a greeting
+    sayHello(greeting_ch)
+```
+
+Dieser Code erstellt einen channel namens `greeting_ch`, der die CSV-Datei liest, sie parst und die erste Spalte aus jeder Zeile extrahiert.
+Das Ergebnis ist ein channel, der `Hello`, `Bonjour` und `Holà` enthält.
+
+??? tip "Wie funktioniert das?"
+
+    Hier ist, was diese Zeile auf Deutsch bedeutet:
+
+    - `channel.fromPath` ist eine **channel factory**, die einen channel aus Dateipfad(en) erstellt
+    - `(params.input)` gibt an, dass der Dateipfad durch `--input` auf der Kommandozeile bereitgestellt wird
+
+    Mit anderen Worten, diese Zeile sagt Nextflow: Nimm den mit `--input` angegebenen Dateipfad und bereite dich darauf vor, seinen Inhalt als Eingabedaten zu behandeln.
+
+    Dann wenden die nächsten beiden Zeilen **Operatoren** an, die das eigentliche Parsen der Datei und das Laden der Daten in die entsprechende Datenstruktur durchführen:
+
+    - `.splitCsv()` sagt Nextflow, dass es die CSV-Datei in ein Array parsen soll, das Zeilen und Spalten repräsentiert
+    - `.map { line -> line[0] }` sagt Nextflow, dass es nur das Element in der ersten Spalte aus jeder Zeile nehmen soll
+
+    In der Praxis also, ausgehend von der folgenden CSV-Datei:
+
+    ```csv title="greetings.csv" linenums="1"
+    Hello,English,123
+    Bonjour,French,456
+    Holà,Spanish,789
+    ```
+
+    Haben wir das in ein Array transformiert, das so aussieht:
+
+    ```txt title="Array-Inhalte"
+    [[Hello,English,123],[Bonjour,French,456],[Holà,Spanish,789]]
+    ```
+
+    Und dann haben wir das erste Element aus jeder der drei Zeilen genommen und sie in einen Nextflow channel geladen, der jetzt enthält: `Hello`, `Bonjour` und `Holà`.
+
+    Wenn du channels und Operatoren im Detail verstehen möchtest, einschließlich wie du sie selbst schreibst, siehe [Hello Nextflow Teil 2: Hello Channels](../hello_nextflow/02_hello_channels.md#4-read-input-values-from-a-csv-file).
+
+#### 1.4.2. Den process für jeden Gruß aufrufen
+
+Als nächstes geben wir in der letzten Zeile des `main:`-Blocks des Workflows den geladenen `greeting_ch` channel als Eingabe für den `sayHello()` process an.
+
+```groovy title="2a-inputs.nf" linenums="29" hl_lines="7"
+    main:
+    // create a channel for inputs from a CSV file
+    greeting_ch = channel.fromPath(params.input)
+                        .splitCsv()
+                        .map { line -> line[0] }
+    // emit a greeting
+    sayHello(greeting_ch)
+```
+
+Dies sagt Nextflow, dass es den process einzeln auf jedes Element im channel ausführen soll, _d.h._ auf jeden Gruß.
+Und weil Nextflow so clever ist, wird es diese process-Aufrufe parallel ausführen, wenn möglich, abhängig von der verfügbaren Recheninfrastruktur.
+
+So kannst du eine effiziente und skalierbare Verarbeitung vieler Daten (viele Proben oder Datenpunkte, was auch immer deine Forschungseinheit ist) mit vergleichsweise sehr wenig Code erreichen.
+
+#### 1.4.3. Wie die Ausgaben benannt werden
+
+Schließlich lohnt es sich, einen kurzen Blick auf den process-Code zu werfen, um zu sehen, wie wir die Ausgabedateien eindeutig benennen.
+
+```groovy title="2a-inputs.nf" linenums="6" hl_lines="7 11"
+process sayHello {
+
+    input:
+    val greeting
+
+    output:
+    path "${greeting}-output.txt"
+
+    script:
+    """
+    echo '${greeting}' > '${greeting}-output.txt'
+    """
+}
+```
+
+Du siehst, dass sich im Vergleich zur Version dieses process in `1-hello.nf` die Ausgabe-Deklaration und der relevante Teil des Befehls geändert haben, um den Gruß-Wert in den Ausgabedateinamen aufzunehmen.
+
+Dies ist eine Möglichkeit sicherzustellen, dass die Ausgabedateinamen nicht kollidieren, wenn sie im gemeinsamen results-Verzeichnis veröffentlicht werden.
+
+Und das ist die einzige Änderung, die wir innerhalb der process-Deklaration vornehmen mussten!
+
+### Zusammenfassung
+
+Du verstehst auf einem grundlegenden Niveau, wie channels und Operatoren uns ermöglichen, mehrere Eingaben effizient zu verarbeiten.
+
+### Was kommt als Nächstes?
+
+Entdecke, wie mehrstufige Workflows aufgebaut sind und wie sie funktionieren.
+
+---
+
+## 2. Mehrstufige Workflows ausführen
+
+Die meisten realen Workflows umfassen mehr als einen Schritt.
+Lass uns auf dem aufbauen, was wir gerade über channels gelernt haben, und schauen, wie Nextflow channels und Operatoren verwendet, um processes in einem mehrstufigen Workflow miteinander zu verbinden.
+
+Zu diesem Zweck stellen wir dir einen Beispiel-Workflow zur Verfügung, der drei separate Schritte miteinander verkettet und Folgendes demonstriert:
+
+1. Daten von einem process zum nächsten fließen lassen
+2. Ausgaben von mehreren process-Aufrufen in einem einzigen process-Aufruf sammeln
+
+Konkret haben wir eine erweiterte Version des Workflows namens `2b-multistep.nf` erstellt, die jeden Eingabe-Gruß nimmt, ihn in Großbuchstaben umwandelt und dann alle großgeschriebenen Grüße in einer einzigen Ausgabedatei sammelt.
+
+<figure class="excalidraw">
+--8<-- "docs/nextflow_run/img/hello-pipeline-multi-steps.svg"
+</figure>
+
+Wie zuvor werden wir den Workflow zuerst ausführen und dann den Code ansehen, um zu sehen, was neu ist.
+
+### 2.1. Den Workflow ausführen
+
+Führe den folgenden Befehl in deinem Terminal aus:
+
+```bash
+nextflow run 2b-multistep.nf --input data/greetings.csv
+```
+
+??? success "Befehlsausgabe"
+
+    ```console linenums="1"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `2b-multistep.nf` [soggy_franklin] DSL2 - revision: bc8e1b2726
+
+    [d6/cdf466] sayHello (1)       | 3 of 3 ✔
+    [99/79394f] convertToUpper (2) | 3 of 3 ✔
+    [1e/83586c] collectGreetings   | 1 of 1 ✔
+    ```
+
+Du siehst, dass wie versprochen mehrere Schritte als Teil des Workflows ausgeführt wurden; die ersten beiden (`sayHello` und `convertToUpper`) wurden vermutlich auf jeden einzelnen Gruß ausgeführt, und der dritte (`collectGreetings`) wird nur einmal ausgeführt worden sein, auf den Ausgaben aller drei `convertToUpper`-Aufrufe.
+
+### 2.2. Die Ausgaben finden
+
+Lass uns überprüfen, dass das tatsächlich passiert ist, indem wir einen Blick in das `results`-Verzeichnis werfen.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console linenums="1" hl_lines="8-16"
+    results
+    ├── 1-hello
+    |   └── output.txt
+    ├── 2a-inputs
+    |   ├── Bonjour-output.txt
+    |   ├── Hello-output.txt
+    |   └── Holà-output.txt
+    └── 2b-multistep
+        ├── COLLECTED-batch-output.txt
+        ├── batch-report.txt
+        └── intermediates
+            ├── Bonjour-output.txt
+            ├── Hello-output.txt
+            ├── Holà-output.txt
+            ├── UPPER-Bonjour-output.txt
+            ├── UPPER-Hello-output.txt
+            └── UPPER-Holà-output.txt
+
+    ```
+
+Wie du sehen kannst, haben wir ein neues Verzeichnis namens `2b-multistep`, und es enthält einiges mehr Dateien als zuvor.
+Einige der Dateien wurden in einem Unterverzeichnis namens `intermediates` gruppiert, während sich zwei Dateien auf der obersten Ebene befinden.
+
+Diese beiden sind die Endergebnisse des mehrstufigen Workflows.
+Nimm dir eine Minute Zeit, um die Dateinamen anzusehen und ihren Inhalt zu überprüfen, um zu bestätigen, dass sie das sind, was du erwartest.
+
+??? abstract "Dateiinhalte"
+
+    ```txt title="results/2b-multistep/COLLECTED-batch-output.txt"
+    HELLO
+    BONJOUR
+    HOLà
+    ```
+
+    ```txt title="results/2b-multistep/batch-report.txt"
+    There were 3 greetings in this batch.
+    ```
+
+Die erste enthält unsere drei Grüße, großgeschrieben und wie versprochen in einer einzigen Datei gesammelt.
+Die zweite ist eine Berichtsdatei, die einige Informationen über den Lauf zusammenfasst.
+
+### 2.3. Den Code untersuchen
+
+Schauen wir uns den Code an und identifizieren die Schlüsselmuster für mehrstufige Workflows.
+
+??? full-code "Vollständige Code-Datei"
+
+    ```groovy title="2b-multistep.nf" linenums="1" hl_lines="63 75-78 82-84"
+    #!/usr/bin/env nextflow
+
+    /*
+    * Use echo to print 'Hello World!' to a file
+    */
+    process sayHello {
+
+        input:
+        val greeting
+
+        output:
+        path "${greeting}-output.txt"
+
+        script:
+        """
+        echo '${greeting}' > '${greeting}-output.txt'
+        """
+    }
+
+    /*
+    * Use a text replacement tool to convert the greeting to uppercase
+    */
+    process convertToUpper {
+
+        input:
+        path input_file
+
+        output:
+        path "UPPER-${input_file}"
+
+        script:
+        """
+        cat '${input_file}' | tr '[a-z]' '[A-Z]' > 'UPPER-${input_file}'
+        """
+    }
+
+    /*
+    * Collect uppercase greetings into a single output file
+    */
+    process collectGreetings {
+
+        input:
+        path input_files
+        val batch_name
+
+        output:
+        path "COLLECTED-${batch_name}-output.txt", emit: outfile
+        path "${batch_name}-report.txt", emit: report
+
+        script:
+        count_greetings = input_files.size()
+        """
+        cat ${input_files} > 'COLLECTED-${batch_name}-output.txt'
+        echo 'There were ${count_greetings} greetings in this batch.' > '${batch_name}-report.txt'
+        """
+    }
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path
+        batch: String = 'batch'
+    }
+
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emit a greeting
+        sayHello(greeting_ch)
+        // convert the greeting to uppercase
+        convertToUpper(sayHello.out)
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect(), params.batch)
+
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out.outfile
+        batch_report = collectGreetings.out.report
+    }
+
+    output {
+        first_output {
+            path '2b-multistep/intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path '2b-multistep/intermediates'
+            mode 'copy'
+        }
+        collected {
+            path '2b-multistep'
+            mode 'copy'
+        }
+        batch_report {
+            path '2b-multistep'
+            mode 'copy'
+        }
+    }
+    ```
+
+Da passiert viel, aber der offensichtlichste Unterschied im Vergleich zur vorherigen Version des Workflows ist, dass es jetzt mehrere process-Definitionen gibt und entsprechend mehrere process-Aufrufe im workflow-Block.
+
+Schauen wir uns das genauer an und sehen, ob wir die interessantesten Teile identifizieren können.
+
+#### 2.3.1. Workflow-Struktur visualisieren
+
+Wenn du VSCode mit der Nextflow-Erweiterung verwendest, kannst du ein hilfreiches Diagramm bekommen, das zeigt, wie die processes verbunden sind, indem du auf den kleinen `DAG preview`-Link klickst, der direkt über dem workflow-Block in jedem Nextflow-Script angezeigt wird.
+
+<figure class="excalidraw">
+--8<-- "docs/nextflow_run/img/DAG-multistep.svg"
+</figure>
+
+Das gibt dir einen schönen Überblick darüber, wie die processes verbunden sind und was sie produzieren.
+
+Du siehst, dass wir zusätzlich zum ursprünglichen `sayHello` process jetzt auch `convertToUpper` und `collectGreetings` haben, die mit den Namen der processes übereinstimmen, die wir in der Konsolenausgabe gesehen haben.
+Die beiden neuen process-Definitionen sind auf die gleiche Weise strukturiert wie der `sayHello` process, außer dass `collectGreetings` einen zusätzlichen Eingabe-Parameter namens `batch` nimmt und zwei Ausgaben produziert.
+
+Wir werden nicht im Detail auf den Code für jeden eingehen, aber wenn du neugierig bist, kannst du die Details in [Teil 2 von Hello Nextflow](../hello_nextflow/03_hello_workflow.md) nachschlagen.
+
+Für jetzt lass uns untersuchen, wie die processes miteinander verbunden sind.
+
+#### 2.3.2. Wie die processes verbunden sind
+
+Das wirklich Interessante hier ist, wie die process-Aufrufe im `main:`-Block des Workflows miteinander verkettet sind.
+
+```groovy title="2b-multistep.nf" linenums="68" hl_lines="9 11"
+    main:
+    // create a channel for inputs from a CSV file
+    greeting_ch = channel.fromPath(params.input)
+                        .splitCsv()
+                        .map { line -> line[0] }
+    // emit a greeting
+    sayHello(greeting_ch)
+    // convert the greeting to uppercase
+    convertToUpper(sayHello.out)
+    // collect all the greetings into one file
+    collectGreetings(convertToUpper.out.collect(), params.batch)
+```
+
+Du kannst sehen, dass der erste process-Aufruf, `sayHello(greeting_ch)`, unverändert ist.
+Dann bezieht sich der nächste process-Aufruf, zu `convertToUpper`, auf die Ausgabe von `sayHello` als `sayHello.out`.
+
+Das Muster ist einfach: `processName.out` bezieht sich auf den Ausgabe-channel eines process, der direkt an den nächsten process übergeben werden kann.
+So transportieren wir Daten von einem Schritt zum nächsten in Nextflow.
+
+#### 2.3.3. Ein process kann mehrere Eingaben nehmen
+
+Der dritte process-Aufruf, zu `collectGreetings`, ist etwas anders.
+
+```groovy title="2b-multistep.nf" linenums="77"
+    // collect all the greetings into one file
+    collectGreetings(convertToUpper.out.collect(), params.batch)
+```
+
+Du siehst, dass diesem Aufruf zwei Eingaben gegeben werden, `convertToUpper.out.collect()` und `params.batch`.
+Wenn wir das `.collect()`-Teil für jetzt ignorieren, können wir das als `collectGreetings(input1, input2)` verallgemeinern.
+
+Das entspricht den beiden Eingabe-Deklarationen im process-Modul:
+
+```groovy title="2b-multistep.nf" linenums="40"
+process collectGreetings {
+
+    input:
+    path input_files
+    val batch_name
+```
+
+Wenn Nextflow das parst, wird es die erste Eingabe im Aufruf `path input_files` zuweisen und die zweite `val batch_name`.
+
+Jetzt weißt du also, dass ein process mehrere Eingaben nehmen kann, und wie der Aufruf im workflow-Block aussieht.
+
+Lass uns nun einen genaueren Blick auf diese erste Eingabe werfen, `convertToUpper.out.collect()`.
+
+#### 2.3.4. Was `collect()` im `collectGreetings`-Aufruf tut
+
+Um die Ausgabe von `sayHello` an `convertToUpper` zu übergeben, haben wir einfach auf den Ausgabe-channel von `sayHello` als `sayHello.out` verwiesen. Aber für den nächsten Schritt sehen wir einen Verweis auf `convertToUpper.out.collect()`.
+
+Was ist dieses `collect()`-Teil und was tut es?
+
+Es ist natürlich ein Operator. Genau wie die `splitCsv`- und `map`-Operatoren, die wir vorher kennengelernt haben.
+Diesmal heißt der Operator `collect` und wird auf den Ausgabe-channel angewendet, der von `convertToUpper` produziert wird.
+
+Der `collect`-Operator wird verwendet, um die Ausgaben von mehreren Aufrufen desselben process zu sammeln und sie in ein einzelnes channel-Element zu verpacken.
+
+Im Kontext dieses Workflows nimmt er die drei großgeschriebenen Grüße im `convertToUpper.out` channel --die drei separate channel-Elemente sind und normalerweise in separaten Aufrufen vom nächsten process behandelt würden-- und verpackt sie in ein einzelnes Element.
+
+In praktischeren Begriffen: Wenn wir `collect()` nicht auf die Ausgabe von `convertToUpper()` anwenden würden, bevor wir sie an `collectGreetings()` füttern, würde Nextflow einfach `collectGreetings()` unabhängig auf jeden Gruß ausführen, was unser Ziel nicht erreichen würde.
+
+<figure class="excalidraw">
+--8<-- "docs/nextflow_run/img/without-collect-operator.svg"
+</figure>
+
+Im Gegensatz dazu erlaubt uns die Verwendung von `collect()`, alle separaten großgeschriebenen Grüße, die vom zweiten Schritt des Workflows produziert wurden, zu nehmen und sie alle zusammen einem einzigen Aufruf im dritten Schritt der Pipeline zuzuführen.
+
+<figure class="excalidraw">
+--8<-- "docs/nextflow_run/img/with-collect-operator.svg"
+</figure>
+
+So bekommen wir alle Grüße zurück in dieselbe Datei.
+
+Es gibt viele andere [Operatoren](https://www.nextflow.io/docs/latest/reference/operator.html#operator-page), die verfügbar sind, um Transformationen auf den Inhalt von channels zwischen process-Aufrufen anzuwenden.
+
+Das gibt Pipeline-Entwicklern viel Flexibilität für die Anpassung der Flusslogik ihrer Pipeline.
+Der Nachteil ist, dass es manchmal schwieriger machen kann, zu entziffern, was die Pipeline tut.
+
+#### 2.3.5. Ein Eingabe-Parameter kann einen Standardwert haben
+
+Du hast vielleicht bemerkt, dass `collectGreetings` eine zweite Eingabe nimmt, `params.batch`:
+
+```groovy title="2b-multistep.nf" linenums="77"
+    // collect all the greetings into one file
+    collectGreetings(convertToUpper.out.collect(), params.batch)
+```
+
+Das übergibt einen CLI-Parameter namens `--batch` an den Workflow.
+Allerdings haben wir beim Starten des Workflows vorhin keinen `--batch`-Parameter angegeben.
+
+Was passiert da?
+Schau dir den `params`-Block an:
+
+```groovy title="2b-multistep.nf" linenums="61" hl_lines="3"
+params {
+    input: Path
+    batch: String = 'batch'
+}
+```
+
+Es ist ein Standardwert im Workflow konfiguriert, also müssen wir ihn nicht angeben.
+Aber wenn wir einen auf der Kommandozeile angeben, wird der von uns angegebene Wert anstelle des Standards verwendet.
+
+Probier es aus:
+
+```bash
+nextflow run 2b-multistep.nf --input data/greetings.csv --batch test
+```
+
+??? success "Befehlsausgabe"
+
+    ```console linenums="1"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `2b-multistep.nf` [soggy_franklin] DSL2 - revision: bc8e1b2726
+
+    [a5/cdff26] sayHello (1)       | 3 of 3 ✔
+    [c5/78794f] convertToUpper (2) | 3 of 3 ✔
+    [d3/b4d86c] collectGreetings   | 1 of 1 ✔
+    ```
+
+Du solltest neue Endausgaben sehen, die mit deinem benutzerdefinierten Batch-Namen benannt sind.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console linenums="1" hl_lines="10 12"
+    results
+    ├── 1-hello
+    |   └── output.txt
+    ├── 2a-inputs
+    |   ├── Bonjour-output.txt
+    |   ├── Hello-output.txt
+    |   └── Holà-output.txt
+    └── 2b-multistep
+        ├── COLLECTED-batch-output.txt
+        ├── COLLECTED-test-output.txt
+        ├── batch-report.txt
+        ├── test-report.txt
+        └── intermediates
+            ├── Bonjour-output.txt
+            ├── Hello-output.txt
+            ├── Holà-output.txt
+            ├── UPPER-Bonjour-output.txt
+            ├── UPPER-Hello-output.txt
+            └── UPPER-Holà-output.txt
+    ```
+
+Dies ist ein Aspekt der Eingabe-Konfiguration, den wir in Teil 3 ausführlicher behandeln werden, aber für jetzt ist das Wichtige zu wissen, dass Eingabe-Parameter Standardwerte haben können.
+
+#### 2.3.6. Ein process kann mehrere Ausgaben produzieren
+
+In der `collectGreetings` process-Definition sehen wir die folgenden Ausgabe-Deklarationen:
+
+```groovy title="2b-multistep.nf" linenums="46"
+    output:
+    path "COLLECTED-${batch_name}-output.txt", emit: outfile
+    path "${batch_name}-report.txt", emit: report
+```
+
+Auf die dann im `publish:`-Block mit dem mit `emit:` angegebenen Namen verwiesen wird:
+
+```groovy title="2b-multistep.nf" linenums="80" hl_lines="4 5"
+    publish:
+    first_output = sayHello.out
+    uppercased = convertToUpper.out
+    collected = collectGreetings.out.outfile
+    batch_report = collectGreetings.out.report
+```
+
+Das macht es einfach, spezifische Ausgaben einzeln an andere processes im Workflow zu übergeben, in Kombination mit verschiedenen Operatoren.
+
+#### 2.3.7. Veröffentlichte Ausgaben können organisiert werden
+
+Im `output`-Block haben wir benutzerdefinierte Pfade verwendet, um Zwischenergebnisse zu gruppieren, um es einfacher zu machen, nur die Endausgaben des Workflows herauszupicken.
+
+```groovy title="2b-multistep.nf" linenums="87" hl_lines="3 7 11 15"
+output {
+    first_output {
+        path '2b-multistep/intermediates'
+        mode 'copy'
+    }
+    uppercased {
+        path '2b-multistep/intermediates'
+        mode 'copy'
+    }
+    collected {
+        path '2b-multistep'
+        mode 'copy'
+    }
+    batch_report {
+        path '2b-multistep'
+        mode 'copy'
+    }
+}
+```
+
+Es gibt anspruchsvollere Möglichkeiten, veröffentlichte Ausgaben zu organisieren; wir werden einige davon im Teil über Konfiguration ansprechen.
+
+!!! tip "Möchtest du mehr über das Erstellen von Workflows erfahren?"
+
+    Für eine detaillierte Behandlung des Aufbaus mehrstufiger Workflows, siehe [Hello Nextflow Teil 3: Hello Workflow](../hello_nextflow/03_hello_workflow.md).
+
+### Zusammenfassung
+
+Du verstehst auf einem grundlegenden Niveau, wie mehrstufige Workflows unter Verwendung von channels und Operatoren aufgebaut werden und wie sie funktionieren.
+Du hast auch gesehen, dass processes mehrere Eingaben nehmen und mehrere Ausgaben produzieren können, und dass diese auf strukturierte Weise veröffentlicht werden können.
+
+### Was kommt als Nächstes?
+
+Lerne, wie Nextflow Pipelines modularisiert werden können, um Code-Wiederverwendung und Wartbarkeit zu fördern.
+
+---
+
+## 3. Modularisierte Pipelines ausführen
+
+Bisher bestanden alle Workflows, die wir uns angesehen haben, aus einer einzigen Workflow-Datei, die den gesamten relevanten Code enthielt.
+
+Allerdings profitieren reale Pipelines typischerweise davon, _modularisiert_ zu sein, was bedeutet, dass der Code in verschiedene Dateien aufgeteilt wird.
+Das kann ihre Entwicklung und Wartung effizienter und nachhaltiger machen.
+
+Hier werden wir die häufigste Form der Code-Modularität in Nextflow demonstrieren, nämlich die Verwendung von **Modulen**.
+
+In Nextflow ist ein **Modul** eine einzelne process-Definition, die für sich allein in einer eigenständigen Code-Datei gekapselt ist.
+Um ein Modul in einem Workflow zu verwenden, fügst du einfach eine einzeilige import-Anweisung zu deiner Workflow-Code-Datei hinzu; dann kannst du den process genauso in den Workflow integrieren, wie du es normalerweise tun würdest.
+Das macht es möglich, process-Definitionen in mehreren Workflows wiederzuverwenden, ohne mehrere Kopien des Codes zu erzeugen.
+
+Bis jetzt haben wir Workflows ausgeführt, die alle ihre processes in einer monolithischen Code-Datei enthalten hatten.
+Jetzt werden wir sehen, wie es aussieht, wenn die processes in einzelnen Modulen gespeichert sind.
+
+Wir haben natürlich wieder einen geeigneten Workflow für Demonstrationszwecke vorbereitet, genannt `2c-modules.nf`, zusammen mit einer Reihe von Modulen, die sich im `modules/`-Verzeichnis befinden.
+
+<figure class="excalidraw">
+--8<-- "docs/nextflow_run/img/modules.svg"
+</figure>
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console
+    modules/
+    ├── collectGreetings.nf
+    ├── convertToUpper.nf
+    ├── cowpy.nf
+    └── sayHello.nf
+    ```
+
+Du siehst, dass es vier Nextflow-Dateien gibt, jede nach einem der processes benannt.
+Du kannst die `cowpy.nf`-Datei für jetzt ignorieren; wir kommen später dazu.
+
+### 3.1. Den Code untersuchen
+
+Diesmal werden wir zuerst den Code ansehen.
+Beginne damit, die `2c-modules.nf` Workflow-Datei zu öffnen.
+
+??? full-code "Vollständige Code-Datei"
+
+    ```groovy title="2c-modules.nf" linenums="1"
+    #!/usr/bin/env nextflow
+
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+    include { collectGreetings } from './modules/collectGreetings.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path
+        batch: String = 'batch'
+    }
+
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emit a greeting
+        sayHello(greeting_ch)
+        // convert the greeting to uppercase
+        convertToUpper(sayHello.out)
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect(), params.batch)
+
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out.outfile
+        batch_report = collectGreetings.out.report
+    }
+
+    output {
+        first_output {
+            path '2c-modules/intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path '2c-modules/intermediates'
+            mode 'copy'
+        }
+        collected {
+            path '2c-modules'
+            mode 'copy'
+        }
+        batch_report {
+            path '2c-modules'
+            mode 'copy'
+        }
+    }
+    ```
+
+Du siehst, dass die Workflow-Logik genau dieselbe ist wie in der vorherigen Version des Workflows.
+Allerdings ist der process-Code aus der Workflow-Datei verschwunden, und stattdessen gibt es `include`-Anweisungen, die auf separate Dateien unter `modules` verweisen.
+
+```groovy title="hello-modules.nf" linenums="3"
+// Include modules
+include { sayHello } from './modules/sayHello.nf'
+include { convertToUpper } from './modules/convertToUpper.nf'
+include { collectGreetings } from './modules/collectGreetings.nf'
+```
+
+Öffne eine dieser Dateien und du findest den Code für den entsprechenden process.
+
+??? full-code "Vollständige Code-Datei"
+
+    ```groovy title="modules/sayHello.nf" linenums="1"
+    #!/usr/bin/env nextflow
+
+    /*
+    * Use echo to print 'Hello World!' to a file
+    */
+    process sayHello {
+
+        input:
+        val greeting
+
+        output:
+        path "${greeting}-output.txt"
+
+        script:
+        """
+        echo '${greeting}' > '${greeting}-output.txt'
+        """
+    }
+    ```
+
+Wie du sehen kannst, hat sich der process-Code nicht geändert; er wurde nur in eine einzelne Modul-Datei kopiert, anstatt in der Haupt-Workflow-Datei zu sein.
+Das Gleiche gilt für die anderen beiden processes.
+
+Also schauen wir uns an, wie es aussieht, diese neue Version auszuführen.
+
+### 3.2. Den Workflow ausführen
+
+Führe diesen Befehl in deinem Terminal aus, mit dem `-resume`-Flag:
+
+```bash
+nextflow run 2c-modules.nf --input data/greetings.csv -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `2c-modules.nf` [soggy_franklin] DSL2 - revision: bc8e1b2726
+
+    [j6/cdfa66] sayHello (1)       | 3 of 3, cached: ✔
+    [95/79484f] convertToUpper (2) | 3 of 3, cached: ✔
+    [5e/4358gc] collectGreetings   | 1 of 1, cached: ✔
+    ```
+
+Du wirst bemerken, dass alle process-Ausführungen erfolgreich aus dem cache geladen wurden, was bedeutet, dass Nextflow erkannt hat, dass es die angeforderte Arbeit bereits erledigt hat, obwohl der Code aufgeteilt wurde und die Haupt-Workflow-Datei umbenannt wurde.
+
+Nichts davon ist für Nextflow wichtig; was zählt, ist das Job-Script, das generiert wird, nachdem der gesamte Code zusammengezogen und ausgewertet wurde.
+
+!!! tip "Tipp"
+
+    Es ist auch möglich, einen Abschnitt eines Workflows als 'Subworkflow' zu kapseln, der in eine größere Pipeline importiert werden kann, aber das liegt außerhalb des Umfangs dieses Kurses.
+
+    Du kannst mehr über die Entwicklung zusammensetzbarer Workflows in der Side Quest über [Workflows of Workflows](https://training.nextflow.io/latest/side_quests/workflows_of_workflows/) erfahren.
+
+### Zusammenfassung
+
+Du weißt, wie processes in eigenständigen Modulen gespeichert werden können, um Code-Wiederverwendung zu fördern und die Wartbarkeit zu verbessern.
+
+### Was kommt als Nächstes?
+
+Lerne, Container für die Verwaltung von Software-Abhängigkeiten zu verwenden.
+
+---
+
+## 4. Containerisierte Software verwenden
+
+Bisher haben die Workflows, die wir als Beispiele verwendet haben, nur sehr grundlegende Textverarbeitungsoperationen mit UNIX-Tools ausgeführt, die in unserer Umgebung verfügbar sind.
+
+Allerdings erfordern reale Pipelines typischerweise spezialisierte Tools und Pakete, die standardmäßig in den meisten Umgebungen nicht enthalten sind.
+Normalerweise müsstest du diese Tools installieren, ihre Abhängigkeiten verwalten und eventuelle Konflikte lösen.
+
+Das ist alles sehr mühsam und nervig.
+Ein viel besserer Weg, dieses Problem anzugehen, ist die Verwendung von **Containern**.
+
+Ein **Container** ist eine leichtgewichtige, eigenständige, ausführbare Einheit von Software, die aus einem Container-**Image** erstellt wird und alles enthält, was zum Ausführen einer Anwendung benötigt wird, einschließlich Code, Systembibliotheken und Einstellungen.
+
+!!! tip "Tipp"
+
+    Wir vermitteln dies mit der Technologie [Docker](https://www.docker.com/get-started/), aber Nextflow unterstützt auch [mehrere andere Container-Technologien](https://www.nextflow.io/docs/latest/container.html#).
+
+### 4.1. Einen Container direkt verwenden
+
+Zuerst versuchen wir, direkt mit einem Container zu interagieren.
+Das wird helfen, dein Verständnis davon zu festigen, was Container sind, bevor wir sie in Nextflow verwenden.
+
+#### 4.1.1. Das Container-Image pullen
+
+Um einen Container zu verwenden, lädst du normalerweise ein Container-Image aus einer Container-Registry herunter oder "pullst" es, und führst dann das Container-Image aus, um eine Container-Instanz zu erstellen.
+
+Die allgemeine Syntax ist wie folgt:
+
+```bash title="Syntax"
+docker pull '<container>'
+```
+
+- `docker pull` ist die Anweisung an das Container-System, ein Container-Image aus einem Repository zu pullen.
+- `'<container>'` ist die URI-Adresse des Container-Images.
+
+Als Beispiel pullen wir ein Container-Image, das [cowpy](https://github.com/jeffbuttars/cowpy) enthält, eine Python-Implementierung eines Tools namens `cowsay`, das ASCII-Kunst generiert, um beliebige Texteingaben auf unterhaltsame Weise anzuzeigen.
+
+Es gibt verschiedene Repositories, in denen du veröffentlichte Container finden kannst.
+Wir haben den [Seqera Containers](https://seqera.io/containers/) Dienst verwendet, um dieses Docker Container-Image aus dem `cowpy` Conda-Paket zu generieren: `'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'`.
+
+Führe den vollständigen pull-Befehl aus:
+
+```bash
+docker pull 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    Unable to find image 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273' locally
+    131d6a1b707a8e65: Pulling from library/cowpy
+    dafa2b0c44d2: Pull complete
+    dec6b097362e: Pull complete
+    f88da01cff0b: Pull complete
+    4f4fb700ef54: Pull complete
+    92dc97a3ef36: Pull complete
+    403f74b0f85e: Pull complete
+    10b8c00c10a5: Pull complete
+    17dc7ea432cc: Pull complete
+    bb36d6c3110d: Pull complete
+    0ea1a16bbe82: Pull complete
+    030a47592a0a: Pull complete
+    622dd7f15040: Pull complete
+    895fb5d0f4df: Pull complete
+    Digest: sha256:fa50498b32534d83e0a89bb21fec0c47cc03933ac95c6b6587df82aaa9d68db3
+    Status: Downloaded newer image for community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273
+    community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273
+    ```
+
+Das sagt dem System, das angegebene Image herunterzuladen.
+Sobald der Download abgeschlossen ist, hast du eine lokale Kopie des Container-Images.
+
+#### 4.1.2. Den Container starten
+
+Container können als einmaliger Befehl ausgeführt werden, aber du kannst sie auch interaktiv verwenden, was dir eine Shell-Eingabeaufforderung innerhalb des Containers gibt und es dir ermöglicht, mit dem Befehl zu spielen.
+
+Die allgemeine Syntax ist wie folgt:
+
+```bash title="Syntax"
+docker run --rm '<container>' [tool command]
+```
+
+- `docker run --rm '<container>'` ist die Anweisung an das Container-System, eine Container-Instanz aus einem Container-Image zu starten und einen Befehl darin auszuführen.
+- `--rm` sagt dem System, die Container-Instanz herunterzufahren, nachdem der Befehl abgeschlossen ist.
+
+Vollständig zusammengesetzt sieht der Container-Ausführungsbefehl so aus:
+
+```bash
+docker run --rm -it 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+```
+
+Führe diesen Befehl aus, und du solltest sehen, dass sich deine Eingabeaufforderung in etwas wie `(base) root@b645838b3314:/tmp#` ändert, was anzeigt, dass du dich jetzt innerhalb des Containers befindest.
+
+Du kannst das überprüfen, indem du `ls` ausführst, um Verzeichnisinhalte aufzulisten:
+
+```bash
+ls /
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
+    ```
+
+Du siehst, dass das Dateisystem innerhalb des Containers sich vom Dateisystem auf deinem Host-System unterscheidet.
+
+!!! tip "Tipp"
+
+    Wenn du einen Container ausführst, ist er standardmäßig vom Host-System isoliert.
+    Das bedeutet, dass der Container auf keine Dateien auf dem Host-System zugreifen kann, es sei denn, du erlaubst es ihm ausdrücklich, indem du angibst, dass du ein Volume als Teil des `docker run`-Befehls mounten möchtest, mit der folgenden Syntax:
+
+    ```bash title="Syntax"
+    -v <außerhalb_pfad>:<innerhalb_pfad>
+    ```
+
+    Das etabliert effektiv einen Tunnel durch die Container-Wand, den du verwenden kannst, um auf diesen Teil deines Dateisystems zuzugreifen.
+
+    Das wird ausführlicher in [Teil 5 von Hello Nextflow](../hello_nextflow/05_hello_containers.md) behandelt.
+
+#### 4.1.3. Das `cowpy`-Tool ausführen
+
+Von innerhalb des Containers kannst du den `cowpy`-Befehl direkt ausführen.
+
+```bash
+cowpy "Hello Containers"
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    ______________________________________________________
+    < Hello Containers >
+    ------------------------------------------------------
+        \   ^__^
+          \  (oo)\_______
+            (__)\       )\/\
+              ||----w |
+              ||     ||
+    ```
+
+Das produziert ASCII-Kunst des Standard-Kuh-Charakters (oder 'Cowacter') mit einer Sprechblase, die den von uns angegebenen Text enthält.
+
+Jetzt, da du die grundlegende Verwendung getestet hast, kannst du versuchen, ihm einige Parameter zu geben.
+Zum Beispiel sagt die Tool-Dokumentation, dass wir den Charakter mit `-c` setzen können.
+
+```bash
+cowpy "Hello Containers" -c tux
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    __________________
+    < Hello Containers >
+    ------------------
+      \
+        \
+            .--.
+          |o_o |
+          |:_/ |
+          //   \ \
+        (|     | )
+        /'\_   _/`\
+        \___)=(___/
+    ```
+
+Diesmal zeigt die ASCII-Kunst-Ausgabe den Linux-Pinguin Tux, weil wir den Parameter `-c tux` angegeben haben.
+
+Da du dich innerhalb des Containers befindest, kannst du den cowpy-Befehl so oft ausführen, wie du möchtest, mit unterschiedlichen Eingabe-Parametern, ohne dir Sorgen machen zu müssen, irgendwelche Bibliotheken auf deinem System selbst zu installieren.
+
+??? tip "Andere verfügbare Charaktere"
+
+    Verwende das '-c' Flag, um einen anderen Charakter auszuwählen, einschließlich:
+
+    `beavis`, `cheese`, `daemon`, `dragonandcow`, `ghostbusters`, `kitty`, `moose`, `milk`, `stegosaurus`, `turkey`, `turtle`, `tux`
+
+Fühl dich frei, damit herumzuspielen.
+Wenn du fertig bist, verlasse den Container mit dem `exit`-Befehl:
+
+```bash
+exit
+```
+
+Du findest dich in deiner normalen Shell wieder.
+
+### 4.2. Einen Container in einem Workflow verwenden
+
+Wenn wir eine Pipeline ausführen, möchten wir Nextflow sagen können, welchen Container es bei jedem Schritt verwenden soll, und wichtigerweise möchten wir, dass es all die Arbeit handhabt, die wir gerade gemacht haben: den Container pullen, ihn starten, den Befehl ausführen und den Container herunterfahren, wenn er fertig ist.
+
+Gute Nachrichten: Das ist genau das, was Nextflow für uns tun wird.
+Wir müssen nur einen Container für jeden process angeben.
+
+Um zu demonstrieren, wie das funktioniert, haben wir eine weitere Version unseres Workflows erstellt, die `cowpy` auf der Datei mit den gesammelten Grüßen ausführt, die im dritten Schritt produziert wurde.
+
+<figure class="excalidraw">
+--8<-- "docs/nextflow_run/img/hello-pipeline-cowpy.svg"
+</figure>
+
+Das sollte eine Datei ausgeben, die die ASCII-Kunst mit den drei Grüßen in der Sprechblase enthält.
+
+#### 4.2.1. Den Code untersuchen
+
+Der Workflow ist sehr ähnlich zum vorherigen, plus der extra Schritt, um `cowpy` auszuführen.
+
+??? full-code "Vollständige Code-Datei"
+
+    ```groovy title="2d-container.nf" linenums="1" hl_lines="7 15 32 39 59-62"
+    #!/usr/bin/env nextflow
+
+    // Include modules
+    include { sayHello } from './modules/sayHello.nf'
+    include { convertToUpper } from './modules/convertToUpper.nf'
+    include { collectGreetings } from './modules/collectGreetings.nf'
+    include { cowpy } from './modules/cowpy.nf'
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path
+        batch: String = 'batch'
+        character: String
+    }
+
+    workflow {
+
+        main:
+        // create a channel for inputs from a CSV file
+        greeting_ch = channel.fromPath(params.input)
+                            .splitCsv()
+                            .map { line -> line[0] }
+        // emit a greeting
+        sayHello(greeting_ch)
+        // convert the greeting to uppercase
+        convertToUpper(sayHello.out)
+        // collect all the greetings into one file
+        collectGreetings(convertToUpper.out.collect(), params.batch)
+        // generate ASCII art of the greetings with cowpy
+        cowpy(collectGreetings.out.outfile, params.character)
+
+        publish:
+        first_output = sayHello.out
+        uppercased = convertToUpper.out
+        collected = collectGreetings.out.outfile
+        batch_report = collectGreetings.out.report
+        cowpy_art = cowpy.out
+    }
+
+    output {
+        first_output {
+            path '2d-container/intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path '2d-container/intermediates'
+            mode 'copy'
+        }
+        collected {
+            path '2d-container/intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path '2d-container'
+            mode 'copy'
+        }
+        cowpy_art {
+            path '2d-container'
+            mode 'copy'
+        }
+    }
+    ```
+
+Du siehst, dass dieser Workflow einen `cowpy` process aus einer Modul-Datei importiert und ihn auf der Ausgabe des `collectGreetings()`-Aufrufs ausführt, plus einem Eingabe-Parameter namens `params.character`.
+
+```groovy title="2d-container.nf" linenums="25"
+// generate ASCII art with cowpy
+cowpy(collectGreetings.out, params.character)
+```
+
+Der `cowpy` process, der den cowpy-Befehl zum Generieren von ASCII-Kunst umhüllt, ist im `cowpy.nf`-Modul definiert.
+
+??? full-code "Vollständige Code-Datei"
+
+    ```groovy title="modules/cowpy.nf" linenums="1"
+    #!/usr/bin/env nextflow
+
+    // Generate ASCII art with cowpy (https://github.com/jeffbuttars/cowpy)
+    process cowpy {
+
+        container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+
+        input:
+        path input_file
+        val character
+
+        output:
+        path "cowpy-${input_file}"
+
+        script:
+        """
+        cat ${input_file} | cowpy -c "${character}" > cowpy-${input_file}
+        """
+    }
+    ```
+
+Der `cowpy` process erfordert zwei Eingaben: den Pfad zu einer Eingabedatei, die den Text enthält, der in die Sprechblase kommt (`input_file`), und einen Wert für die character-Variable.
+
+Wichtig ist, dass er auch die Zeile `container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'` enthält, die auf die Container-URI verweist, die wir vorher verwendet haben.
+
+#### 4.2.2. Überprüfen, dass Docker in der Konfiguration aktiviert ist
+
+Wir werden Teil 3 dieses Trainingskurses etwas vorwegnehmen, indem wir die `nextflow.config` Konfigurationsdatei vorstellen, die eine der Hauptmöglichkeiten ist, die Nextflow bietet, um die Workflow-Ausführung zu konfigurieren.
+Wenn eine Datei namens `nextflow.config` im aktuellen Verzeichnis vorhanden ist, wird Nextflow sie automatisch laden und jede darin enthaltene Konfiguration anwenden.
+
+Zu diesem Zweck haben wir eine `nextflow.config`-Datei mit einer einzigen Codezeile eingefügt, die Docker aktiviert.
+
+```groovy title="nextflow.config" linenums="1"
+docker.enabled = true
+```
+
+Diese Konfiguration sagt Nextflow, Docker für jeden process zu verwenden, der einen kompatiblen Container angibt.
+
+!!! tip "Tipp"
+
+    Es ist technisch möglich, die Docker-Ausführung von der Kommandozeile aus zu aktivieren, auf Basis jeder Ausführung, unter Verwendung des Parameters `-with-docker <container>`.
+    Allerdings erlaubt uns das nur, einen Container für den gesamten Workflow anzugeben, während der Ansatz, den wir dir gerade gezeigt haben, es uns ermöglicht, einen anderen Container pro process anzugeben.
+    Letzteres ist viel besser für Modularität, Code-Wartung und Reproduzierbarkeit.
+
+#### 4.2.3. Den Workflow ausführen
+
+Nur zur Rekapitulation, das ist, was wir gleich ausführen werden:
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_pipeline_complete.svg"
+</figure>
+
+Denkst du, es wird funktionieren?
+
+Lass uns den Workflow mit dem `-resume`-Flag ausführen und angeben, dass wir den Charakter als turkey haben wollen.
+
+```bash
+nextflow run 2d-container.nf --input data/greetings.csv --character turkey -resume
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `2d-container.nf` [elegant_brattain] DSL2 - revision: 028a841db1
+
+    executor >  local (1)
+    [95/fa0bac] sayHello (3)       | 3 of 3, cached: 3 ✔
+    [92/32533f] convertToUpper (3) | 3 of 3, cached: 3 ✔
+    [aa/e697a2] collectGreetings   | 1 of 1, cached: 1 ✔
+    [7f/caf718] cowpy              | 1 of 1 ✔
+    ```
+
+Die ersten drei Schritte wurden aus dem cache geladen, da wir sie zuvor schon ausgeführt haben, aber der `cowpy` process ist neu, also wird der tatsächlich ausgeführt.
+
+Du kannst die Ausgabe des `cowpy`-Schritts im `results`-Verzeichnis finden.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/2d-container/cowpy-COLLECTED-batch-output.txt"
+    _________
+    / HOLà    \
+    | HELLO   |
+    \ BONJOUR /
+    ---------
+      \                                  ,+*^^*+___+++_
+      \                           ,*^^^^              )
+        \                       _+*                     ^**+_
+        \                    +^       _ _++*+_+++_,         )
+                  _+^^*+_    (     ,+*^ ^          \+_        )
+                {       )  (    ,(    ,_+--+--,      ^)      ^\
+                { (\@)    } f   ,(  ,+-^ __*_*_  ^^\_   ^\       )
+              {:;-/    (_+*-+^^^^^+*+*<_ _++_)_    )    )      /
+              ( /  (    (        ,___    ^*+_+* )   <    <      \
+              U _/     )    *--<  ) ^\-----++__)   )    )       )
+                (      )  _(^)^^))  )  )\^^^^^))^*+/    /       /
+              (      /  (_))_^)) )  )  ))^^^^^))^^^)__/     +^^
+            (     ,/    (^))^))  )  ) ))^^^^^^^))^^)       _)
+              *+__+*       (_))^)  ) ) ))^^^^^^))^^^^^)____*^
+              \             \_)^)_)) ))^^^^^^^^^^))^^^^)
+              (_             ^\__^^^^^^^^^^^^))^^^^^^^)
+                ^\___            ^\__^^^^^^))^^^^^^^^)\\
+                      ^^^^^\uuu/^^\uuu/^^^^\^\^\^\^\^\^\^\
+                        ___) >____) >___   ^\_\_\_\_\_\_\)
+                        ^^^//\\_^^//\\_^       ^(\_\_\_\)
+                          ^^^ ^^ ^^^ ^
+    ```
+
+Du siehst, dass der Charakter alle Grüße sagt, da er auf der Datei mit den gesammelten großgeschriebenen Grüßen ausgeführt wurde.
+
+Noch wichtiger ist, dass wir das als Teil unserer Pipeline ausführen konnten, ohne eine richtige Installation von cowpy und all seinen Abhängigkeiten machen zu müssen.
+Und wir können jetzt die Pipeline mit Mitarbeitern teilen und sie auf ihrer Infrastruktur ausführen lassen, ohne dass sie etwas installieren müssen, abgesehen von Docker oder einer seiner Alternativen (wie Singularity/Apptainer), wie oben erwähnt.
+
+#### 4.2.4. Untersuchen, wie Nextflow die containerisierte Aufgabe gestartet hat
+
+Als abschließende Coda zu diesem Abschnitt, schauen wir uns das work-Unterverzeichnis für einen der `cowpy` process-Aufrufe an, um etwas mehr Einblick zu bekommen, wie Nextflow mit Containern unter der Haube arbeitet.
+
+Überprüfe die Ausgabe deines `nextflow run`-Befehls, um den Pfad zum work-Unterverzeichnis für den `cowpy` process zu finden.
+Wenn wir uns ansehen, was wir für den oben gezeigten Lauf bekommen haben, beginnt die Konsolen-Log-Zeile für den `cowpy` process mit `[7f/caf718]`.
+Das entspricht dem folgenden abgekürzten Verzeichnispfad: `work/7f/caf718`.
+
+In diesem Verzeichnis findest du die `.command.run`-Datei, die alle Befehle enthält, die Nextflow in deinem Namen im Verlauf der Pipeline-Ausführung ausgeführt hat.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="work/7f/caf71890cce1667c094d880f4b6dcc/.command.run"
+    #!/bin/bash
+    ### ---
+    ### name: 'cowpy'
+    ### container: 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+    ### outputs:
+    ### - 'cowpy-COLLECTED-batch-output.txt'
+    ### ...
+    set -e
+    set -u
+    NXF_DEBUG=${NXF_DEBUG:=0}; [[ $NXF_DEBUG > 1 ]] && set -x
+    NXF_ENTRY=${1:-nxf_main}
+
+
+    nxf_sleep() {
+      sleep $1 2>/dev/null || sleep 1;
+    }
+
+    nxf_date() {
+        local ts=$(date +%s%3N);
+        if [[ ${#ts} == 10 ]]; then echo ${ts}000
+        elif [[ $ts == *%3N ]]; then echo ${ts/\%3N/000}
+        elif [[ $ts == *3N ]]; then echo ${ts/3N/000}
+        elif [[ ${#ts} == 13 ]]; then echo $ts
+        else echo "Unexpected timestamp value: $ts"; exit 1
+        fi
+    }
+
+    nxf_env() {
+        echo '============= task environment ============='
+        env | sort | sed "s/\(.*\)AWS\(.*\)=\(.\{6\}\).*/\1AWS\2=\3xxxxxxxxxxxxx/"
+        echo '============= task output =================='
+    }
+
+    nxf_kill() {
+        declare -a children
+        while read P PP;do
+            children[$PP]+=" $P"
+        done < <(ps -e -o pid= -o ppid=)
+
+        kill_all() {
+    ...
+    ```
+
+### Zusammenfassung
+
+Du weißt, wie man Containern für die Verwaltung von Software-Abhängigkeiten in Nextflow Pipelines verwendet, und wie man sie sowohl direkt als auch innerhalb eines Workflows ausführt.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du die Konfiguration deiner Workflow-Ausführungen anpassen kannst, um verschiedene Rechen-Plattformen zu unterstützen und die Reproduzierbarkeit deiner Analysen zu verbessern.

--- a/docs/de/docs/nextflow_run/03_config.md
+++ b/docs/de/docs/nextflow_run/03_config.md
@@ -1,0 +1,1628 @@
+# Teil 3: Ausführungskonfiguration
+
+Dieser Abschnitt wird erkunden, wie man die Konfiguration einer Nextflow Pipeline verwaltet, um ihr Verhalten anzupassen, sie an verschiedene Umgebungen anzupassen und die Ressourcennutzung zu optimieren - _ohne eine einzige Zeile des Workflow-Codes selbst zu ändern_.
+
+Es gibt mehrere Möglichkeiten, dies zu tun, die kombiniert werden können und gemäß der [hier](https://www.nextflow.io/docs/latest/config.html) beschriebenen Rangfolge interpretiert werden.
+
+In diesem Teil des Kurses werden wir dir den einfachsten und gebräuchlichsten Konfigurationsdatei-Mechanismus zeigen, die `nextflow.config`-Datei, die du bereits im Abschnitt über Container in Teil 2 kennengelernt hast.
+
+Wir werden wesentliche Komponenten der Nextflow-Konfiguration durchgehen, wie process-Direktiven, executors, profiles und Parameter-Dateien.
+Indem du lernst, diese Konfigurationsoptionen effektiv zu nutzen, kannst du die Flexibilität, Skalierbarkeit und Leistung von Nextflow Pipelines voll ausschöpfen.
+
+Um diese Konfigurationselemente zu üben, werden wir eine frische Kopie des Workflows ausführen, den wir zuletzt am Ende von Teil 2 dieses Trainingskurses ausgeführt haben, umbenannt in `3-main.nf`.
+
+Wenn du mit der Hello Pipeline nicht vertraut bist oder eine Auffrischung gebrauchen könntest, siehe [diese Info-Seite](../info/hello_pipeline.md).
+
+---
+
+## 1. Workflow-Eingabe-Parameter verwalten
+
+??? example "Szenario"
+
+    Du hast eine Pipeline heruntergeladen und möchtest sie wiederholt mit denselben Eingabedateien und Einstellungen ausführen, aber du möchtest nicht jedes Mal alle Parameter eintippen.
+    Oder vielleicht richtest du die Pipeline für einen Kollegen ein, der sich nicht wohl mit Kommandozeilen-Argumenten fühlt.
+
+Wir beginnen mit einem Aspekt der Konfiguration, der einfach eine Erweiterung dessen ist, womit wir bisher gearbeitet haben: die Verwaltung von Eingabe-Parametern.
+
+Derzeit ist unser Workflow so eingerichtet, dass er mehrere Parameter-Werte über die Kommandozeile akzeptiert, die in einem `params`-Block im Workflow-Script selbst deklariert sind.
+Einer hat einen Standardwert, der als Teil seiner Deklaration gesetzt ist.
+
+Allerdings möchtest du vielleicht Standardwerte für alle setzen oder den bestehenden Standard überschreiben, ohne entweder Parameter auf der Kommandozeile angeben oder die Originaldatei ändern zu müssen.
+
+Es gibt mehrere Möglichkeiten, das zu tun; wir werden dir drei grundlegende Wege zeigen, die sehr häufig verwendet werden.
+
+### 1.1. Werte in `nextflow.config` einrichten
+
+Das ist der einfachste Ansatz, obwohl er möglicherweise am wenigsten flexibel ist, da die Haupt-`nextflow.config`-Datei nichts ist, was du für jeden Lauf bearbeiten möchtest.
+Aber es hat den Vorteil, die Anliegen der _Deklaration_ der Parameter im Workflow (was definitiv dorthin gehört) von der Bereitstellung von _Standardwerten_ zu trennen, die eher in einer Konfigurationsdatei zu Hause sind.
+
+Lass uns das in zwei Schritten machen.
+
+#### 1.1.1. Einen `params`-Block in der Konfigurationsdatei erstellen
+
+Nimm die folgenden Code-Änderungen in der `nextflow.config`-Datei vor:
+
+=== "Nachher"
+
+    ```groovy title="nextflow.config" linenums="1" hl_lines="3-10"
+    docker.enabled = true
+
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input = 'data/greetings.csv'
+        batch = 'batch'
+        character = 'turkey'
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="nextflow.config" linenums="1"
+    docker.enabled = true
+    ```
+
+Beachte, dass wir nicht einfach den `params`-Block vom Workflow in die Konfigurationsdatei kopiert haben.
+Für den `batch`-Parameter, der bereits einen Standardwert deklariert hatte, ist die Syntax etwas anders.
+In der Workflow-Datei ist das eine typisierte Deklaration.
+In der Konfiguration sind das Wertzuweisungen.
+
+Technisch reicht das aus, um die noch in der Workflow-Datei angegebenen Standardwerte zu überschreiben.
+Du könntest den Standardwert für `batch` ändern und den Workflow ausführen, um dich zu vergewissern, dass der in der Konfigurationsdatei gesetzte Wert den in der Workflow-Datei gesetzten überschreibt.
+
+Aber im Sinne davon, die Konfiguration vollständig in die Konfigurationsdatei zu verschieben, lass uns diesen Standardwert ganz aus der Workflow-Datei entfernen.
+
+#### 1.1.2. Den Standardwert für `batch` in der Workflow-Datei entfernen
+
+Nimm die folgende Code-Änderung an der `3-main.nf` Workflow-Datei vor:
+
+=== "Nachher"
+
+    ```groovy title="3-main.nf" linenums="9" hl_lines="6"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path
+        batch: String
+        character: String
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="3-main.nf" linenums="9" hl_lines="6"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input: Path
+        batch: String = 'batch'
+        character: String
+    }
+    ```
+
+Jetzt setzt die Workflow-Datei selbst keine Standardwerte mehr für diese Parameter.
+
+#### 1.1.3. Die Pipeline ausführen
+
+Lass uns testen, dass es korrekt funktioniert, ohne irgendwelche Parameter in der Kommandozeile anzugeben.
+
+```bash
+nextflow run 3-main.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `3-main.nf` [disturbed_einstein] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Das produziert immer noch dieselbe Ausgabe wie zuvor.
+
+Die finale ASCII-Kunst-Ausgabe befindet sich im `results/3-main/`-Verzeichnis unter dem Namen `cowpy-COLLECTED-batch-output.txt`, wie zuvor.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/3-main/cowpy-COLLECTED-batch-output.txt"
+    _________
+    / HOLà    \
+    | HELLO   |
+    \ BONJOUR /
+    ---------
+      \                                  ,+*^^*+___+++_
+      \                           ,*^^^^              )
+        \                       _+*                     ^**+_
+        \                    +^       _ _++*+_+++_,         )
+                  _+^^*+_    (     ,+*^ ^          \+_        )
+                {       )  (    ,(    ,_+--+--,      ^)      ^\
+                { (\@)    } f   ,(  ,+-^ __*_*_  ^^\_   ^\       )
+              {:;-/    (_+*-+^^^^^+*+*<_ _++_)_    )    )      /
+              ( /  (    (        ,___    ^*+_+* )   <    <      \
+              U _/     )    *--<  ) ^\-----++__)   )    )       )
+                (      )  _(^)^^))  )  )\^^^^^))^*+/    /       /
+              (      /  (_))_^)) )  )  ))^^^^^))^^^)__/     +^^
+            (     ,/    (^))^))  )  ) ))^^^^^^^))^^)       _)
+              *+__+*       (_))^)  ) ) ))^^^^^^))^^^^^)____*^
+              \             \_)^)_)) ))^^^^^^^^^^))^^^^)
+              (_             ^\__^^^^^^^^^^^^))^^^^^^^)
+                ^\___            ^\__^^^^^^))^^^^^^^^)\\
+                      ^^^^^\uuu/^^\uuu/^^^^\^\^\^\^\^\^\^\
+                        ___) >____) >___   ^\_\_\_\_\_\_\)
+                        ^^^//\\_^^//\\_^       ^(\_\_\_\)
+                          ^^^ ^^ ^^^ ^
+    ```
+
+Funktional hat diese Verschiebung nichts geändert, aber konzeptionell ist es etwas sauberer, die Standardwerte in der Konfigurationsdatei zu setzen.
+
+### 1.2. Eine lauf-spezifische Konfigurationsdatei verwenden
+
+??? example "Szenario"
+
+    Du möchtest mit verschiedenen Einstellungen experimentieren, ohne deine Haupt-Konfigurationsdatei zu ändern.
+
+Du kannst das tun, indem du eine neue `nextflow.config`-Datei in einem Unterverzeichnis erstellst, das du als Arbeitsverzeichnis für deine Experimente verwenden wirst.
+
+#### 1.2.1. Das Arbeitsverzeichnis mit einer leeren Konfiguration erstellen
+
+Lass uns beginnen, indem wir ein neues Verzeichnis erstellen und hineinwechseln:
+
+```bash
+mkdir -p tux-run
+cd tux-run
+```
+
+Dann erstelle eine leere Konfigurationsdatei in diesem Verzeichnis:
+
+```bash
+touch nextflow.config
+```
+
+Das erzeugt eine leere Datei.
+
+#### 1.2.2. Die experimentelle Konfiguration einrichten
+
+Öffne jetzt die neue Datei und füge die Parameter hinzu, die du anpassen möchtest:
+
+```groovy title="tux-run/nextflow.config" linenums="1"
+params {
+    input = '../data/greetings.csv'
+    batch = 'experiment'
+    character = 'tux'
+}
+```
+
+Beachte, dass der Pfad zur Eingabedatei die Verzeichnisstruktur widerspiegeln muss.
+
+#### 1.2.3. Die Pipeline ausführen
+
+Wir können jetzt unsere Pipeline von innerhalb unseres neuen Arbeitsverzeichnisses ausführen.
+Stelle sicher, den Pfad entsprechend anzupassen!
+
+```bash
+nextflow run ../3-main.nf
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `../3-main.nf` [trusting_escher] DSL2 - revision: 356df0818d
+
+    executor >  local (8)
+    [59/b66913] sayHello (2)       [100%] 3 of 3 ✔
+    [ad/f06364] convertToUpper (3) [100%] 3 of 3 ✔
+    [10/714895] collectGreetings   [100%] 1 of 1 ✔
+    [88/3ece98] cowpy              [100%] 1 of 1 ✔
+    ```
+
+Das wird neue Verzeichnisse unter `tux-run/` erstellen, einschließlich `tux-run/work/` und `tux-run/results/`.
+
+In diesem Lauf kombiniert Nextflow die `nextflow.config` in unserem aktuellen Verzeichnis mit der `nextflow.config` im Stammverzeichnis der Pipeline und überschreibt dadurch den Standard-Charakter (turkey) mit dem tux-Charakter.
+
+Die finale Ausgabedatei sollte den tux-Charakter enthalten, der die Grüße sagt.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="tux-run/results/3-main/cowpy-COLLECTED-experiment-output.txt"
+    _________
+    / HELLO   \
+    | BONJOUR |
+    \ HOLà    /
+    ---------
+      \
+        \
+            .--.
+          |o_o |
+          |:_/ |
+          //   \ \
+        (|     | )
+        /'\_   _/`\
+        \___)=(___/
+
+    ```
+
+Das war's; jetzt hast du einen Raum zum Experimentieren, ohne deine 'normale' Konfiguration zu ändern.
+
+!!! warning "Warnung"
+
+    Stelle sicher, dass du zum vorherigen Verzeichnis zurückwechselst, bevor du zum nächsten Abschnitt übergehst!
+
+    ```bash
+    cd ..
+    ```
+
+Jetzt schauen wir uns eine weitere nützliche Möglichkeit an, Parameter-Werte zu setzen.
+
+### 1.3. Eine Parameter-Datei verwenden
+
+??? example "Szenario"
+
+    Du musst exakte Ausführungs-Parameter mit einem Mitarbeiter teilen oder sie für eine Publikation aufzeichnen.
+
+Der Unterverzeichnis-Ansatz funktioniert großartig zum Experimentieren, aber er erfordert etwas Einrichtung und verlangt, dass du Pfade entsprechend anpasst.
+Es gibt einen einfacheren Ansatz für den Fall, dass du deine Pipeline mit einem bestimmten Satz von Werten ausführen oder jemand anderem ermöglichen möchtest, dies mit minimalem Aufwand zu tun.
+
+Nextflow erlaubt uns, Parameter über eine Parameter-Datei im YAML- oder JSON-Format anzugeben, was es sehr bequem macht, alternative Sätze von Standardwerten sowie lauf-spezifische Parameter-Werte zu verwalten und zu verteilen.
+
+#### 1.3.1. Die Beispiel-Parameter-Datei untersuchen
+
+Um das zu demonstrieren, stellen wir eine Beispiel-Parameter-Datei im aktuellen Verzeichnis bereit, genannt `test-params.yaml`:
+
+```yaml title="test-params.yaml" linenums="1"
+input: "data/greetings.csv"
+batch: "yaml"
+character: "stegosaurus"
+```
+
+Diese Parameter-Datei enthält ein Schlüssel-Wert-Paar für jede der Eingaben, die wir angeben möchten.
+Beachte die Verwendung von Doppelpunkten (`:`) anstelle von Gleichheitszeichen (`=`), wenn du die Syntax mit der Konfigurationsdatei vergleichst.
+Die config-Datei ist in Groovy geschrieben, während die Parameter-Datei in YAML geschrieben ist.
+
+!!! info "Hinweis"
+
+    Wir stellen auch eine JSON-Version der Parameter-Datei als Beispiel bereit, aber wir werden hier nicht damit ausführen.
+    Fühl dich frei, diese auf eigene Faust auszuprobieren.
+
+#### 1.3.2. Die Pipeline ausführen
+
+Um den Workflow mit dieser Parameter-Datei auszuführen, füge einfach `-params-file <dateiname>` zum Basis-Befehl hinzu.
+
+```bash
+nextflow run 3-main.nf -params-file test-params.yaml
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `3-main.nf` [disturbed_sammet] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Die finale Ausgabedatei sollte den stegosaurus-Charakter enthalten, der die Grüße sagt.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/3-main/cowpy-COLLECTED-yaml-output.txt"
+    _________
+    / HELLO   \
+    | HOLà    |
+    \ BONJOUR /
+    ---------
+    \                             .       .
+    \                           / `.   .' "
+      \                  .---.  <    > <    >  .---.
+      \                 |    \  \ - ~ ~ - /  /    |
+            _____          ..-~             ~-..-~
+            |     |   \~~~\.'                    `./~~~/
+          ---------   \__/                        \__/
+          .'  O    \     /               /       \  "
+        (_____,    `._.'               |         }  \/~~~/
+          `----.          /       }     |        /    \__/
+                `-.      |       /      |       /      `. ,~~|
+                    ~-.__|      /_ - ~ ^|      /- _      `..-'
+                        |     /        |     /     ~-.     `-. _  _  _
+                        |_____|        |_____|         ~ - . _ _ _ _ _>
+    ```
+
+Die Verwendung einer Parameter-Datei mag übertrieben erscheinen, wenn du nur ein paar Parameter angeben musst, aber einige Pipelines erwarten Dutzende von Parametern.
+In diesen Fällen erlaubt uns die Verwendung einer Parameter-Datei, Parameter-Werte zur Laufzeit bereitzustellen, ohne massive Kommandozeilen eintippen zu müssen und ohne das Workflow-Script zu ändern.
+
+Es macht es auch einfacher, Sätze von Parametern an Mitarbeiter zu verteilen oder als Zusatzinformationen für eine Publikation zum Beispiel.
+Das macht deine Arbeit für andere reproduzierbarer.
+
+### Zusammenfassung
+
+Du weißt, wie du wichtige Konfigurationsoptionen für die Verwaltung von Workflow-Eingaben nutzen kannst.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du verwalten kannst, wo und wie deine Workflow-Ausgaben veröffentlicht werden.
+
+---
+
+## 2. Workflow-Ausgaben verwalten
+
+??? example "Szenario"
+
+    Deine Pipeline veröffentlicht Ausgaben in ein fest codiertes Verzeichnis, aber du möchtest die Ergebnisse nach Projekt- oder Experimentnamen organisieren, ohne jedes Mal den Workflow-Code bearbeiten zu müssen.
+
+Der Workflow, den wir geerbt haben, verwendet Pfade für Workflow-Level-Ausgabe-Deklarationen, was nicht besonders flexibel ist und viel Wiederholung beinhaltet.
+
+Schauen wir uns ein paar gängige Möglichkeiten an, wie du das konfigurieren könntest, um flexibler zu sein.
+
+### 2.1. Den `outputDir`-Verzeichnisnamen anpassen
+
+Jede Version des Workflows, die wir bisher ausgeführt haben, hat ihre Ausgaben in ein anderes Unterverzeichnis veröffentlicht, das in den Ausgabe-Definitionen fest codiert ist.
+
+Lass uns das ändern, um einen benutzer-konfigurierbaren Parameter zu verwenden.
+Wir könnten einen ganz neuen Parameter dafür erstellen, aber lass uns den `batch`-Parameter verwenden, da er direkt verfügbar ist.
+
+#### 2.1.1. Einen Wert für `outputDir` in der Konfigurationsdatei setzen
+
+Der Pfad, den Nextflow zum Veröffentlichen von Ausgaben verwendet, wird durch die `outputDir`-Option gesteuert.
+Um den Pfad für alle Ausgaben zu ändern, kannst du in der `nextflow.config`-Konfigurationsdatei einen Wert für diese Option setzen.
+
+Füge den folgenden Code zur `nextflow.config`-Datei hinzu:
+
+=== "Nachher"
+
+    ```groovy title="nextflow.config" linenums="9" hl_lines="10-13"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input = 'data/greetings.csv'
+        batch = 'batch'
+        character = 'turkey'
+    }
+
+    /*
+    * Output settings
+    */
+    outputDir = "results/${params.batch}"
+    ```
+
+=== "Vorher"
+
+    ```groovy title="nextflow.config" linenums="9"
+    /*
+    * Pipeline parameters
+    */
+    params {
+        input = 'data/greetings.csv'
+        batch = 'batch'
+        character = 'turkey'
+    }
+    ```
+
+Das wird den eingebauten Standardpfad `results/` durch `results/` plus dem Wert des `batch`-Parameters als Unterverzeichnis ersetzen.
+Du könntest auch den `results`-Teil ändern, wenn du möchtest.
+
+Für eine temporäre Änderung könntest du diese Option von der Kommandozeile aus setzen, indem du den `-output-dir`-Parameter in deinem Befehl verwendest (aber dann könntest du nicht den `batch`-Parameter-Wert verwenden).
+
+#### 2.1.2. Den wiederholten Teil des fest codierten Pfades entfernen
+
+Wir haben immer noch ein Unterverzeichnis fest codiert in den Ausgabe-Optionen, also lass uns das jetzt loswerden.
+
+Nimm die folgenden Code-Änderungen in der Workflow-Datei vor:
+
+=== "Nachher"
+
+    ```groovy title="3-main.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path 'intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path 'intermediates'
+            mode 'copy'
+        }
+        collected {
+            path 'intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path ''
+            mode 'copy'
+        }
+        cowpy_art {
+            path ''
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="3-main.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path '3-main/intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path '3-main/intermediates'
+            mode 'copy'
+        }
+        collected {
+            path '3-main/intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path '3-main'
+            mode 'copy'
+        }
+        cowpy_art {
+            path '3-main'
+            mode 'copy'
+        }
+    }
+    ```
+
+Wir hätten auch einfach `${params.batch}` zu jedem Pfad hinzufügen können, anstatt den `outputDir`-Standard zu ändern, aber das ist prägnanter.
+
+#### 2.1.3. Die Pipeline ausführen
+
+Lass uns testen, dass es korrekt funktioniert, indem wir den Batch-Namen auf `outdir` von der Kommandozeile setzen.
+
+```bash
+nextflow run 3-main.nf --batch outdir
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `3-main.nf` [disturbed_einstein] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Das produziert immer noch dieselbe Ausgabe wie zuvor, außer dass wir unsere Ausgaben diesmal unter `results/outdir/` finden.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console
+    results/outdir/
+    ├── cowpy-COLLECTED-outdir-output.txt
+    ├── intermediates
+    │   ├── Bonjour-output.txt
+    │   ├── COLLECTED-outdir-output.txt
+    │   ├── Hello-output.txt
+    │   ├── Holà-output.txt
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    └── outdir-report.txt
+    ```
+
+Du kannst diesen Ansatz mit benutzerdefinierten Pfad-Definitionen kombinieren, um jede gewünschte Verzeichnishierarchie zu konstruieren.
+
+### 2.2. Ausgaben nach process organisieren
+
+Eine beliebte Möglichkeit, Ausgaben weiter zu organisieren, ist es nach process zu tun, _d.h._ Unterverzeichnisse für jeden in der Pipeline ausgeführten process zu erstellen.
+
+#### 2.2.1. Die Ausgabe-Pfade durch einen Verweis auf process-Namen ersetzen
+
+Alles, was du tun musst, ist den Namen des process als `<task>.name` in der Ausgabe-Pfad-Deklaration zu referenzieren.
+
+Nimm die folgenden Änderungen in der Workflow-Datei vor:
+
+=== "Nachher"
+
+    ```groovy title="3-main.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path { sayHello.name }
+            mode 'copy'
+        }
+        uppercased {
+            path { convertToUpper.name }
+            mode 'copy'
+        }
+        collected {
+            path { collectGreetings.name }
+            mode 'copy'
+        }
+        batch_report {
+            path { collectGreetings.name }
+            mode 'copy'
+        }
+        cowpy_art {
+            path { cowpy.name }
+            mode 'copy'
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="3-main.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path 'intermediates'
+            mode 'copy'
+        }
+        uppercased {
+            path 'intermediates'
+            mode 'copy'
+        }
+        collected {
+            path 'intermediates'
+            mode 'copy'
+        }
+        batch_report {
+            path ''
+            mode 'copy'
+        }
+        cowpy_art {
+            path ''
+            mode 'copy'
+        }
+    }
+    ```
+
+Das entfernt die verbleibenden fest codierten Elemente aus der Ausgabe-Pfad-Konfiguration.
+
+#### 2.2.2. Die Pipeline ausführen
+
+Lass uns testen, dass es korrekt funktioniert, indem wir den Batch-Namen auf `pnames` von der Kommandozeile setzen.
+
+```bash
+nextflow run 3-main.nf --batch pnames
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `3-main.nf` [jovial_mcclintock] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Das produziert immer noch dieselbe Ausgabe wie zuvor, außer dass wir unsere Ausgaben diesmal unter `results/pnames/` finden, und sie sind nach process gruppiert.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console
+    results/pnames/
+    ├── collectGreetings
+    │   ├── COLLECTED-pnames-output.txt
+    │   └── pnames-report.txt
+    ├── convertToUpper
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    ├── cowpy
+    │   └── cowpy-COLLECTED-pnames-output.txt
+    └── sayHello
+        ├── Bonjour-output.txt
+        ├── Hello-output.txt
+        └── Holà-output.txt
+    ```
+
+Beachte, dass wir hier die Unterscheidung zwischen `intermediates` versus finalen Ausgaben auf der obersten Ebene gelöscht haben.
+Du könntest natürlich diese Ansätze mischen und kombinieren, zum Beispiel indem du den Pfad der ersten Ausgabe als `intermediates/${sayHello.name}` setzt.
+
+### 2.3. Den publish-Modus auf Workflow-Ebene setzen
+
+Schließlich können wir im Sinne der Reduzierung der Menge an sich wiederholendem Code die pro-Ausgabe `mode`-Deklarationen durch eine einzelne Zeile in der Konfiguration ersetzen.
+
+#### 2.3.1. `workflow.output.mode` zur Konfigurationsdatei hinzufügen
+
+Füge den folgenden Code zur `nextflow.config`-Datei hinzu:
+
+=== "Nachher"
+
+    ```groovy title="nextflow.config" linenums="2" hl_lines="5"
+    /*
+    * Output settings
+    */
+    outputDir = "results/${params.batch}"
+    workflow.output.mode = 'copy'
+    ```
+
+=== "Vorher"
+
+    ```groovy title="nextflow.config" linenums="12"
+    /*
+    * Output settings
+    */
+    outputDir = "results/${params.batch}"
+    ```
+
+Genau wie bei der `outputDir`-Option würde es ausreichen, `workflow.output.mode` einen Wert in der Konfigurationsdatei zu geben, um zu überschreiben, was in der Workflow-Datei gesetzt ist, aber lass uns den unnötigen Code trotzdem entfernen.
+
+#### 2.3.2. Den output-Modus aus der Workflow-Datei entfernen
+
+Nimm die folgenden Änderungen in der Workflow-Datei vor:
+
+=== "Nachher"
+
+    ```groovy title="3-main.nf" linenums="42"
+    output {
+        first_output {
+            path { sayHello.name }
+        }
+        uppercased {
+            path { convertToUpper.name }
+        }
+        collected {
+            path { collectGreetings.name }
+        }
+        batch_report {
+            path { collectGreetings.name }
+        }
+        cowpy_art {
+            path { cowpy.name }
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="3-main.nf" linenums="42" hl_lines="3 7 11 15 19"
+    output {
+        first_output {
+            path { sayHello.name }
+            mode 'copy'
+        }
+        uppercased {
+            path { convertToUpper.name }
+            mode 'copy'
+        }
+        collected {
+            path { collectGreetings.name }
+            mode 'copy'
+        }
+        batch_report {
+            path { collectGreetings.name }
+            mode 'copy'
+        }
+        cowpy_art {
+            path { cowpy.name }
+            mode 'copy'
+        }
+    }
+    ```
+
+Das ist prägnanter, nicht wahr?
+
+#### 2.3.3. Die Pipeline ausführen
+
+Lass uns testen, dass es korrekt funktioniert, indem wir den Batch-Namen auf `outmode` von der Kommandozeile setzen.
+
+```bash
+nextflow run 3-main.nf --batch outmode
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `3-main.nf` [rowdy_sagan] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [f0/35723c] sayHello (2)       | 3 of 3 ✔
+    [40/3efd1a] convertToUpper (3) | 3 of 3 ✔
+    [17/e97d32] collectGreetings   | 1 of 1 ✔
+    [98/c6b57b] cowpy              | 1 of 1 ✔
+    ```
+
+Das produziert immer noch dieselbe Ausgabe wie zuvor, außer dass wir unsere Ausgaben diesmal unter `results/outmode/` finden.
+Es sind immer noch alles echte Kopien, keine Symlinks.
+
+??? abstract "Verzeichnisinhalte"
+
+    ```console
+    results/outmode/
+    ├── collectGreetings
+    │   ├── COLLECTED-outmode-output.txt
+    │   └── outmode-report.txt
+    ├── convertToUpper
+    │   ├── UPPER-Bonjour-output.txt
+    │   ├── UPPER-Hello-output.txt
+    │   └── UPPER-Holà-output.txt
+    ├── cowpy
+    │   └── cowpy-COLLECTED-outmode-output.txt
+    └── sayHello
+        ├── Bonjour-output.txt
+        ├── Hello-output.txt
+        └── Holà-output.txt
+    ```
+
+Der Hauptgrund, warum du vielleicht immer noch die pro-Ausgabe-Art des Setzens des mode verwenden möchtest, ist, wenn du innerhalb desselben Workflows mischen und kombinieren möchtest, _d.h._ einige Ausgaben kopiert und einige per Symlink verlinkt haben möchtest.
+
+Es gibt viele andere Optionen, die du auf diese Weise anpassen kannst, aber hoffentlich gibt dir das einen Eindruck von der Bandbreite der Optionen und wie du sie effektiv nutzen kannst, um deinen Präferenzen zu entsprechen.
+
+### Zusammenfassung
+
+Du weißt, wie du die Benennung und Struktur der Verzeichnisse kontrollieren kannst, in denen deine Ausgaben veröffentlicht werden, sowie den Workflow-Ausgabe-Veröffentlichungsmodus.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du deine Workflow-Konfiguration an deine Rechenumgebung anpassen kannst, beginnend mit der Software-Paketierungstechnologie.
+
+---
+
+## 3. Eine Software-Paketierungstechnologie auswählen
+
+Bisher haben wir Konfigurationselemente betrachtet, die steuern, wie Eingaben hineingehen und wo Ausgaben herauskommen. Jetzt ist es an der Zeit, uns spezieller darauf zu konzentrieren, deine Workflow-Konfiguration an deine Rechenumgebung anzupassen.
+
+Der erste Schritt auf diesem Weg ist anzugeben, woher die Software-Pakete kommen werden, die in jedem Schritt ausgeführt werden.
+Sind sie bereits in der lokalen Rechenumgebung installiert?
+Müssen wir Images abrufen und sie über ein Container-System ausführen?
+Oder müssen wir Conda-Pakete abrufen und eine lokale Conda-Umgebung erstellen?
+
+Im allerersten Teil dieses Trainingskurses (Teile 1-4) haben wir in unserem Workflow einfach lokal installierte Software verwendet.
+Dann haben wir in Teil 5 Docker-Container und die `nextflow.config`-Datei eingeführt, die wir verwendet haben, um die Verwendung von Docker-Containern zu aktivieren.
+
+Jetzt schauen wir uns an, wie wir eine alternative Software-Paketierungsoption über die `nextflow.config`-Datei konfigurieren können.
+
+### 3.1. Docker deaktivieren und Conda in der config-Datei aktivieren
+
+??? example "Szenario"
+
+    Du verschiebst deine Pipeline auf einen HPC-Cluster, wo Docker aus Sicherheitsgründen nicht erlaubt ist.
+    Der Cluster unterstützt Singularity und Conda, also musst du deine Konfiguration entsprechend umstellen.
+
+Nextflow unterstützt mehrere Container-Technologien einschließlich Singularity (das auf HPC weiter verbreitet ist), sowie Software-Paketmanager wie Conda.
+
+Wir können unsere Konfigurationsdatei ändern, um Conda anstelle von Docker zu verwenden.
+Dazu setzen wir den Wert von `docker.enabled` auf `false` und fügen eine Direktive hinzu, die die Verwendung von Conda aktiviert:
+
+=== "Nachher"
+
+    ```groovy title="nextflow.config" linenums="1" hl_lines="1-2"
+    docker.enabled = false
+    conda.enabled = true
+    ```
+
+=== "Vorher"
+
+    ```groovy title="nextflow.config" linenums="1" hl_lines="1"
+    docker.enabled = true
+    ```
+
+Das wird Nextflow erlauben, Conda-Umgebungen für processes zu erstellen und zu nutzen, die Conda-Pakete angegeben haben.
+Das bedeutet, dass wir jetzt eines davon zu unserem `cowpy` process hinzufügen müssen!
+
+### 3.2. Ein Conda-Paket in der process-Definition angeben
+
+Wir haben bereits die URI für ein Conda-Paket abgerufen, das das `cowpy`-Tool enthält: `conda-forge::cowpy==1.1.5`
+
+Jetzt fügen wir die URI zur `cowpy` process-Definition hinzu, indem wir die `conda`-Direktive verwenden:
+
+=== "Nachher"
+
+    ```groovy title="modules/cowpy.nf" linenums="4" hl_lines="4"
+    process cowpy {
+
+        container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+        conda 'conda-forge::cowpy==1.1.5'
+
+        input:
+    ```
+
+=== "Vorher"
+
+    ```groovy title="modules/cowpy.nf" linenums="4"
+    process cowpy {
+
+        container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
+
+        input:
+    ```
+
+Um das klarzustellen, wir _ersetzen_ nicht die `docker`-Direktive, wir _fügen_ eine alternative Option hinzu.
+
+!!! tip "Tipp"
+
+    Es gibt einige verschiedene Möglichkeiten, die URI für ein bestimmtes Conda-Paket zu bekommen.
+    Wir empfehlen, die [Seqera Containers](https://seqera.io/containers/) Suchabfrage zu verwenden, die dir eine URI gibt, die du kopieren und einfügen kannst, selbst wenn du nicht planst, einen Container daraus zu erstellen.
+
+### 3.3. Den Workflow ausführen, um zu verifizieren, dass er Conda verwenden kann
+
+Lass es uns ausprobieren.
+
+```bash
+nextflow run 3-main.nf --batch conda
+```
+
+??? success "Befehlsausgabe"
+
+    ```console title="Ausgabe"
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `3-main.nf` [trusting_lovelace] DSL2 - revision: 028a841db1
+
+    executor >  local (8)
+    [ee/4ca1f2] sayHello (3)       | 3 of 3 ✔
+    [20/2596a7] convertToUpper (1) | 3 of 3 ✔
+    [b3/e15de5] collectGreetings   | 1 of 1 ✔
+    [c5/af5f88] cowpy              | 1 of 1 ✔
+    ```
+
+Das sollte ohne Probleme funktionieren und dieselben Ausgaben wie zuvor unter `results/conda` produzieren.
+
+Hinter den Kulissen hat Nextflow die Conda-Pakete abgerufen und die Umgebung erstellt, was normalerweise etwas Arbeit erfordert; also ist es schön, dass wir nichts davon selbst machen müssen!
+
+!!! info "Hinweis"
+
+    Das läuft schnell, weil das `cowpy`-Paket ziemlich klein ist, aber wenn du mit großen Paketen arbeitest, kann es beim ersten Mal etwas länger dauern als üblich, und du könntest sehen, dass die Konsolenausgabe für eine Minute oder so 'stecken bleibt', bevor sie abgeschlossen ist.
+    Das ist normal und liegt an der zusätzlichen Arbeit, die Nextflow beim ersten Mal macht, wenn du ein neues Paket verwendest.
+
+Aus unserer Sicht sieht es so aus, als ob es genau so funktioniert wie mit Docker, obwohl die Mechanik im Hintergrund etwas anders ist.
+
+Das bedeutet, dass wir bereit sind, bei Bedarf mit Conda-Umgebungen auszuführen.
+
+??? info "Docker und Conda mischen und kombinieren"
+
+    Da diese Direktiven pro process zugewiesen werden, ist es möglich, zu 'mischen und kombinieren', _d.h._ einige der processes in deinem Workflow so zu konfigurieren, dass sie mit Docker laufen und andere mit Conda, zum Beispiel, wenn die von dir verwendete Recheninfrastruktur beides unterstützt.
+    In diesem Fall würdest du sowohl Docker als auch Conda in deiner Konfigurationsdatei aktivieren.
+    Wenn beide für einen bestimmten process verfügbar sind, wird Nextflow Container priorisieren.
+
+    Und wie bereits erwähnt, unterstützt Nextflow mehrere andere Software-Paketierungs- und Container-Technologien, sodass du nicht auf nur diese beiden beschränkt bist.
+
+### Zusammenfassung
+
+Du weißt, wie du konfigurierst, welches Software-Paket jeder process verwenden soll, und wie du zwischen Technologien wechselst.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du die Ausführungsplattform änderst, die Nextflow verwendet, um die eigentliche Arbeit zu erledigen.
+
+---
+
+## 4. Eine Ausführungsplattform auswählen
+
+??? example "Szenario"
+
+    Du hast deine Pipeline auf deinem Laptop entwickelt und getestet, aber jetzt musst du sie auf Tausenden von Proben ausführen.
+    Deine Institution hat einen HPC-Cluster mit einem Slurm-Scheduler, den du stattdessen verwenden möchtest.
+
+Bis jetzt haben wir unsere Pipeline mit dem local executor ausgeführt.
+Dieser führt jede Aufgabe auf der Maschine aus, auf der Nextflow läuft.
+Wenn Nextflow startet, schaut es sich die verfügbaren CPUs und den Speicher an.
+Wenn die Ressourcen der zur Ausführung bereiten Aufgaben die verfügbaren Ressourcen überschreiten, wird Nextflow die letzten Aufgaben von der Ausführung zurückhalten, bis eine oder mehrere der früheren Aufgaben beendet sind und die notwendigen Ressourcen freigeben.
+
+Der local executor ist bequem und effizient, aber er ist auf diese einzelne Maschine beschränkt. Bei sehr großen Workloads könntest du feststellen, dass deine lokale Maschine ein Engpass ist, entweder weil du eine einzelne Aufgabe hast, die mehr Ressourcen erfordert als du verfügbar hast, oder weil du so viele Aufgaben hast, dass das Warten darauf, dass eine einzelne Maschine sie ausführt, zu lange dauern würde.
+
+Nextflow unterstützt [viele verschiedene Ausführungs-Backends](https://www.nextflow.io/docs/latest/executor.html), einschließlich HPC-Scheduler (Slurm, LSF, SGE, PBS, Moab, OAR, Bridge, HTCondor und andere) sowie Cloud-Ausführungs-Backends (AWS Batch, Google Cloud Batch, Azure Batch, Kubernetes und mehr).
+
+### 4.1. Ein anderes Backend anvisieren
+
+Die Wahl des executor wird durch eine process-Direktive namens `executor` gesetzt.
+Standardmäßig ist sie auf `local` gesetzt, also ist die folgende Konfiguration impliziert:
+
+```groovy title="Eingebaute Konfiguration"
+process {
+    executor = 'local'
+}
+```
+
+Um den executor auf ein anderes Backend zu setzen, würdest du einfach den gewünschten executor mit ähnlicher Syntax angeben, wie oben für Ressourcenzuweisungen beschrieben (siehe [Dokumentation](https://www.nextflow.io/docs/latest/executor.html) für alle Optionen).
+
+```groovy title="nextflow.config"
+process {
+    executor = 'slurm'
+}
+```
+
+!!! warning "Warnung"
+
+    Wir können das in der Trainingsumgebung nicht wirklich testen, weil sie nicht eingerichtet ist, um sich mit einem HPC zu verbinden.
+
+### 4.2. Mit Backend-spezifischer Syntax für Ausführungsparameter umgehen
+
+Die meisten Hochleistungs-Rechenplattformen erlauben (und erfordern manchmal), dass du bestimmte Parameter wie Ressourcenzuweisungsanfragen und -beschränkungen (z.B. Anzahl der CPUs und Speicher) und den Namen der zu verwendenden Job-Queue angibst.
+
+Leider verwendet jedes dieser Systeme unterschiedliche Technologien, Syntaxen und Konfigurationen, um zu definieren, wie ein Job definiert und an den entsprechenden Scheduler übermittelt werden soll.
+
+??? abstract "Beispiele"
+
+    Zum Beispiel muss derselbe Job, der 8 CPUs und 4GB RAM benötigt und auf der Queue "my-science-work" ausgeführt werden soll, je nach Backend auf unterschiedliche Weise ausgedrückt werden.
+
+    ```bash title="Config für SLURM / übermitteln mit sbatch"
+    #SBATCH -o /path/to/my/task/directory/my-task-1.log
+    #SBATCH --no-requeue
+    #SBATCH -c 8
+    #SBATCH --mem 4096M
+    #SBATCH -p my-science-work
+    ```
+
+    ```bash title="Config für PBS / übermitteln mit qsub"
+    #PBS -o /path/to/my/task/directory/my-task-1.log
+    #PBS -j oe
+    #PBS -q my-science-work
+    #PBS -l nodes=1:ppn=5
+    #PBS -l mem=4gb
+    ```
+
+    ```bash title="Config für SGE / übermitteln mit qsub"
+    #$ -o /path/to/my/task/directory/my-task-1.log
+    #$ -j y
+    #$ -terse
+    #$ -notify
+    #$ -q my-science-work
+    #$ -l slots=5
+    #$ -l h_rss=4096M,mem_free=4096M
+    ```
+
+Glücklicherweise vereinfacht Nextflow all das.
+Es bietet eine standardisierte Syntax, sodass du die relevanten Eigenschaften wie `cpus`, `memory` und `queue` (siehe Dokumentation für andere Eigenschaften) nur einmal angeben kannst.
+Dann wird Nextflow zur Laufzeit diese Einstellungen verwenden, um die entsprechenden Backend-spezifischen Scripts basierend auf der executor-Einstellung zu generieren.
+
+Wir werden diese standardisierte Syntax im nächsten Abschnitt behandeln.
+
+### Zusammenfassung
+
+Du weißt jetzt, wie du den executor änderst, um verschiedene Arten von Recheninfrastruktur zu verwenden.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du Rechenressourcenzuweisungen und -beschränkungen in Nextflow ausdrückst.
+
+---
+
+## 5. Rechenressourcenzuweisungen steuern
+
+??? example "Szenario"
+
+    Deine Pipeline schlägt auf dem Cluster immer fehl, weil Aufgaben wegen Überschreitung von Speicherlimits beendet werden.
+    Oder vielleicht werden dir Ressourcen berechnet, die du nicht nutzt, und du möchtest die Kosten optimieren.
+
+Die meisten Hochleistungs-Rechenplattformen erlauben (und erfordern manchmal), dass du bestimmte Ressourcenzuweisungsparameter wie Anzahl der CPUs und Speicher angibst.
+
+Standardmäßig wird Nextflow eine einzelne CPU und 2GB Speicher für jeden process verwenden.
+Die entsprechenden process-Direktiven heißen `cpus` und `memory`, also ist die folgende Konfiguration impliziert:
+
+```groovy title="Eingebaute Konfiguration" linenums="1"
+process {
+    cpus = 1
+    memory = 2.GB
+}
+```
+
+Du kannst diese Werte ändern, entweder für alle processes oder für bestimmte benannte processes, indem du zusätzliche process-Direktiven in deiner Konfigurationsdatei verwendest.
+Nextflow wird sie in die entsprechenden Anweisungen für den gewählten executor übersetzen.
+
+Aber woher weißt du, welche Werte du verwenden sollst?
+
+### 5.1. Den Workflow ausführen, um einen Ressourcennutzungsbericht zu generieren
+
+??? example "Szenario"
+
+    Du weißt nicht, wie viel Speicher oder CPU deine processes brauchen und möchtest vermeiden, Ressourcen zu verschwenden oder Jobs beenden zu lassen.
+
+Wenn du nicht im Voraus weißt, wie viel CPU und Speicher deine processes wahrscheinlich brauchen, kannst du etwas Ressourcen-Profiling machen, was bedeutet, dass du den Workflow mit einigen Standardzuweisungen ausführst, aufzeichnest, wie viel jeder process verwendet hat, und von dort aus schätzt, wie du die Basiszuweisungen anpassen kannst.
+
+Praktischerweise enthält Nextflow eingebaute Tools dafür und wird auf Anfrage gerne einen Bericht für dich generieren.
+
+Um das zu tun, füge `-with-report <dateiname>.html` zu deiner Kommandozeile hinzu.
+
+```bash
+nextflow run 3-main.nf -with-report report-config-1.html
+```
+
+Der Bericht ist eine HTML-Datei, die du herunterladen und in deinem Browser öffnen kannst. Du kannst auch mit der rechten Maustaste darauf im Datei-Explorer auf der linken Seite klicken und auf `Show preview` klicken, um sie in der Trainingsumgebung anzuzeigen.
+
+Nimm dir ein paar Minuten Zeit, um den Bericht durchzusehen und zu schauen, ob du einige Möglichkeiten zur Anpassung der Ressourcen identifizieren kannst.
+Stelle sicher, dass du auf die Tabs klickst, die die Nutzungsergebnisse als Prozentsatz dessen zeigen, was zugewiesen wurde.
+Es gibt [Dokumentation](https://www.nextflow.io/docs/latest/reports.html), die alle verfügbaren Funktionen beschreibt.
+
+### 5.2. Ressourcenzuweisungen für alle processes setzen
+
+Das Profiling zeigt, dass die processes in unserem Trainings-Workflow sehr leichtgewichtig sind, also lass uns die Standard-Speicherzuweisung auf 1GB pro process reduzieren.
+
+Füge das Folgende zu deiner `nextflow.config`-Datei hinzu, vor dem Abschnitt mit den Pipeline-Parametern:
+
+```groovy title="nextflow.config" linenums="4"
+/*
+* Process settings
+*/
+process {
+    memory = 1.GB
+}
+```
+
+Das wird helfen, die Menge an Rechenleistung zu reduzieren, die wir verbrauchen.
+
+### 5.3. Ressourcenzuweisungen für einen bestimmten process setzen
+
+Gleichzeitig werden wir so tun, als ob der `cowpy` process mehr Ressourcen benötigt als die anderen, nur um zu demonstrieren, wie man Zuweisungen für einen einzelnen process anpasst.
+
+=== "Nachher"
+
+    ```groovy title="nextflow.config" linenums="4" hl_lines="6-9"
+    /*
+    * Process settings
+    */
+    process {
+        memory = 1.GB
+        withName: 'cowpy' {
+            memory = 2.GB
+            cpus = 2
+        }
+    }
+    ```
+
+=== "Vorher"
+
+    ```groovy title="nextflow.config" linenums="4"
+    /*
+    * Process settings
+    */
+    process {
+        memory = 1.GB
+    }
+    ```
+
+Mit dieser Konfiguration werden alle processes 1GB Speicher und eine einzelne CPU (der implizierte Standard) anfordern, außer dem `cowpy` process, der 2GB und 2 CPUs anfordern wird.
+
+!!! info "Hinweis"
+
+    Wenn du eine Maschine mit wenigen CPUs hast und du eine hohe Anzahl pro process zuweist, könntest du sehen, dass process-Aufrufe hintereinander in die Warteschlange gestellt werden.
+    Das liegt daran, dass Nextflow sicherstellt, dass wir nicht mehr CPUs anfordern als verfügbar sind.
+
+### 5.4. Den Workflow mit der aktualisierten Konfiguration ausführen
+
+Lass uns das ausprobieren, indem wir einen anderen Dateinamen für den Profiling-Bericht angeben, damit wir die Leistung vor und nach den Konfigurationsänderungen vergleichen können.
+
+```bash
+nextflow run 3-main.nf -with-report report-config-2.html
+```
+
+Du wirst wahrscheinlich keinen echten Unterschied bemerken, da dies ein so kleiner Workload ist, aber das ist der Ansatz, den du verwenden würdest, um die Leistung und Ressourcenanforderungen eines realen Workflows zu analysieren.
+
+Es ist sehr nützlich, wenn deine processes unterschiedliche Ressourcenanforderungen haben. Es befähigt dich, die Ressourcenzuweisungen, die du für jeden process einrichtest, basierend auf tatsächlichen Daten richtig zu dimensionieren, nicht auf Vermutungen.
+
+!!! tip "Tipp"
+
+    Das ist nur ein kleiner Vorgeschmack auf das, was du tun kannst, um deine Ressourcennutzung zu optimieren.
+    Nextflow selbst hat wirklich raffinierte [dynamische Wiederholungslogik](https://www.nextflow.io/docs/latest/process.html#dynamic-task-resources) eingebaut, um Jobs, die aufgrund von Ressourcenbeschränkungen fehlschlagen, erneut zu versuchen.
+    Zusätzlich bietet die Seqera Platform auch KI-gesteuerte Tools zur automatischen Optimierung deiner Ressourcenzuweisungen.
+
+### 5.5. Ressourcenlimits hinzufügen
+
+Abhängig davon, welchen Rechen-executor und welche Recheninfrastruktur du verwendest, kann es einige Einschränkungen geben, was du zuweisen kannst (oder musst).
+Zum Beispiel kann dein Cluster verlangen, dass du innerhalb bestimmter Limits bleibst.
+
+Du kannst die `resourceLimits`-Direktive verwenden, um die relevanten Beschränkungen zu setzen. Die Syntax sieht so aus, wenn sie allein in einem process-Block steht:
+
+```groovy title="Syntax-Beispiel"
+process {
+    resourceLimits = [
+        memory: 750.GB,
+        cpus: 200,
+        time: 30.d
+    ]
+}
+```
+
+Nextflow wird diese Werte in die entsprechenden Anweisungen übersetzen, abhängig vom executor, den du angegeben hast.
+
+Wir werden das nicht ausführen, da wir keinen Zugang zu relevanter Infrastruktur in der Trainingsumgebung haben.
+Wenn du jedoch versuchen würdest, den Workflow mit Ressourcenzuweisungen auszuführen, die diese Limits überschreiten, und dann den `sbatch`-Befehl in der `.command.run`-Script-Datei nachschlagen würdest, würdest du sehen, dass die Anforderungen, die tatsächlich an den executor gesendet werden, auf die durch `resourceLimits` angegebenen Werte begrenzt sind.
+
+??? info "Institutionelle Referenzkonfigurationen"
+
+    Das nf-core-Projekt hat eine [Sammlung von Konfigurationsdateien](https://nf-co.re/configs/) zusammengestellt, die von verschiedenen Institutionen auf der ganzen Welt geteilt werden und eine breite Palette von HPC- und Cloud-executors abdecken.
+
+    Diese geteilten Configs sind sowohl für Leute wertvoll, die dort arbeiten und daher einfach die Konfiguration ihrer Institution sofort nutzen können, als auch als Modell für Leute, die eine Konfiguration für ihre eigene Infrastruktur entwickeln möchten.
+
+### Zusammenfassung
+
+Du weißt, wie du einen Profiling-Bericht generierst, um die Ressourcennutzung zu bewerten, und wie du Ressourcenzuweisungen für alle processes und/oder für einzelne processes änderst, sowie Ressourcenbeschränkungen für die Ausführung auf HPC setzt.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du voreingestellte Konfigurationsprofile einrichtest und zur Laufzeit zwischen ihnen wechselst.
+
+---
+
+## 6. Profile verwenden, um zwischen voreingestellten Konfigurationen zu wechseln
+
+??? example "Szenario"
+
+    Du wechselst regelmäßig zwischen dem Ausführen von Pipelines auf deinem Laptop für die Entwicklung und auf dem HPC deiner Institution für Produktionsläufe.
+    Du bist es leid, jedes Mal manuell Konfigurationseinstellungen zu ändern, wenn du die Umgebung wechselst.
+
+Wir haben dir eine Reihe von Möglichkeiten gezeigt, wie du deine Pipeline-Konfiguration anpassen kannst, abhängig vom Projekt, an dem du arbeitest, oder der Rechenumgebung, die du verwendest.
+
+Du möchtest vielleicht zwischen alternativen Einstellungen wechseln, abhängig davon, welche Recheninfrastruktur du verwendest. Zum Beispiel möchtest du vielleicht lokal auf deinem Laptop entwickeln und kleine Tests ausführen, dann vollständige Workloads auf HPC oder Cloud ausführen.
+
+Nextflow ermöglicht es dir, beliebig viele Profile einzurichten, die verschiedene Konfigurationen beschreiben, die du dann zur Laufzeit mit einem Kommandozeilen-Argument auswählen kannst, anstatt die Konfigurationsdatei selbst ändern zu müssen.
+
+### 6.1. Profile für das Wechseln zwischen lokaler Entwicklung und Ausführung auf HPC erstellen
+
+Lass uns zwei alternative Profile einrichten; eines für das Ausführen kleiner Lasten auf einem normalen Computer, wo wir Docker-Container verwenden werden, und eines für das Ausführen auf einem Universitäts-HPC mit einem Slurm-Scheduler, wo wir Conda-Pakete verwenden werden.
+
+#### 6.1.1. Die Profile einrichten
+
+Füge das Folgende zu deiner `nextflow.config`-Datei hinzu, nach dem Abschnitt mit den Pipeline-Parametern, aber vor den Ausgabe-Einstellungen:
+
+```groovy title="nextflow.config" linenums="24"
+/*
+* Profiles
+*/
+profiles {
+    my_laptop {
+        process.executor = 'local'
+        docker.enabled = true
+    }
+    univ_hpc {
+        process.executor = 'slurm'
+        conda.enabled = true
+        process.resourceLimits = [
+            memory: 750.GB,
+            cpus: 200,
+            time: 30.d
+        ]
+    }
+}
+```
+
+Du siehst, dass wir für das Universitäts-HPC auch Ressourcenbeschränkungen angeben.
+
+#### 6.1.2. Den Workflow mit einem Profil ausführen
+
+Um ein Profil in unserer Nextflow-Kommandozeile anzugeben, verwenden wir das `-profile`-Argument.
+
+Lass uns versuchen, den Workflow mit der `my_laptop`-Konfiguration auszuführen.
+
+```bash
+nextflow run 3-main.nf -profile my_laptop
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `3-main.nf` [gigantic_brazil] DSL2 - revision: ede9037d02
+
+    executor >  local (8)
+    [58/da9437] sayHello (3)       | 3 of 3 ✔
+    [35/9cbe77] convertToUpper (2) | 3 of 3 ✔
+    [67/857d05] collectGreetings   | 1 of 1 ✔
+    [37/7b51b5] cowpy              | 1 of 1 ✔
+    ```
+
+Wie du sehen kannst, erlaubt uns das, sehr bequem zur Laufzeit zwischen Konfigurationen zu wechseln.
+
+!!! warning "Warnung"
+
+    Das `univ_hpc`-Profil wird in der Trainingsumgebung nicht richtig laufen, da wir keinen Zugang zu einem Slurm-Scheduler haben.
+
+Wenn wir in Zukunft andere Konfigurationselemente finden, die immer gemeinsam mit diesen auftreten, können wir sie einfach zum entsprechenden Profil/zu den entsprechenden Profilen hinzufügen.
+Wir können auch zusätzliche Profile erstellen, wenn es andere Konfigurationselemente gibt, die wir zusammenfassen möchten.
+
+### 6.2. Ein Profil mit Test-Parametern erstellen
+
+??? example "Szenario"
+
+    Du möchtest, dass andere deine Pipeline schnell ausprobieren können, ohne ihre eigenen Eingabedaten sammeln zu müssen.
+
+Profile sind nicht nur für Infrastruktur-Konfiguration.
+Wir können sie auch verwenden, um Standardwerte für Workflow-Parameter zu setzen, um es anderen einfacher zu machen, den Workflow auszuprobieren, ohne selbst geeignete Eingabewerte sammeln zu müssen.
+Du kannst das als Alternative zur Verwendung einer Parameter-Datei betrachten.
+
+#### 6.2.1. Das Profil einrichten
+
+Die Syntax für das Ausdrücken von Standardwerten in diesem Kontext sieht so aus, für ein Profil, das wir `test` nennen:
+
+```groovy title="Syntax-Beispiel"
+    test {
+        params.<parameter1>
+        params.<parameter2>
+        ...
+    }
+```
+
+Wenn wir ein test-Profil für unseren Workflow hinzufügen, wird der `profiles`-Block:
+
+```groovy title="nextflow.config" linenums="24"
+/*
+* Profiles
+*/
+profiles {
+    my_laptop {
+        process.executor = 'local'
+        docker.enabled = true
+    }
+    univ_hpc {
+        process.executor = 'slurm'
+        conda.enabled = true
+        process.resourceLimits = [
+            memory: 750.GB,
+            cpus: 200,
+            time: 30.d
+        ]
+    }
+    test {
+        params.input = 'data/greetings.csv'
+        params.batch = 'test'
+        params.character = 'dragonandcow'
+    }
+}
+```
+
+Genau wie für technische Konfigurationsprofile kannst du mehrere verschiedene Profile einrichten, die Parameter unter einem beliebigen Namen angeben, den du magst.
+
+#### 6.2.2. Den Workflow lokal mit dem test-Profil ausführen
+
+Praktischerweise schließen sich Profile nicht gegenseitig aus, sodass wir mehrere Profile in unserer Kommandozeile mit der folgenden Syntax angeben können `-profile <profil1>,<profil2>` (für eine beliebige Anzahl von Profilen).
+
+Wenn du Profile kombinierst, die Werte für dieselben Konfigurationselemente setzen und in derselben Konfigurationsdatei beschrieben sind, wird Nextflow den Konflikt lösen, indem es den Wert verwendet, den es zuletzt eingelesen hat (_d.h._ was auch immer später in der Datei kommt).
+Wenn die widersprüchlichen Einstellungen in verschiedenen Konfigurationsquellen gesetzt sind, gilt die Standard-[Rangfolge](https://www.nextflow.io/docs/latest/config.html).
+
+Lass uns versuchen, das test-Profil zu unserem vorherigen Befehl hinzuzufügen:
+
+```bash
+nextflow run 3-main.nf -profile my_laptop,test
+```
+
+??? success "Befehlsausgabe"
+
+    ```console
+    N E X T F L O W   ~  version 25.10.2
+
+    Launching `3-main.nf` [jovial_coulomb] DSL2 - revision: 46a6763141
+
+    executor >  local (8)
+    [9b/687cdc] sayHello (2)       | 3 of 3 ✔
+    [ca/552187] convertToUpper (3) | 3 of 3 ✔
+    [e8/83e306] collectGreetings   | 1 of 1 ✔
+    [fd/e84fa9] cowpy              | 1 of 1 ✔
+    ```
+
+Das wird Docker verwenden, wo möglich, und Ausgaben unter `results/test` produzieren, und diesmal ist der Charakter das komische Duo `dragonandcow`.
+
+??? abstract "Dateiinhalte"
+
+    ```console title="results/test/"
+     _________
+    / HOLà    \
+    | HELLO   |
+    \ BONJOUR /
+    ---------
+                \                    ^    /^
+                  \                  / \  // \
+                  \   |\___/|      /   \//  .\
+                    \  /O  O  \__  /    //  | \ \           *----*
+                      /     /  \/_/    //   |  \  \          \   |
+                      \@___\@`    \/_   //    |   \   \         \/\ \
+                    0/0/|       \/_ //     |    \    \         \ \
+                0/0/0/0/|        \///      |     \     \       | |
+              0/0/0/0/0/_|_ /   (  //       |      \     _\     |  /
+          0/0/0/0/0/0/`/,_ _ _/  ) ; -.    |    _ _\.-~       /   /
+                      ,-}        _      *-.|.-~-.           .~    ~
+      \     \__/        `/\      /                 ~-. _ .-~      /
+      \____(oo)           *.   }            {                   /
+      (    (--)          .----~-.\        \-`                 .~
+      //__\\  \__ Ack!   ///.----..<        \             _ -~
+      //    \\               ///-._ _ _ _ _ _ _{^ - - - - ~
+    ```
+
+Das bedeutet, solange wir alle Testdatendateien mit dem Workflow-Code verteilen, kann jeder den Workflow schnell ausprobieren, ohne eigene Eingaben über die Kommandozeile oder eine Parameter-Datei bereitstellen zu müssen.
+
+!!! tip "Tipp"
+
+    Wir können für größere Dateien, die extern gespeichert sind, auf URLs verweisen.
+    Nextflow wird sie automatisch herunterladen, solange eine offene Verbindung besteht.
+
+    Für mehr Details, siehe die Side Quest [Working with Files](../side_quests/working_with_files.md)
+
+### 6.3. `nextflow config` verwenden, um die aufgelöste Konfiguration zu sehen
+
+Wie oben erwähnt, kann manchmal derselbe Parameter auf verschiedene Werte in Profilen gesetzt sein, die du kombinieren möchtest.
+Und allgemeiner gibt es zahlreiche Orte, an denen Konfigurationselemente gespeichert werden können, und manchmal können dieselben Eigenschaften an verschiedenen Orten auf verschiedene Werte gesetzt sein.
+
+Nextflow wendet eine festgelegte [Rangfolge](https://www.nextflow.io/docs/latest/config.html) an, um Konflikte zu lösen, aber das kann schwierig sein, selbst zu bestimmen.
+Und selbst wenn nichts im Konflikt steht, kann es mühsam sein, alle möglichen Orte nachzuschlagen, an denen Dinge konfiguriert sein könnten.
+
+Glücklicherweise enthält Nextflow ein praktisches Hilfsprogramm namens `config`, das diesen gesamten Prozess für dich automatisieren kann.
+
+Das `config`-Tool wird alle Inhalte in deinem aktuellen Arbeitsverzeichnis erkunden, alle Konfigurationsdateien aufsaugen und die vollständig aufgelöste Konfiguration produzieren, die Nextflow verwenden würde, um den Workflow auszuführen.
+Das ermöglicht es dir herauszufinden, welche Einstellungen verwendet werden, ohne etwas starten zu müssen.
+
+#### 6.3.1. Die Standardkonfiguration auflösen
+
+Führe diesen Befehl aus, um die Konfiguration aufzulösen, die standardmäßig angewendet würde.
+
+```bash
+nextflow config
+```
+
+??? success "Befehlsausgabe"
+
+    ```groovy
+    docker {
+      enabled = false
+    }
+
+    conda {
+      enabled = true
+    }
+
+    process {
+      memory = '1 GB'
+      withName:cowpy {
+          memory = '2 GB'
+          cpus = 2
+      }
+    }
+
+    params {
+      input = 'greetings.csv'
+      batch = 'batch'
+      character = 'turkey'
+    }
+    ```
+
+Das zeigt dir die Basiskonfiguration, die du bekommst, wenn du nichts Extra in der Kommandozeile angibst.
+
+#### 6.3.2. Die Konfiguration mit spezifischen aktivierten Einstellungen auflösen
+
+Wenn du Kommandozeilen-Parameter angibst, z.B. ein oder mehrere Profile aktivierst oder eine Parameter-Datei lädst, wird der Befehl diese zusätzlich berücksichtigen.
+
+```bash
+nextflow config -profile my_laptop,test
+```
+
+??? success "Befehlsausgabe"
+
+    ```groovy
+    docker {
+      enabled = true
+    }
+
+    conda {
+      enabled = true
+    }
+
+    process {
+      memory = '1 GB'
+      withName:cowpy {
+          memory = '2 GB'
+          cpus = 2
+      }
+      executor = 'local'
+    }
+
+    params {
+      input = 'greetings.csv'
+      batch = 'test'
+      character = 'dragonandcow'
+    }
+    ```
+
+Das wird besonders nützlich für komplexe Projekte, die mehrere Konfigurationsebenen beinhalten.
+
+### Zusammenfassung
+
+Du weißt, wie du Profile verwendest, um zur Laufzeit mit minimalem Aufwand eine voreingestellte Konfiguration auszuwählen.
+Allgemeiner weißt du, wie du deine Workflow-Ausführungen konfigurierst, um verschiedenen Rechenplattformen zu entsprechen und die Reproduzierbarkeit deiner Analysen zu verbessern.
+
+### Was kommt als Nächstes?
+
+Lerne, wie du Pipelines direkt aus Remote-Repositories wie GitHub ausführst.
+
+---
+
+## 7. Pipelines aus Remote-Repositories ausführen
+
+??? example "Szenario"
+
+    Du möchtest eine etablierte Pipeline wie die von nf-core ausführen, ohne den Code selbst herunterladen und verwalten zu müssen.
+
+Bisher haben wir Workflow-Scripts ausgeführt, die sich im aktuellen Verzeichnis befinden.
+In der Praxis wirst du oft Pipelines ausführen wollen, die in Remote-Repositories gespeichert sind, wie GitHub.
+
+Nextflow macht das einfach: Du kannst jede Pipeline direkt von einer Git-Repository-URL ausführen, ohne sie vorher manuell herunterladen zu müssen.
+
+### 7.1. Eine Pipeline von GitHub ausführen
+
+Die grundlegende Syntax für das Ausführen einer Remote-Pipeline ist `nextflow run <repository>`, wobei `<repository>` ein GitHub-Repository-Pfad wie `nextflow-io/hello`, eine vollständige URL oder ein Pfad zu GitLab, Bitbucket oder anderen Git-Hosting-Diensten sein kann.
+
+Versuche, die offizielle Nextflow "hello" Demo-Pipeline auszuführen:
+
+```bash
+nextflow run nextflow-io/hello
+```
+
+Das erste Mal, wenn du eine Remote-Pipeline ausführst, lädt Nextflow sie herunter und speichert sie lokal im cache.
+Nachfolgende Ausführungen verwenden die gecachte Version, es sei denn, du forderst explizit ein Update an.
+
+### 7.2. Eine Version für Reproduzierbarkeit angeben
+
+Standardmäßig führt Nextflow die neueste Version vom Standard-Branch aus.
+Du kannst eine bestimmte Version, einen Branch oder einen Commit mit dem `-r`-Flag angeben:
+
+```bash
+nextflow run nextflow-io/hello -r v1.1
+```
+
+Das Angeben exakter Versionen ist essentiell für die Reproduzierbarkeit.
+
+### Zusammenfassung
+
+Du weißt, wie du Pipelines direkt von GitHub und anderen Remote-Repositories ausführst, und wie du Versionen für die Reproduzierbarkeit angibst.
+
+### Was kommt als Nächstes?
+
+Klopf dir kräftig auf die Schulter!
+Du weißt alles, was du wissen musst, um mit dem Ausführen und Verwalten von Nextflow Pipelines zu beginnen.
+
+Das schließt diesen Kurs ab, aber wenn du eifrig weiterlernen möchtest, haben wir zwei Hauptempfehlungen:
+
+- Wenn du tiefer in die Entwicklung eigener Pipelines eintauchen möchtest, schau dir [Hello Nextflow](../hello_nextflow/index.md) an, einen Kurs für Anfänger, der denselben allgemeinen Verlauf wie dieser abdeckt, aber viel mehr ins Detail über channels und Operatoren geht.
+- Wenn du weiterhin lernen möchtest, wie man Nextflow Pipelines ausführt, ohne tiefer in den Code einzusteigen, schau dir den ersten Teil von [Hello nf-core](../hello_nf-core/index.md) an, der die Tools zum Finden und Ausführen von Pipelines aus dem äußerst beliebten [nf-core](https://nf-co.re/) Projekt vorstellt.
+
+Viel Spaß!
+
+---
+
+## Quiz
+
+<quiz>
+Wenn Parameter-Werte sowohl in der Workflow-Datei als auch in `nextflow.config` gesetzt sind, welcher hat Vorrang?
+- [ ] Der Wert aus der Workflow-Datei
+- [x] Der Wert aus der Konfigurationsdatei
+- [ ] Der zuerst gefundene Wert
+- [ ] Es verursacht einen Fehler
+
+Mehr erfahren: [1.1. Set up values in `nextflow.config`](#11-set-up-values-in-nextflowconfig)
+</quiz>
+
+<quiz>
+Was ist der Syntax-Unterschied zwischen dem Setzen eines Parameter-Standards in einer Workflow-Datei vs. einer config-Datei?
+- [ ] Sie verwenden dieselbe Syntax
+- [x] Workflow verwendet typisierte Deklaration (`#!groovy param: Type = value`), config verwendet Zuweisung (`#!groovy param = value`)
+- [ ] Config verwendet typisierte Deklaration, Workflow verwendet Zuweisung
+- [ ] Nur config-Dateien können Standardwerte setzen
+
+Mehr erfahren: [1.1. Set up values in `nextflow.config`](#11-set-up-values-in-nextflowconfig)
+</quiz>
+
+<quiz>
+Wie gibst du eine Parameter-Datei an, wenn du einen Workflow ausführst?
+- [ ] `--params params.yaml`
+- [ ] `-config params.yaml`
+- [x] `-params-file params.yaml`
+- [ ] `--input-params params.yaml`
+
+Mehr erfahren: [1.3. Use a parameter file](#13-use-a-parameter-file)
+</quiz>
+
+<quiz>
+Was steuert die `outputDir`-Konfigurationsoption?
+- [ ] Den Ort des work directory
+- [x] Den Basispfad, wo Workflow-Ausgaben veröffentlicht werden
+- [ ] Das Verzeichnis für Log-Dateien
+- [ ] Den Ort der Modul-Dateien
+
+Mehr erfahren: [2.1. Customize the outputDir directory name](#21-customize-the-outputdir-directory-name)
+</quiz>
+
+<quiz>
+Wie referenzierst du einen process-Namen dynamisch in der Ausgabe-Pfad-Konfiguration?
+- [ ] `#!groovy ${processName}`
+- [ ] `process.name`
+- [x] `#!groovy { meta.id }`
+- [ ] `@processName`
+
+Mehr erfahren: [2.2. Organize outputs by process](#22-organize-outputs-by-process)
+</quiz>
+
+<quiz>
+Wenn sowohl Docker als auch Conda aktiviert sind und ein process beide Direktiven hat, welche wird priorisiert?
+- [x] Docker (containers)
+- [ ] Conda
+- [ ] Die zuerst im process definierte
+- [ ] Es verursacht einen Fehler
+
+Mehr erfahren: [3. Select a software packaging technology](#3-select-a-software-packaging-technology)
+</quiz>
+
+<quiz>
+Was ist der Standard-executor in Nextflow?
+- [x] `local`
+- [ ] `slurm`
+- [ ] `kubernetes`
+- [ ] `aws`
+
+Mehr erfahren: [4. Select an execution platform](#4-select-an-execution-platform)
+</quiz>
+
+<quiz>
+Welcher Befehl generiert einen Ressourcennutzungsbericht?
+- [ ] `nextflow run workflow.nf -with-metrics`
+- [ ] `nextflow run workflow.nf -with-stats`
+- [x] `nextflow run workflow.nf -with-report report.html`
+- [ ] `nextflow run workflow.nf -profile report`
+
+Mehr erfahren: [5.1. Run the workflow to generate a resource utilization report](#51-run-the-workflow-to-generate-a-resource-utilization-report)
+</quiz>
+
+<quiz>
+Wie setzt du Ressourcenanforderungen für einen bestimmten process namens `cowpy` in der config-Datei?
+- [ ] `#!groovy cowpy.memory = '2.GB'`
+- [ ] `#!groovy process.cowpy.memory = '2.GB'`
+- [x] `#!groovy process { withName: 'cowpy' { memory = '2.GB' } }`
+- [ ] `#!groovy resources.cowpy.memory = '2.GB'`
+
+Mehr erfahren: [5.3. Set resource allocations for a specific process](#53-set-resource-allocations-for-a-specific-process)
+</quiz>
+
+<quiz>
+Was macht die `resourceLimits`-Direktive?
+- [ ] Setzt minimale Ressourcenanforderungen
+- [ ] Weist Ressourcen zu processes zu
+- [x] Begrenzt die maximalen Ressourcen, die angefordert werden können
+- [ ] Überwacht die Ressourcennutzung in Echtzeit
+
+Mehr erfahren: [5.5. Add resource limits](#55-add-resource-limits)
+</quiz>
+
+<quiz>
+Wie gibst du mehrere Profile in einem einzelnen Befehl an?
+- [ ] `-profile profile1 -profile profile2`
+- [ ] `-profiles profile1,profile2`
+- [x] `-profile profile1,profile2`
+- [ ] `--profile profile1 --profile profile2`
+
+Mehr erfahren: [6. Use profiles to switch between preset configurations](#6-use-profiles-to-switch-between-preset-configurations)
+</quiz>
+
+<quiz>
+Welcher Befehl zeigt die vollständig aufgelöste Konfiguration, die Nextflow verwenden würde?
+- [ ] `nextflow show-config`
+- [ ] `nextflow settings`
+- [x] `nextflow config`
+- [ ] `nextflow resolve`
+
+Mehr erfahren: [6.3. Use `nextflow config` to see the resolved configuration](#63-use-nextflow-config-to-see-the-resolved-configuration)
+</quiz>
+
+<quiz>
+Wofür können Profile verwendet werden? (Wähle alle zutreffenden aus)
+- [x] Definieren von infrastrukturspezifischen Einstellungen (executors, containers)
+- [x] Setzen von Ressourcenlimits für verschiedene Umgebungen
+- [x] Bereitstellen von Test-Parametern für einfaches Workflow-Testen
+- [ ] Definieren neuer processes
+
+Mehr erfahren: [6. Use profiles to switch between preset configurations](#6-use-profiles-to-switch-between-preset-configurations)
+</quiz>

--- a/docs/de/docs/nextflow_run/index.md
+++ b/docs/de/docs/nextflow_run/index.md
@@ -1,0 +1,57 @@
+---
+title: Nextflow Run
+hide:
+  - toc
+page_type: index_page
+index_type: course
+additional_information:
+  technical_requirements: true
+  learning_objectives:
+    - Nextflow-Workflows starten und ihre Ausführung verwalten
+    - Ausgaben (Ergebnisse) und Protokolldateien finden und interpretieren
+    - Kernkomponenten von Nextflow in einem einfachen mehrstufigen Workflow erkennen
+    - Pipeline-Ausführung für gängige Rechenplattformen einschließlich HPC und Cloud konfigurieren
+    - Best Practices für Reproduzierbarkeit, Portabilität und Code-Wiederverwendung zusammenfassen, die Pipelines FAIR machen, einschließlich Code-Modularität und Software-Container
+  audience_prerequisites:
+    - "**Zielgruppe:** Dieser Kurs richtet sich an Lernende, die völlig neu bei Nextflow sind und bestehende Pipelines ausführen möchten."
+    - "**Kenntnisse:** Grundlegende Vertrautheit mit der Befehlszeile, grundlegenden Scripting-Konzepten und gängigen Dateiformaten wird vorausgesetzt."
+    - "**Fachgebiet:** Die Übungen sind alle fachunabhängig, sodass keine wissenschaftlichen Vorkenntnisse erforderlich sind."
+---
+
+# Nextflow Run
+
+**Nextflow Run ist eine praktische Einführung in die Ausführung reproduzierbarer und skalierbarer Datenanalyse-Workflows.**
+
+Durch praktische Beispiele und geführte Übungen lernst du die Grundlagen der Verwendung von Nextflow, einschließlich der Ausführung von Pipelines, der Verwaltung von Dateien und Software-Abhängigkeiten, der mühelosen Parallelisierung der Ausführung und der Ausführung von Workflows in verschiedenen Rechenumgebungen.
+
+Du wirst die Fähigkeiten und das Selbstvertrauen mitnehmen, um Workflows mit Nextflow auszuführen.
+
+<!-- additional_information -->
+
+## Kursübersicht
+
+### Was du tun wirst
+
+Dieser Kurs ist praxisorientiert, mit zielgerichteten Übungen, die Informationen schrittweise einführen.
+
+Du wirst mehrere Versionen einer Nextflow-Pipeline ausführen, die Texteingaben verarbeitet.
+Du beginnst mit einer einfachen Version, die aus einem einzelnen Schritt besteht, und gelangst schließlich zu einer mehrstufigen Version, die eine CSV-Datei mit tabellarischen Texteingaben nimmt, einige Transformationsschritte ausführt und eine einzelne Textdatei ausgibt, die ein ASCII-Bild eines Charakters enthält, der den transformierten Text sagt.
+
+Dieser Kurs konzentriert sich auf das Ausführen von Pipelines (benannt nach dem Kernbefehl `nextflow run`).
+Wenn du eine Einführung in die Entwicklung von Nextflow-Pipelines suchst, siehe [Hello Nextflow](../hello_nextflow/index.md).
+
+### Lehrplan
+
+Wir haben dies in drei Teile unterteilt, die sich jeweils auf bestimmte Aspekte des Ausführens und Verwaltens von Pipelines konzentrieren, die in Nextflow geschrieben sind.
+
+| Kurskapitel                                           | Zusammenfassung                                                                                                 | Geschätzte Dauer |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------- |
+| [Teil 1: Grundlegende Operationen](./01_basics.md)    | Starten und Verwalten der Ausführung eines einfachen Workflows                                                  | 30 Min           |
+| [Teil 2: Echte Pipelines ausführen](./02_pipeline.md) | Komplexe Eingaben verarbeiten, mehrstufige Workflows ausführen, Container verwenden und mühelos parallelisieren | 60 Min           |
+| [Teil 3: Konfiguration](./03_config.md)               | Pipeline-Verhalten anpassen und Nutzung in verschiedenen Rechenumgebungen optimieren                            | 60 Min           |
+
+Am Ende dieses Kurses wirst du gut vorbereitet sein, um die nächsten Schritte auf deinem Weg zum Ausführen reproduzierbarer Workflows für deine wissenschaftlichen Rechenanforderungen anzugehen.
+
+Bereit, den Kurs zu beginnen?
+
+[Jetzt lernen :material-arrow-right:](00_orientation.md){ .md-button .md-button--primary }

--- a/docs/de/docs/nextflow_run/next_steps.md
+++ b/docs/de/docs/nextflow_run/next_steps.md
@@ -1,0 +1,64 @@
+# Kurszusammenfassung
+
+Herzlichen Glückwunsch zum Abschluss des Nextflow Run-Trainingskurses! 🎉
+
+<!-- placeholder for video -->
+
+## Deine Reise
+
+Du hast mit einem sehr grundlegenden Workflow begonnen und gelernt, ihn auszuführen, die Ausgaben zu finden und seine Ausführung zu verwalten.
+Dann hast du dich durch immer komplexere Versionen dieses Workflows gearbeitet und gelernt, die wesentlichen Konzepte und Mechanismen zu erkennen, die Nextflow-Pipelines antreiben, einschließlich Channels und Operatoren, Code-Modularisierung und Container.
+Schließlich hast du gelernt, wie du die Konfiguration einer Pipeline an deine Präferenzen und deine Recheninfrastruktur anpasst.
+
+### Was du gelernt hast
+
+Du bist jetzt in der Lage, die Ausführung der Hello-Pipeline zu verwalten, zu beschreiben, wie sie strukturiert ist, und die wichtigsten Code-Teile zu identifizieren.
+
+- Die endgültige Form des Hello-Workflows nimmt als Eingabe eine CSV-Datei, die Text-Grüße enthält.
+- Die vier Schritte sind als Nextflow-Prozesse (`sayHello`, `convertToUpper`, `collectGreetings` und `cowpy`) implementiert und in separaten Modul-Dateien gespeichert.
+- Die Ergebnisse werden in ein Verzeichnis namens `results/` veröffentlicht.
+- Die finale Ausgabe der Pipeline ist eine einfache Textdatei, die ASCII-Kunst eines Charakters enthält, der die großgeschriebenen Grüße sagt.
+
+<figure class="excalidraw">
+--8<-- "docs/hello_nextflow/img/hello_pipeline_complete.svg"
+</figure>
+
+1. **`sayHello`:** Schreibt jeden Gruß in seine eigene Ausgabedatei (_z.B._ "Hello-output.txt")
+2. **`convertToUpper`:** Konvertiert jeden Gruß in Großbuchstaben (_z.B._ "HELLO")
+3. **`collectGreetings`:** Sammelt alle großgeschriebenen Grüße in einer einzelnen Batch-Datei
+4. **`cowpy`:** Generiert ASCII-Kunst mit dem `cowpy`-Tool
+
+Die Workflow-Konfiguration unterstützt die flexible und reproduzierbare Bereitstellung von Eingaben und Parametern.
+
+### Erworbene Fähigkeiten
+
+Durch diesen praxisorientierten Kurs hast du gelernt, wie man:
+
+- Einen Nextflow-Workflow lokal startet
+- Ausgaben (Ergebnisse) und Protokolldateien, die von Nextflow generiert werden, findet und interpretiert
+- Die Kernkomponenten von Nextflow erkennt, die einen einfachen mehrstufigen Workflow ausmachen
+- Fortgeschrittene Konzepte wie Operatoren und Channel-Factories beschreibt
+- Pipelines für verschiedene Rechenumgebungen konfiguriert
+
+Du bist jetzt mit dem grundlegenden Wissen ausgestattet, um bestehende Nextflow-Pipelines in deine eigene Arbeit zu integrieren.
+
+## Nächste Schritte zum Aufbau deiner Fähigkeiten
+
+Hier sind unsere Top-Vorschläge, was du als Nächstes tun kannst:
+
+- Führe Nextflow nicht nur aus, schreibe es! Werde ein Nextflow-Entwickler mit [Hello Nextflow](../hello_nextflow/index.md)
+- Wende Nextflow auf einen wissenschaftlichen Analyse-Anwendungsfall an mit [Nextflow for Science](../nf4_science/index.md)
+- Starte mit nf-core mit [Hello nf-core](../hello_nf-core/index.md)
+- Lerne Troubleshooting-Techniken mit der [Debugging Side Quest](../side_quests/debugging.md)
+
+Schließlich empfehlen wir dir einen Blick auf [**Seqera Platform**](https://seqera.io/), eine Cloud-basierte Plattform, die von den Erstellern von Nextflow entwickelt wurde und es noch einfacher macht, deine Workflows zu starten und zu verwalten, deine Daten zu verwalten und Analysen interaktiv in jeder Umgebung auszuführen.
+
+## Hilfe bekommen
+
+Für Hilfe-Ressourcen und Community-Support siehe die [Hilfe-Seite](../help.md).
+
+## Feedback-Umfrage
+
+Bevor du weitergehst, nimm dir bitte eine Minute Zeit, um die Kurs-Umfrage auszufüllen! Dein Feedback hilft uns, unsere Trainingsmaterialien für alle zu verbessern.
+
+[Zur Umfrage :material-arrow-right:](survey.md){ .md-button .md-button--primary }

--- a/docs/de/docs/nextflow_run/survey.md
+++ b/docs/de/docs/nextflow_run/survey.md
@@ -1,0 +1,7 @@
+# Feedback-Umfrage
+
+Bevor du weitergehst, fülle bitte diese kurze 5-Fragen-Umfrage aus, um das Training zu bewerten, Feedback zu deiner Erfahrung zu teilen und uns mitzuteilen, was wir sonst noch tun können, um dir auf deiner Nextflow-Reise zu helfen.
+
+Das sollte weniger als eine Minute dauern. Vielen Dank, dass du uns hilfst, unsere Trainingsmaterialien für alle zu verbessern!
+
+<div data-tf-live="01K85R7F5HMAGCD298M2W7R93Y"></div><script src="//embed.typeform.com/next/embed.js"></script>


### PR DESCRIPTION
## Summary

Adds German (de) translation for the Nextflow training materials.

### Files Translated (23 files)

**Top-level:**
- `docs/de/docs/index.md`
- `docs/de/docs/help.md`

**envsetup (4 files):**
- `index.md`, `01_setup.md`, `02_local.md`, `03_devcontainer.md`

**hello_nextflow (10 files):**
- `index.md`, `00_orientation.md`, `01_hello_world.md`, `02_hello_channels.md`
- `03_hello_workflow.md`, `04_hello_modules.md`, `05_hello_containers.md`
- `06_hello_config.md`, `next_steps.md`, `survey.md`

**nextflow_run (7 files):**
- `index.md`, `00_orientation.md`, `01_basics.md`, `02_pipeline.md`
- `03_config.md`, `next_steps.md`, `survey.md`

### Translation Guidelines
- Informal German ("du" instead of "Sie")
- Technical Nextflow terms kept in English (channel, process, workflow, pipeline, params, etc.)
- Admonition titles translated (Note→Hinweis, Tip→Tipp, Warning→Warnung, etc.)

### New Files
- `docs/de/llm-prompt.md` - German-specific translation guidelines and glossary
- `docs/de/mkdocs.yml` - MkDocs configuration for German
- Updated `docs/language_names.yml` to include German