### PR TITLE
Add permissions to translate workflow

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -21,6 +21,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   detect:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds explicit `contents: write` and `pull-requests: write` permissions to the translate workflow

## Problem
The translate workflow was failing with:
```
refusing to allow a GitHub App to create or update workflow `.github/workflows/translate.yml` without `workflows` permission
```

See: https://github.com/nextflow-io/training/actions/runs/21623447012/job/62317679335

## Fix
Adding explicit permissions allows the workflow to push branches and create PRs. The translation only modifies files in `docs/`, so `workflows: write` is not needed.