### PR TITLE
Fix ci-detect outputting ANSI codes to GITHUB_OUTPUT

### DIFF
--- a/_scripts/translate.py
+++ b/_scripts/translate.py
@@ -738,7 +738,9 @@ def sync(
 @app.command("ci-detect")
 def ci_detect(language: str | None = typer.Option(None, "--language")):
     """Detect languages needing sync (GitHub Actions output)."""
-    console = Console(force_terminal=True if os.getenv("GITHUB_ACTIONS") else None)
+    console = Console(
+        stderr=True, force_terminal=True if os.getenv("GITHUB_ACTIONS") else None
+    )
     all_langs = get_translation_languages()
 
     if language:


### PR DESCRIPTION
## Summary

- Fix `ci-detect` command outputting ANSI color codes to `$GITHUB_OUTPUT`
- The Rich console was writing colored diagnostic output to stdout, which got piped to `$GITHUB_OUTPUT` and broke the expected format
- Added `stderr=True` to redirect diagnostic output to stderr, keeping stdout clean for GitHub Actions output

Fixes https://github.com/nextflow-io/training/actions/runs/21644520564/job/62392953237