### PR TITLE
Fix mkdocs build output path in docs-release workflow

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -49,7 +49,7 @@ jobs:
         run: pip install mkdocs-material mkdocs-enumerate-headings-plugin mkdocs-quiz
 
       - name: Build ${{ matrix.lang }} docs
-        run: mkdocs build -f docs/${{ matrix.lang }}/mkdocs.yml -d site-${{ matrix.lang }}
+        run: mkdocs build -f docs/${{ matrix.lang }}/mkdocs.yml -d ${{ github.workspace }}/site-${{ matrix.lang }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- Use absolute path for mkdocs build output in `docs-release.yml`, matching the fix applied to `docs-dev.yml` in #813

## Problem

The release workflow was using a relative path (`-d site-${{ matrix.lang }}`), but mkdocs interprets this relative to the config file location (`docs/en/mkdocs.yml`), causing output to go to `docs/en/site-en/` instead of the repo root where `upload-artifact` expected it.

This caused all artifact uploads to fail with "No files were found with the provided path", resulting in the deploy job failing.

## Fix

Changed from:
```yaml
mkdocs build -f docs/${{ matrix.lang }}/mkdocs.yml -d site-${{ matrix.lang }}
```

To:
```yaml
mkdocs build -f docs/${{ matrix.lang }}/mkdocs.yml -d ${{ github.workspace }}/site-${{ matrix.lang }}
```

This matches the approach used in `docs-dev.yml` after #813.

Fixes the failure in https://github.com/nextflow-io/training/actions/runs/21628227613/job/62333885769