### PR TITLE
Fix translate workflow race condition with checkout ref

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -24,7 +24,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   detect:
@@ -91,6 +90,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.sha }} # Use trigger SHA, not latest master (avoids workflow file conflicts)
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all translation artifacts


### PR DESCRIPTION
## Summary

- Fix race condition where the merge job could checkout a newer master commit instead of the workflow trigger SHA
- Remove invalid `workflows: write` permission

## Problem

When master is updated during a long-running translation workflow (which can take 30+ minutes), the merge job would checkout the latest master instead of the SHA that triggered the workflow. If those newer commits modified workflow files, the push would fail with:

```
refusing to allow a GitHub App to create or update workflow `.github/workflows/translate.yml` without `workflows` permission
```

This happened in [run #21637682812](https://github.com/nextflow-io/training/actions/runs/21637682812/job/62371741635) when commit e9c5486d was pushed to master while the translate jobs were still running.

## Fix

Explicitly specify `ref: ${{ github.sha }}` in the merge job's checkout step to ensure it uses the exact commit that triggered the workflow.