### PR TITLE
Fix translation baseline detection using PR trigger commit

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -16,6 +16,9 @@ on:
       language:
         description: "Language code (empty = all)"
         type: string
+      since:
+        description: "Compare since this commit (default: auto-detect from last translation PR)"
+        type: string
       dry_run:
         description: "Dry run (preview only)"
         type: boolean
@@ -41,9 +44,13 @@ jobs:
       - name: Detect work
         id: detect
         working-directory: _scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           uv run -q translate.py ci-detect \
             ${{ inputs.language && format('--language "{0}"', inputs.language) || '' }} \
+            ${{ inputs.since && format('--since "{0}"', inputs.since) || '' }} \
             >> $GITHUB_OUTPUT
 
   translate:


### PR DESCRIPTION
## Summary

Fixes an issue where translation detection would miss English content changes that occurred while a translation PR was in-flight.

**The problem:** The previous logic compared file timestamps - English file's last commit time vs translation file's last commit time (merge time). When translation PRs stacked up and got cancelled, then manually triggered, the comparison used the merge time of the last translation PR, missing any English changes that happened between when that translation was *started* and when it was *merged*.

**The solution:** Instead of comparing timestamps, compare against the **trigger commit** - the commit that initiated the translation workflow. This is already stored in the PR body as `Update triggered by: commit 3c20b0c944`. The new logic finds the last merged translation PR, extracts this commit SHA, and checks if English files have changed since that commit.

## Changes

- Add `get_translation_baseline()` function using PyGitHub to find trigger commit from last translation PR
- Add `file_changed_since()` git helper to check if file changed since a baseline commit  
- Modify `get_outdated_files()` to use baseline comparison instead of timestamps
- Add `--since` option to `sync` and `ci-detect` commands for manual override
- Update `ci_pr()` to always include commit SHA in PR body (required for future baseline detection)
- Add `since` input to `workflow_dispatch` for manual triggers

## Testing

```bash
# With explicit baseline
python translate.py sync pt --dry-run --since 3c20b0c944

# With auto-detected baseline (requires GITHUB_TOKEN)
GITHUB_TOKEN=$(gh auth token) GITHUB_REPOSITORY=nextflow-io/training \
  python translate.py sync pt --dry-run
```

Both correctly identify files that changed since the baseline commit.