### PR TITLE
Fix mkdocs build output path in CI workflow

### DIFF
--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -43,7 +43,7 @@ jobs:
         run: pip install mkdocs-material mkdocs-enumerate-headings-plugin mkdocs-quiz
 
       - name: Build ${{ matrix.lang }} docs
-        run: mkdocs build -f docs/${{ matrix.lang }}/mkdocs.yml -d site-${{ matrix.lang }}
+        run: mkdocs build -f docs/${{ matrix.lang }}/mkdocs.yml -d ${{ github.workspace }}/site-${{ matrix.lang }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- Fixes the docs-dev.yml workflow that was failing after the multi-language merge
- MkDocs interprets the `-d` output directory flag relative to the config file location, not the working directory
- Changed to use absolute path with `${{ github.workspace }}` so site output goes to the expected location

## Problem

The build was outputting to `docs/en/site-en/` instead of `site-en/` at the repo root, causing the artifact upload to fail with "No files were found".

Fixes the CI failure from https://github.com/nextflow-io/training/actions/runs/21610061088