### PR TITLE
Language dropdown: hover on navbar, not on entire list area.

### DIFF
--- a/docs/en/docs/assets/stylesheets/extra.css
+++ b/docs/en/docs/assets/stylesheets/extra.css
@@ -450,6 +450,7 @@ h3 .enumerate-headings-plugin {
 }
 
 /* Language selector dropdown - allow dynamic height */
-.md-select__inner {
+.md-select:focus-within .md-select__inner,
+.md-select:hover .md-select__inner {
   max-height: min(80vh, 30rem) !important;
 }


### PR DESCRIPTION
Fixes #824