### PR TITLE
Fix uv run command to use inline script dependencies

### DIFF
--- a/.github/workflows/translate-auto.yml
+++ b/.github/workflows/translate-auto.yml
@@ -1,4 +1,4 @@
-name: Auto-update Translations
+name: "Translate: Auto-update"
 
 # Automatically update translations when English content or prompts change
 on:
@@ -68,7 +68,7 @@ jobs:
           # Check each language for outdated translations (English source newer than translation)
           languages_with_outdated=""
           for lang in $all_languages; do
-            outdated=$(uv run python translate.py list-outdated "$lang" 2>/dev/null | grep -c "docs/" || echo "0")
+            outdated=$(uv run translate.py list-outdated "$lang" 2>/dev/null | grep -c "docs/" || echo "0")
             if [ "$outdated" -gt 0 ]; then
               echo "Found $outdated outdated files for $lang"
               if [ -n "$languages_with_outdated" ]; then
@@ -146,7 +146,7 @@ jobs:
         working-directory: _scripts
         run: |
           echo "Updating outdated translations for ${{ matrix.language }}..."
-          uv run python translate.py update-outdated --language ${{ matrix.language }}
+          uv run translate.py update-outdated --language ${{ matrix.language }}
 
       - name: Check for changes
         id: changes
@@ -224,7 +224,7 @@ jobs:
         working-directory: _scripts
         run: |
           echo "Fixing ${{ matrix.language }} translations to comply with updated prompt guidelines..."
-          uv run python translate.py fix-translations --language ${{ matrix.language }} --max-iterations 8
+          uv run translate.py fix-translations --language ${{ matrix.language }} --max-iterations 8
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -56,26 +56,26 @@ jobs:
         run: |
           case "$COMMAND" in
             list-outdated)
-              uv run python translate.py list-outdated "$LANGUAGE"
+              uv run translate.py list-outdated "$LANGUAGE"
               ;;
             list-missing)
-              uv run python translate.py list-missing "$LANGUAGE"
+              uv run translate.py list-missing "$LANGUAGE"
               ;;
             update-outdated)
-              uv run python translate.py update-outdated --language "$LANGUAGE"
+              uv run translate.py update-outdated --language "$LANGUAGE"
               ;;
             add-missing)
-              uv run python translate.py add-missing --language "$LANGUAGE"
+              uv run translate.py add-missing --language "$LANGUAGE"
               ;;
             update-and-add)
-              uv run python translate.py update-and-add --language "$LANGUAGE"
+              uv run translate.py update-and-add --language "$LANGUAGE"
               ;;
           esac
 
       - name: Fix translations
         if: inputs.command == 'update-outdated' || inputs.command == 'add-missing' || inputs.command == 'update-and-add'
         working-directory: _scripts
-        run: uv run python translation_fixer.py fix-all ${{ inputs.language }}
+        run: uv run translation_fixer.py fix-all ${{ inputs.language }}
 
       - name: Create PR with changes
         if: inputs.command == 'update-outdated' || inputs.command == 'add-missing' || inputs.command == 'update-and-add'
@@ -87,7 +87,7 @@ jobs:
           COMMAND: ${{ inputs.command }}
         working-directory: _scripts
         run: |
-          uv run python translate.py make-pr \
+          uv run translate.py make-pr \
             --language "$LANGUAGE" \
             --command "$COMMAND" \
             --github-token "$GITHUB_TOKEN" \


### PR DESCRIPTION
## Summary

- Fixed translation workflow scripts to use `uv run script.py` instead of `uv run python script.py`, allowing uv to recognize and install PEP 723 inline script dependencies
- Renamed "Auto-update Translations" workflow to "Translate: Auto-update" for alphabetical sorting