### PR TITLE
Quieten uv output and force colors in GitHub Actions

### DIFF
--- a/.github/workflows/check-headings.yml
+++ b/.github/workflows/check-headings.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run check_headings.py
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: uv run .github/check_headings.py ${{ steps.changed-files.outputs.all_changed_files }}
+        run: uv run -q .github/check_headings.py ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Skip check (no markdown files changed)
         if: steps.changed-files.outputs.any_changed != 'true'

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -42,7 +42,7 @@ jobs:
         id: detect
         working-directory: _scripts
         run: |
-          uv run translate.py ci-detect \
+          uv run -q translate.py ci-detect \
             ${{ inputs.language && format('--language "{0}"', inputs.language) || '' }} \
             >> $GITHUB_OUTPUT
 
@@ -66,12 +66,12 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         working-directory: _scripts
-        run: uv run translate.py sync ${{ matrix.language }}
+        run: uv run -q translate.py sync ${{ matrix.language }}
 
       - name: Dry run ${{ matrix.language }}
         if: ${{ inputs.dry_run }}
         working-directory: _scripts
-        run: uv run translate.py sync ${{ matrix.language }} --dry-run
+        run: uv run -q translate.py sync ${{ matrix.language }} --dry-run
 
       - name: Upload translation artifacts
         if: ${{ !inputs.dry_run && success() }}
@@ -129,4 +129,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         working-directory: _scripts
-        run: uv run translate.py ci-pr
+        run: uv run -q translate.py ci-pr

--- a/_scripts/translate.py
+++ b/_scripts/translate.py
@@ -40,6 +40,7 @@ import typer
 import yaml
 from rich.console import Console
 
+
 # =============================================================================
 # Configuration
 # =============================================================================
@@ -652,7 +653,7 @@ def translate(
 ):
     """Translate a single file."""
     check_api_key()
-    console = Console()
+    console = Console(force_terminal=True if os.getenv("GITHUB_ACTIONS") else None)
 
     if lang == "en":
         raise typer.Exit("Cannot translate to English")
@@ -672,7 +673,7 @@ def sync(
     dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Preview only"),
 ):
     """Sync translations: update outdated, add missing, remove orphaned."""
-    console = Console()
+    console = Console(force_terminal=True if os.getenv("GITHUB_ACTIONS") else None)
 
     # Gather work
     orphaned = get_orphaned_files(lang)
@@ -765,7 +766,7 @@ def ci_run(
     dry_run: bool = typer.Option(False, "--dry-run"),
 ):
     """Run sync for multiple languages (CI)."""
-    console = Console()
+    console = Console(force_terminal=True if os.getenv("GITHUB_ACTIONS") else None)
     for lang in json.loads(languages):
         console.rule(f"[bold]{lang}[/bold]")
         sync(lang, include=None, dry_run=dry_run)


### PR DESCRIPTION
## Summary
- Add `-q` flag to all `uv run` commands in GitHub Actions workflows to suppress package installation output
- Add `force_terminal` to Rich Console in `translate.py` to preserve colored output when running in CI