### PR TITLE
Fix snippets base_path to resolve SVG includes

### DIFF
--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -224,7 +224,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.keys
   - pymdownx.snippets:
-      base_path: ["../.."]
+      base_path: [".", "../.."]
   - pymdownx.superfences:
       preserve_tabs: true
       custom_fences:


### PR DESCRIPTION
## Summary

- Fixes SVG diagrams not rendering in the deployed site (empty `<figure class="excalidraw">` elements)
- Changed `pymdownx.snippets` `base_path` from `["../.."]` to `[".", "../.."]`

## Root Cause

The `pymdownx.snippets` extension resolves `base_path` relative to the **current working directory** when mkdocs runs, not relative to the mkdocs.yml file location.

When running `mkdocs build -f docs/en/mkdocs.yml` from the repo root (as CI does):
- CWD is `.` (repo root)
- `base_path: ["../.."]` resolved to two directories *above* the repo root
- Snippet paths like `docs/en/docs/hello_nextflow/img/*.svg` couldn't be found

## Fix

Changed to `base_path: [".", "../.."]` to support both contexts:
- `.` for CI builds running from repo root
- `../..` for local preview running from `docs/en/`

Tested both scenarios - 37 SVG tags correctly included in built HTML.

Fixes issue introduced in commit 61c051ee