### PR TITLE
Add diagrams to nf-test side quest

### DIFF
--- a/docs/en/docs/side_quests/img/nf-test/snapshot-vs-content.excalidraw.svg
+++ b/docs/en/docs/side_quests/img/nf-test/snapshot-vs-content.excalidraw.svg
@@ -1,0 +1,126 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" width="960" height="560">
+  <!-- svg-source:excalidraw -->
+  <style>
+    text { font-family: "Segoe UI", system-ui, -apple-system, sans-serif; }
+    .title { font-size: 22px; font-weight: 600; fill: #1e1e1e; }
+    .heading { font-size: 16px; font-weight: 600; }
+    .subheading { font-size: 14px; font-weight: 600; }
+    .code { font-size: 12px; font-family: "SF Mono", "Fira Code", monospace; fill: #333333; }
+    .body { font-size: 12px; fill: #666666; }
+    .vs { font-size: 22px; font-weight: 700; fill: #999999; }
+    .best { font-size: 12px; fill: #666666; }
+  </style>
+
+  <!-- Title -->
+  <text x="480" y="28" text-anchor="middle" class="title">Snapshot vs Content Assertions</text>
+
+  <!-- Divider -->
+  <text x="480" y="310" text-anchor="middle" class="vs">vs</text>
+  <line x1="480" y1="50" x2="480" y2="540" stroke="#e0e0e0" stroke-width="1" stroke-dasharray="6 4"/>
+
+  <!-- === LEFT: Snapshots === -->
+  <rect x="15" y="45" width="445" height="495" rx="10" fill="#dbe4ff" fill-opacity="0.2" stroke="#4a9eed" stroke-width="1.5"/>
+  <text x="237" y="72" text-anchor="middle" class="heading" fill="#4a9eed">Snapshot Assertions</text>
+
+  <!-- Code example -->
+  <rect x="35" y="85" width="405" height="52" rx="6" fill="#f8f9fa" stroke="#4a9eed" stroke-width="1"/>
+  <text x="50" y="106" class="code">assert snapshot(process.out)</text>
+  <text x="70" y="124" class="code">.match()</text>
+
+  <!-- How it works -->
+  <text x="35" y="162" class="subheading" fill="#1e1e1e">How it works</text>
+  <rect x="35" y="172" width="175" height="44" rx="6" fill="#b2f2bb" fill-opacity="0.5" stroke="#22c55e" stroke-width="1"/>
+  <text x="122" y="190" text-anchor="middle" class="body" font-weight="500">First run:</text>
+  <text x="122" y="206" text-anchor="middle" class="body">Save output as .snap</text>
+
+  <line x1="210" y1="194" x2="250" y2="194" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <rect x="255" y="172" width="175" height="44" rx="6" fill="#a5d8ff" fill-opacity="0.5" stroke="#4a9eed" stroke-width="1"/>
+  <text x="342" y="190" text-anchor="middle" class="body" font-weight="500">Next runs:</text>
+  <text x="342" y="206" text-anchor="middle" class="body">Compare to .snap file</text>
+
+  <!-- Strengths -->
+  <text x="35" y="244" class="subheading" fill="#22c55e">Strengths</text>
+  <circle cx="45" cy="262" r="3" fill="#22c55e"/>
+  <text x="55" y="266" class="body">Catches ANY change in output</text>
+  <circle cx="45" cy="282" r="3" fill="#22c55e"/>
+  <text x="55" y="286" class="body">Easy to set up (default behavior)</text>
+  <circle cx="45" cy="302" r="3" fill="#22c55e"/>
+  <text x="55" y="306" class="body">Comprehensive coverage</text>
+
+  <!-- Weaknesses -->
+  <text x="35" y="338" class="subheading" fill="#ef4444">Weaknesses</text>
+  <circle cx="45" cy="356" r="3" fill="#ef4444"/>
+  <text x="55" y="360" class="body">Brittle: breaks on ANY change</text>
+  <circle cx="45" cy="376" r="3" fill="#ef4444"/>
+  <text x="55" y="380" class="body">Opaque: unclear what matters in the output</text>
+  <circle cx="45" cy="396" r="3" fill="#ef4444"/>
+  <text x="55" y="400" class="body">Must update snapshots when valid changes occur</text>
+
+  <!-- Best for -->
+  <rect x="35" y="420" width="405" height="48" rx="6" fill="#fff3bf" fill-opacity="0.5" stroke="#f59e0b" stroke-width="1"/>
+  <text x="50" y="441" class="body" font-weight="600" fill="#b45309">Best for:</text>
+  <text x="110" y="441" class="body">Stable outputs where any change</text>
+  <text x="110" y="457" class="body">should be flagged for review</text>
+
+  <!-- Update hint -->
+  <rect x="35" y="480" width="405" height="40" rx="6" fill="#f8f9fa" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="50" y="501" class="code" fill="#4a9eed">--update-snapshot</text>
+  <text x="210" y="501" class="body">to accept new output as reference</text>
+
+  <!-- === RIGHT: Content === -->
+  <rect x="500" y="45" width="445" height="495" rx="10" fill="#e5dbff" fill-opacity="0.2" stroke="#8b5cf6" stroke-width="1.5"/>
+  <text x="722" y="72" text-anchor="middle" class="heading" fill="#8b5cf6">Content Assertions</text>
+
+  <!-- Code example -->
+  <rect x="520" y="85" width="405" height="52" rx="6" fill="#f8f9fa" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="535" y="106" class="code">assert path(process.out[0][0])</text>
+  <text x="555" y="124" class="code">.readLines().contains('hello')</text>
+
+  <!-- How it works -->
+  <text x="520" y="162" class="subheading" fill="#1e1e1e">How it works</text>
+  <rect x="520" y="172" width="185" height="44" rx="6" fill="#d0bfff" fill-opacity="0.5" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="612" y="190" text-anchor="middle" class="body" font-weight="500">Every run:</text>
+  <text x="612" y="206" text-anchor="middle" class="body">Check specific values</text>
+
+  <line x1="705" y1="194" x2="745" y2="194" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <rect x="750" y="172" width="175" height="44" rx="6" fill="#b2f2bb" fill-opacity="0.5" stroke="#22c55e" stroke-width="1"/>
+  <text x="837" y="190" text-anchor="middle" class="body" font-weight="500">No snapshot</text>
+  <text x="837" y="206" text-anchor="middle" class="body">file needed</text>
+
+  <!-- Strengths -->
+  <text x="520" y="244" class="subheading" fill="#22c55e">Strengths</text>
+  <circle cx="530" cy="262" r="3" fill="#22c55e"/>
+  <text x="540" y="266" class="body">Explicit: clear what is being tested</text>
+  <circle cx="530" cy="282" r="3" fill="#22c55e"/>
+  <text x="540" y="286" class="body">Resilient to irrelevant changes</text>
+  <circle cx="530" cy="302" r="3" fill="#22c55e"/>
+  <text x="540" y="306" class="body">Better error messages when tests fail</text>
+
+  <!-- Weaknesses -->
+  <text x="520" y="338" class="subheading" fill="#ef4444">Weaknesses</text>
+  <circle cx="530" cy="356" r="3" fill="#ef4444"/>
+  <text x="540" y="360" class="body">More code to write</text>
+  <circle cx="530" cy="376" r="3" fill="#ef4444"/>
+  <text x="540" y="380" class="body">May miss unexpected changes in output</text>
+  <circle cx="530" cy="396" r="3" fill="#ef4444"/>
+  <text x="540" y="400" class="body">Must know what to check for in advance</text>
+
+  <!-- Best for -->
+  <rect x="520" y="420" width="405" height="48" rx="6" fill="#fff3bf" fill-opacity="0.5" stroke="#f59e0b" stroke-width="1"/>
+  <text x="535" y="441" class="body" font-weight="600" fill="#b45309">Best for:</text>
+  <text x="595" y="441" class="body">Outputs with variable parts</text>
+  <text x="595" y="457" class="body">(timestamps, random IDs, etc.)</text>
+
+  <!-- Methods hint -->
+  <rect x="520" y="480" width="405" height="40" rx="6" fill="#f8f9fa" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="535" y="501" class="code" fill="#8b5cf6">readLines(), contains(), getText()</text>
+  <text x="535" y="515" class="body">and other Groovy/Java methods</text>
+
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1e1e1e"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/en/docs/side_quests/img/nf-test/test-execution-flow.excalidraw.svg
+++ b/docs/en/docs/side_quests/img/nf-test/test-execution-flow.excalidraw.svg
@@ -1,0 +1,119 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520" width="900" height="520">
+  <!-- svg-source:excalidraw -->
+  <style>
+    text { font-family: "Segoe UI", system-ui, -apple-system, sans-serif; }
+    .title { font-size: 22px; font-weight: 600; fill: #1e1e1e; }
+    .step-num { font-size: 20px; font-weight: 700; }
+    .step-label { font-size: 14px; font-weight: 500; fill: #1e1e1e; }
+    .step-detail { font-size: 11px; fill: #666666; }
+    .heading { font-size: 15px; font-weight: 600; }
+    .code { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #444444; }
+    .note { font-size: 12px; fill: #666666; }
+    .result { font-size: 18px; font-weight: 600; }
+  </style>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1e1e1e"/>
+    </marker>
+    <marker id="arrow-green" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#22c55e"/>
+    </marker>
+    <marker id="arrow-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#ef4444"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="210" y="28" text-anchor="middle" class="title">nf-test Execution Flow</text>
+
+  <!-- Step 1 -->
+  <circle cx="40" cy="72" r="16" fill="#4a9eed" stroke="none"/>
+  <text x="40" y="78" text-anchor="middle" class="step-num" fill="#ffffff">1</text>
+  <rect x="65" y="50" width="260" height="44" rx="8" fill="#a5d8ff" stroke="#4a9eed" stroke-width="1.5"/>
+  <text x="195" y="68" text-anchor="middle" class="step-label">Run test command</text>
+  <text x="195" y="84" text-anchor="middle" class="code">nf-test test tests/main.nf.test</text>
+
+  <line x1="195" y1="94" x2="195" y2="120" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 2 -->
+  <circle cx="40" cy="142" r="16" fill="#f59e0b" stroke="none"/>
+  <text x="40" y="148" text-anchor="middle" class="step-num" fill="#ffffff">2</text>
+  <rect x="65" y="120" width="260" height="44" rx="8" fill="#fff3bf" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="195" y="138" text-anchor="middle" class="step-label">Create isolated directory</text>
+  <text x="195" y="154" text-anchor="middle" class="code">.nf-test/tests/&lt;hash&gt;/</text>
+
+  <line x1="195" y1="164" x2="195" y2="190" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 3 -->
+  <circle cx="40" cy="212" r="16" fill="#22c55e" stroke="none"/>
+  <text x="40" y="218" text-anchor="middle" class="step-num" fill="#ffffff">3</text>
+  <rect x="65" y="190" width="260" height="44" rx="8" fill="#b2f2bb" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="195" y="208" text-anchor="middle" class="step-label">Apply when {} block</text>
+  <text x="195" y="224" text-anchor="middle" class="step-detail">Set params and/or process inputs</text>
+
+  <line x1="195" y1="234" x2="195" y2="260" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 4 -->
+  <circle cx="40" cy="282" r="16" fill="#8b5cf6" stroke="none"/>
+  <text x="40" y="288" text-anchor="middle" class="step-num" fill="#ffffff">4</text>
+  <rect x="65" y="260" width="260" height="44" rx="8" fill="#d0bfff" stroke="#8b5cf6" stroke-width="1.5"/>
+  <text x="195" y="278" text-anchor="middle" class="step-label">Run Nextflow</text>
+  <text x="195" y="294" text-anchor="middle" class="step-detail">Pipeline/process executes in isolation</text>
+
+  <line x1="195" y1="304" x2="195" y2="330" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 5 -->
+  <circle cx="40" cy="352" r="16" fill="#ef4444" stroke="none"/>
+  <text x="40" y="358" text-anchor="middle" class="step-num" fill="#ffffff">5</text>
+  <rect x="65" y="330" width="260" height="44" rx="8" fill="#ffc9c9" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="195" y="348" text-anchor="middle" class="step-label">Evaluate then {} block</text>
+  <text x="195" y="364" text-anchor="middle" class="step-detail">Check all assertions</text>
+
+  <!-- Outcomes -->
+  <line x1="325" y1="342" x2="390" y2="342" stroke="#22c55e" stroke-width="2" marker-end="url(#arrow-green)"/>
+  <rect x="395" y="325" width="100" height="36" rx="8" fill="#b2f2bb" stroke="#22c55e" stroke-width="2"/>
+  <text x="445" y="349" text-anchor="middle" class="result" fill="#22c55e">PASSED</text>
+
+  <line x1="325" y1="362" x2="390" y2="362" stroke="#ef4444" stroke-width="2" marker-end="url(#arrow-red)"/>
+  <rect x="395" y="345" width="100" height="36" rx="8" fill="#ffc9c9" stroke="#ef4444" stroke-width="2"/>
+  <text x="445" y="369" text-anchor="middle" class="result" fill="#ef4444">FAILED</text>
+
+  <!-- Right panel: Why isolation matters -->
+  <rect x="530" y="50" width="350" height="455" rx="10" fill="#dbe4ff" fill-opacity="0.2" stroke="#4a9eed" stroke-width="1"/>
+  <text x="705" y="75" text-anchor="middle" class="heading" fill="#4a9eed">Why isolation matters</text>
+
+  <!-- Project directory -->
+  <rect x="550" y="95" width="150" height="140" rx="6" fill="#fff3bf" fill-opacity="0.5" stroke="#f59e0b" stroke-width="1"/>
+  <text x="625" y="115" text-anchor="middle" class="step-label" fill="#b45309">Project directory</text>
+  <text x="570" y="138" class="code">main.nf</text>
+  <text x="570" y="155" class="code">greetings.csv</text>
+  <text x="570" y="172" class="code">tests/</text>
+  <text x="570" y="189" class="code">results/</text>
+
+  <!-- Not equal -->
+  <text x="720" y="172" text-anchor="middle" font-size="24" font-weight="700" fill="#ef4444">&#x2260;</text>
+
+  <!-- Test directory -->
+  <rect x="740" y="95" width="120" height="140" rx="6" fill="#d0bfff" fill-opacity="0.5" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="800" y="115" text-anchor="middle" class="step-label" fill="#8b5cf6">Test directory</text>
+  <text x="758" y="138" class="code">.nf-test/tests/</text>
+  <text x="768" y="155" class="code">&lt;hash&gt;/</text>
+  <text x="778" y="172" class="code">meta/</text>
+  <text x="778" y="192" class="code" fill="#999999">(empty!)</text>
+
+  <!-- Pitfall callout -->
+  <rect x="550" y="260" width="310" height="130" rx="8" fill="#ffc9c9" fill-opacity="0.3" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="570" y="283" class="heading" fill="#ef4444">Common pitfall</text>
+  <text x="570" y="305" class="note">Files like greetings.csv are NOT</text>
+  <text x="570" y="322" class="note">available in the test directory.</text>
+  <text x="570" y="348" class="note" font-weight="500" fill="#444444">Use ${projectDir} to reference</text>
+  <text x="570" y="365" class="note" font-weight="500" fill="#444444">files from the original project.</text>
+
+  <!-- Fix example -->
+  <rect x="550" y="410" width="310" height="80" rx="6" fill="#b2f2bb" fill-opacity="0.3" stroke="#22c55e" stroke-width="1"/>
+  <text x="570" y="432" class="step-label" fill="#22c55e">Solution:</text>
+  <text x="570" y="455" class="code">params {</text>
+  <text x="580" y="472" class="code">input_file = "${projectDir}/greetings.csv"</text>
+  <text x="570" y="484" class="code">}</text>
+</svg>

--- a/docs/en/docs/side_quests/img/nf-test/test-structure-anatomy.excalidraw.svg
+++ b/docs/en/docs/side_quests/img/nf-test/test-structure-anatomy.excalidraw.svg
@@ -1,0 +1,89 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 580" width="1000" height="580">
+  <!-- svg-source:excalidraw -->
+  <style>
+    text { font-family: "Segoe UI", system-ui, -apple-system, sans-serif; }
+    .title { font-size: 22px; font-weight: 600; fill: #1e1e1e; }
+    .heading { font-size: 16px; font-weight: 600; }
+    .keyword { font-size: 13px; font-family: "SF Mono", "Fira Code", monospace; }
+    .code { font-size: 12px; font-family: "SF Mono", "Fira Code", monospace; fill: #444444; }
+    .note { font-size: 12px; fill: #666666; }
+    .diff { font-size: 13px; fill: #666666; }
+  </style>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" class="title">nf-test Structure: Pipeline vs Process Tests</text>
+
+  <!-- Pipeline test (left side) -->
+  <text x="225" y="60" text-anchor="middle" class="heading" fill="#4a9eed">Pipeline-level test</text>
+
+  <!-- Outer block -->
+  <rect x="20" y="75" width="430" height="430" rx="10" fill="#dbe4ff" fill-opacity="0.25" stroke="#4a9eed" stroke-width="2"/>
+  <text x="35" y="97" class="keyword" fill="#4a9eed">nextflow_pipeline {</text>
+
+  <!-- Metadata -->
+  <rect x="40" y="110" width="390" height="52" rx="6" fill="#a5d8ff" fill-opacity="0.5" stroke="#4a9eed" stroke-width="1"/>
+  <text x="55" y="131" class="code">name  "Test Workflow main.nf"</text>
+  <text x="55" y="150" class="code">script  "main.nf"</text>
+
+  <!-- Test block -->
+  <rect x="40" y="178" width="390" height="310" rx="6" fill="#ffffff" stroke="#4a9eed" stroke-width="1"/>
+  <text x="55" y="198" class="keyword" fill="#4a9eed">test("Should run successfully...") {</text>
+
+  <!-- When block -->
+  <rect x="60" y="212" width="350" height="105" rx="6" fill="#fff3bf" fill-opacity="0.5" stroke="#f59e0b" stroke-width="1"/>
+  <text x="75" y="232" class="keyword" fill="#f59e0b">when {</text>
+  <rect x="80" y="242" width="310" height="55" rx="4" fill="#ffffff" stroke="#f59e0b" stroke-width="0.5"/>
+  <text x="95" y="260" class="keyword" fill="#f59e0b">params {</text>
+  <text x="115" y="280" class="code" fill="#888888">input_file = "${projectDir}/..."</text>
+  <text x="75" y="308" class="code" fill="#f59e0b">}</text>
+
+  <!-- Then block -->
+  <rect x="60" y="330" width="350" height="140" rx="6" fill="#b2f2bb" fill-opacity="0.3" stroke="#22c55e" stroke-width="1"/>
+  <text x="75" y="350" class="keyword" fill="#22c55e">then {</text>
+  <text x="95" y="373" class="code">assert workflow.success</text>
+  <text x="95" y="393" class="code">assert workflow.trace</text>
+  <text x="115" y="410" class="code">.tasks().size() == 6</text>
+  <text x="95" y="430" class="code">assert file(...).exists()</text>
+  <text x="75" y="455" class="code" fill="#22c55e">}</text>
+
+  <!-- Process test (right side) -->
+  <text x="735" y="60" text-anchor="middle" class="heading" fill="#8b5cf6">Process-level test</text>
+
+  <!-- Outer block -->
+  <rect x="530" y="75" width="450" height="430" rx="10" fill="#e5dbff" fill-opacity="0.25" stroke="#8b5cf6" stroke-width="2"/>
+  <text x="545" y="97" class="keyword" fill="#8b5cf6">nextflow_process {</text>
+
+  <!-- Metadata -->
+  <rect x="550" y="110" width="410" height="52" rx="6" fill="#d0bfff" fill-opacity="0.5" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="565" y="131" class="code">name  "Test Process sayHello"</text>
+  <text x="565" y="150" class="code">script  "main.nf"   process  "sayHello"</text>
+
+  <!-- Test block -->
+  <rect x="550" y="178" width="410" height="310" rx="6" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="565" y="198" class="keyword" fill="#8b5cf6">test("Should produce correct output") {</text>
+
+  <!-- When block -->
+  <rect x="570" y="212" width="370" height="105" rx="6" fill="#fff3bf" fill-opacity="0.5" stroke="#f59e0b" stroke-width="1"/>
+  <text x="585" y="232" class="keyword" fill="#f59e0b">when {</text>
+  <rect x="590" y="242" width="330" height="55" rx="4" fill="#ffffff" stroke="#f59e0b" stroke-width="0.5"/>
+  <text x="605" y="260" class="keyword" fill="#f59e0b">process {</text>
+  <text x="625" y="280" class="code" fill="#888888">input[0] = "hello"</text>
+  <text x="585" y="308" class="code" fill="#f59e0b">}</text>
+
+  <!-- Then block -->
+  <rect x="570" y="330" width="370" height="140" rx="6" fill="#b2f2bb" fill-opacity="0.3" stroke="#22c55e" stroke-width="1"/>
+  <text x="585" y="350" class="keyword" fill="#22c55e">then {</text>
+  <text x="605" y="373" class="code">assert process.success</text>
+  <text x="605" y="396" class="code">assert snapshot(process.out)</text>
+  <text x="625" y="413" class="code">.match()</text>
+  <text x="585" y="455" class="code" fill="#22c55e">}</text>
+
+  <!-- Key difference callout -->
+  <rect x="20" y="525" width="960" height="45" rx="8" fill="#fff3bf" fill-opacity="0.4" stroke="#f59e0b" stroke-width="1"/>
+  <text x="35" y="545" class="diff" font-weight="600" fill="#1e1e1e">Key difference:</text>
+  <text x="150" y="545" class="diff">Pipeline tests use</text>
+  <text x="280" y="545" class="keyword" fill="#4a9eed">params {}</text>
+  <text x="345" y="545" class="diff">to configure the whole run. Process tests use</text>
+  <text x="645" y="545" class="keyword" fill="#8b5cf6">process {}</text>
+  <text x="716" y="545" class="diff">to provide direct inputs.</text>
+</svg>

--- a/docs/en/docs/side_quests/img/nf-test/testing-strategy.excalidraw.svg
+++ b/docs/en/docs/side_quests/img/nf-test/testing-strategy.excalidraw.svg
@@ -1,0 +1,95 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 530" width="1000" height="530">
+  <!-- svg-source:excalidraw -->
+  <style>
+    text { font-family: "Segoe UI", system-ui, -apple-system, sans-serif; }
+    .title { font-size: 22px; font-weight: 600; fill: #1e1e1e; }
+    .heading { font-size: 15px; font-weight: 600; }
+    .label { font-size: 13px; font-weight: 500; fill: #1e1e1e; }
+    .detail { font-size: 11px; fill: #666666; }
+    .code { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; fill: #444444; }
+    .result { font-size: 18px; font-weight: 600; }
+    .command { font-size: 16px; font-family: "SF Mono", "Fira Code", monospace; fill: #999999; }
+  </style>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1e1e1e"/>
+    </marker>
+    <marker id="arrow-dash" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#22c55e"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" class="title">Complete Testing Strategy</text>
+  <text x="500" y="52" text-anchor="middle" class="command">nf-test test .</text>
+
+  <!-- Pipeline-level tests zone -->
+  <rect x="15" y="70" width="970" height="165" rx="10" fill="#dbe4ff" fill-opacity="0.2" stroke="#4a9eed" stroke-width="1.5"/>
+  <text x="35" y="95" class="heading" fill="#4a9eed">Pipeline-level tests</text>
+  <text x="35" y="112" class="code" fill="#4a9eed">tests/main.nf.test</text>
+
+  <!-- Test 1 -->
+  <rect x="35" y="125" width="290" height="90" rx="8" fill="#a5d8ff" fill-opacity="0.5" stroke="#4a9eed" stroke-width="1"/>
+  <text x="50" y="147" class="label">Test 1: Correct process count</text>
+  <text x="50" y="168" class="code">assert workflow.success</text>
+  <text x="50" y="185" class="code">assert workflow.trace.tasks().size() == 6</text>
+
+  <!-- Test 2 -->
+  <rect x="345" y="125" width="290" height="90" rx="8" fill="#a5d8ff" fill-opacity="0.5" stroke="#4a9eed" stroke-width="1"/>
+  <text x="360" y="147" class="label">Test 2: Correct output files</text>
+  <text x="360" y="168" class="code">assert file("$launchDir/results/</text>
+  <text x="370" y="185" class="code">Hello-output.txt").exists()</text>
+  <text x="360" y="202" class="detail">... for all 6 expected files</text>
+
+  <!-- What pipeline tests cover -->
+  <rect x="660" y="125" width="305" height="90" rx="8" fill="#fff3bf" fill-opacity="0.5" stroke="#f59e0b" stroke-width="1"/>
+  <text x="675" y="147" class="label" fill="#b45309">Pipeline tests cover:</text>
+  <text x="685" y="168" class="detail">End-to-end execution</text>
+  <text x="685" y="185" class="detail">File publishing to results/</text>
+  <text x="685" y="202" class="detail">Process orchestration (all 6 tasks)</text>
+
+  <!-- Process-level tests zone -->
+  <rect x="15" y="260" width="970" height="175" rx="10" fill="#e5dbff" fill-opacity="0.2" stroke="#8b5cf6" stroke-width="1.5"/>
+  <text x="35" y="285" class="heading" fill="#8b5cf6">Process-level tests</text>
+
+  <!-- sayHello process test -->
+  <rect x="35" y="300" width="455" height="120" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="50" y="320" class="code" fill="#8b5cf6">tests/main.sayhello.nf.test</text>
+
+  <rect x="50" y="330" width="280" height="40" rx="6" fill="#d0bfff" fill-opacity="0.4" stroke="#8b5cf6" stroke-width="0.5"/>
+  <text x="65" y="347" class="label">Test: Expected greeting content</text>
+  <text x="65" y="362" class="detail">Content assertion (readLines, contains)</text>
+
+  <rect x="50" y="380" width="130" height="28" rx="4" fill="#fff3bf" fill-opacity="0.5" stroke="#f59e0b" stroke-width="0.5"/>
+  <text x="65" y="399" class="code">input: "hello"</text>
+
+  <line x1="180" y1="394" x2="200" y2="394" stroke="#1e1e1e" stroke-width="1" marker-end="url(#arrow)"/>
+
+  <rect x="205" y="380" width="150" height="28" rx="4" fill="#b2f2bb" fill-opacity="0.5" stroke="#22c55e" stroke-width="0.5"/>
+  <text x="220" y="399" class="code">hello-output.txt</text>
+
+  <!-- convertToUpper process test -->
+  <rect x="510" y="300" width="455" height="120" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="525" y="320" class="code" fill="#8b5cf6">tests/main.converttoupper.nf.test</text>
+
+  <rect x="525" y="330" width="280" height="40" rx="6" fill="#d0bfff" fill-opacity="0.4" stroke="#8b5cf6" stroke-width="0.5"/>
+  <text x="540" y="347" class="label">Test: Correct uppercase output</text>
+  <text x="540" y="362" class="detail">Snapshot assertion (.snap file)</text>
+
+  <rect x="525" y="380" width="155" height="28" rx="4" fill="#fff3bf" fill-opacity="0.5" stroke="#f59e0b" stroke-width="0.5"/>
+  <text x="540" y="399" class="code">input: greetings.csv</text>
+
+  <line x1="680" y1="394" x2="700" y2="394" stroke="#1e1e1e" stroke-width="1" marker-end="url(#arrow)"/>
+
+  <rect x="705" y="380" width="155" height="28" rx="4" fill="#b2f2bb" fill-opacity="0.5" stroke="#22c55e" stroke-width="0.5"/>
+  <text x="720" y="399" class="code">UPPER-*.txt</text>
+
+  <!-- Result -->
+  <line x1="260" y1="435" x2="420" y2="475" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="6 4" marker-end="url(#arrow-dash)"/>
+  <line x1="740" y1="435" x2="580" y2="475" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="6 4" marker-end="url(#arrow-dash)"/>
+
+  <rect x="330" y="468" width="340" height="50" rx="10" fill="#b2f2bb" stroke="#22c55e" stroke-width="2"/>
+  <text x="500" y="491" text-anchor="middle" class="result" fill="#22c55e">SUCCESS: Executed 4 tests</text>
+  <text x="500" y="510" text-anchor="middle" class="detail">2 pipeline + 1 sayHello + 1 convertToUpper</text>
+</svg>

--- a/docs/en/docs/side_quests/img/nf-test/workflow-data-flow.excalidraw.svg
+++ b/docs/en/docs/side_quests/img/nf-test/workflow-data-flow.excalidraw.svg
@@ -1,0 +1,100 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 340" width="1100" height="340">
+  <!-- svg-source:excalidraw -->
+  <style>
+    text { font-family: "Segoe UI", system-ui, -apple-system, sans-serif; }
+    .title { font-size: 22px; font-weight: 600; fill: #1e1e1e; }
+    .label { font-size: 14px; font-weight: 500; }
+    .sublabel { font-size: 12px; fill: #888888; }
+    .file-text { font-size: 11px; fill: #444444; }
+  </style>
+
+  <!-- Title -->
+  <text x="550" y="28" text-anchor="middle" class="title">Workflow Data Flow</text>
+
+  <!-- Input: greetings.csv -->
+  <rect x="20" y="60" width="150" height="55" rx="8" fill="#fff3bf" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="95" y="85" text-anchor="middle" class="label" fill="#b45309">greetings.csv</text>
+  <text x="95" y="102" text-anchor="middle" class="sublabel">Hello, Bonjour, Hola</text>
+
+  <!-- Arrow: csv to splitCsv -->
+  <line x1="170" y1="88" x2="210" y2="88" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="190" y="80" text-anchor="middle" class="sublabel">splitCsv</text>
+
+  <!-- Channel items zone -->
+  <rect x="215" y="48" width="120" height="175" rx="8" fill="#dbe4ff" fill-opacity="0.4" stroke="#4a9eed" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="275" y="66" text-anchor="middle" class="sublabel" fill="#4a9eed">Channel</text>
+
+  <rect x="225" y="74" width="100" height="32" rx="6" fill="#a5d8ff" stroke="#4a9eed" stroke-width="1"/>
+  <text x="275" y="95" text-anchor="middle" class="file-text">"Hello"</text>
+
+  <rect x="225" y="114" width="100" height="32" rx="6" fill="#a5d8ff" stroke="#4a9eed" stroke-width="1"/>
+  <text x="275" y="135" text-anchor="middle" class="file-text">"Bonjour"</text>
+
+  <rect x="225" y="154" width="100" height="32" rx="6" fill="#a5d8ff" stroke="#4a9eed" stroke-width="1"/>
+  <text x="275" y="175" text-anchor="middle" class="file-text">"Hola"</text>
+
+  <!-- Arrows: channel to sayHello -->
+  <line x1="325" y1="90" x2="380" y2="90" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="325" y1="130" x2="380" y2="130" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="325" y1="170" x2="380" y2="170" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- sayHello zone -->
+  <rect x="385" y="48" width="175" height="175" rx="8" fill="#d3f9d8" fill-opacity="0.4" stroke="#22c55e" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="472" y="66" text-anchor="middle" class="label" fill="#22c55e">sayHello</text>
+
+  <rect x="395" y="74" width="155" height="32" rx="6" fill="#b2f2bb" stroke="#22c55e" stroke-width="1"/>
+  <text x="472" y="95" text-anchor="middle" class="file-text">Hello-output.txt</text>
+
+  <rect x="395" y="114" width="155" height="32" rx="6" fill="#b2f2bb" stroke="#22c55e" stroke-width="1"/>
+  <text x="472" y="135" text-anchor="middle" class="file-text">Bonjour-output.txt</text>
+
+  <rect x="395" y="154" width="155" height="32" rx="6" fill="#b2f2bb" stroke="#22c55e" stroke-width="1"/>
+  <text x="472" y="175" text-anchor="middle" class="file-text">Hola-output.txt</text>
+
+  <!-- Arrows: sayHello to convertToUpper -->
+  <line x1="550" y1="90" x2="605" y2="90" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="550" y1="130" x2="605" y2="130" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="550" y1="170" x2="605" y2="170" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- convertToUpper zone -->
+  <rect x="610" y="48" width="230" height="175" rx="8" fill="#e5dbff" fill-opacity="0.4" stroke="#8b5cf6" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="725" y="66" text-anchor="middle" class="label" fill="#8b5cf6">convertToUpper</text>
+
+  <rect x="620" y="74" width="210" height="32" rx="6" fill="#d0bfff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="725" y="95" text-anchor="middle" class="file-text">UPPER-Hello-output.txt</text>
+
+  <rect x="620" y="114" width="210" height="32" rx="6" fill="#d0bfff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="725" y="135" text-anchor="middle" class="file-text">UPPER-Bonjour-output.txt</text>
+
+  <rect x="620" y="154" width="210" height="32" rx="6" fill="#d0bfff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="725" y="175" text-anchor="middle" class="file-text">UPPER-Hola-output.txt</text>
+
+  <!-- Arrow: convertToUpper to results -->
+  <line x1="840" y1="130" x2="880" y2="130" stroke="#1e1e1e" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Results directory -->
+  <rect x="885" y="48" width="140" height="175" rx="8" fill="#ffd8a8" fill-opacity="0.5" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="955" y="70" text-anchor="middle" class="label" fill="#b45309">results/</text>
+  <text x="955" y="120" text-anchor="middle" class="sublabel">6 output files</text>
+  <text x="955" y="136" text-anchor="middle" class="sublabel">published here</text>
+
+  <!-- Legend -->
+  <text x="30" y="268" class="label" fill="#1e1e1e">Legend:</text>
+  <rect x="90" y="255" width="16" height="16" rx="3" fill="#fff3bf" stroke="#f59e0b" stroke-width="1"/>
+  <text x="112" y="268" class="sublabel">Input data</text>
+  <rect x="190" y="255" width="16" height="16" rx="3" fill="#a5d8ff" stroke="#4a9eed" stroke-width="1"/>
+  <text x="212" y="268" class="sublabel">Channel items</text>
+  <rect x="310" y="255" width="16" height="16" rx="3" fill="#b2f2bb" stroke="#22c55e" stroke-width="1"/>
+  <text x="332" y="268" class="sublabel">sayHello outputs</text>
+  <rect x="450" y="255" width="16" height="16" rx="3" fill="#d0bfff" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="472" y="268" class="sublabel">convertToUpper outputs</text>
+  <rect x="625" y="255" width="16" height="16" rx="3" fill="#ffd8a8" stroke="#f59e0b" stroke-width="1"/>
+  <text x="647" y="268" class="sublabel">Published results</text>
+
+  <!-- Arrow marker -->
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#1e1e1e"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/en/docs/side_quests/nf-test.md
+++ b/docs/en/docs/side_quests/nf-test.md
@@ -104,6 +104,14 @@ The workflow we'll be testing is a subset of the Hello workflow built in [Hello 
     In this side quest, we use an intermediate form of the Hello workflow that only contains the first two processes. <!-- TODO: change this to use the full finished workflow as suggested in https://github.com/nextflow-io/training/issues/735 -->
 
 The subset we'll be working with is composed of two processes: `sayHello` and `convertToUpper`.
+The following diagram shows how data flows through the workflow.
+
+<!-- prettier-ignore-start -->
+<figure class="excalidraw">
+--8<-- "docs/en/docs/side_quests/img/nf-test/workflow-data-flow.excalidraw.svg"
+</figure>
+<!-- prettier-ignore-end -->
+
 You can see the full workflow code below.
 
 ??? example "Workflow code"
@@ -384,6 +392,12 @@ ERROR ~ No such file or directory: /workspaces/training/side-quests/nf-test/.nf-
 ```
 
 So what was the issue? Remember the pipeline has a greetings.csv file in the project directory. When nf-test runs the pipeline, it will look for this file, but it can't find it. The file is there, what's happening? Well, if we look at the path we can see the test is occurring in the path `./nf-test/tests/longHashString/`. Just like Nextflow, nf-test creates a new directory for each test to keep everything isolated. The data file is not located in there so we must correct the path to the file in the original test.
+
+<!-- prettier-ignore-start -->
+<figure class="excalidraw">
+--8<-- "docs/en/docs/side_quests/img/nf-test/test-execution-flow.excalidraw.svg"
+</figure>
+<!-- prettier-ignore-end -->
 
 Let's go back to the test file and change the path to the file in the `when` block.
 
@@ -693,6 +707,14 @@ nextflow_process {
 
 As before, we start with the test details, followed by the `when` and `then` blocks. However, we also have an additional `process` block which allows us to define the inputs to the process.
 
+The following diagram compares the structure of pipeline-level and process-level tests side by side.
+
+<!-- prettier-ignore-start -->
+<figure class="excalidraw">
+--8<-- "docs/en/docs/side_quests/img/nf-test/test-structure-anatomy.excalidraw.svg"
+</figure>
+<!-- prettier-ignore-end -->
+
 Let's run the test to see if it works.
 
 ```bash title="nf-test pipeline pass"
@@ -858,6 +880,12 @@ SUCCESS: Executed 1 tests in 1.685s
 Success! The test passes because the `sayHello` process ran successfully and the output matched the snapshot.
 
 ### 2.3. Alternative to Snapshots: Direct Content Assertions
+
+<!-- prettier-ignore-start -->
+<figure class="excalidraw">
+--8<-- "docs/en/docs/side_quests/img/nf-test/snapshot-vs-content.excalidraw.svg"
+</figure>
+<!-- prettier-ignore-end -->
 
 While snapshots are great for catching any changes in output, sometimes you want to verify specific content without being so strict about the entire file matching. For example:
 
@@ -1107,6 +1135,12 @@ Learn how to run tests for everything at once!
 Running nf-test on each component is fine, but laborious and error prone. Can't we just test everything at once?
 
 Yes we can!
+
+<!-- prettier-ignore-start -->
+<figure class="excalidraw">
+--8<-- "docs/en/docs/side_quests/img/nf-test/testing-strategy.excalidraw.svg"
+</figure>
+<!-- prettier-ignore-end -->
 
 Let's run nf-test on the entire repo.
 


### PR DESCRIPTION
**Not a serious PR, just testing Excalidraw MCP**

## Summary
- Adds 5 SVG diagrams to the nf-test side quest to improve visual understanding of key concepts
- **Workflow data flow** (Section 0): Shows how data flows from `greetings.csv` through `splitCsv`, `sayHello`, and `convertToUpper` to `results/`
- **Test execution flow** (Section 1.2): Illustrates nf-test's isolation model and the common `projectDir` pitfall
- **Test structure anatomy** (Section 2.1): Side-by-side comparison of pipeline-level vs process-level test structure
- **Snapshot vs content assertions** (Section 2.3): Visual comparison of trade-offs between the two assertion approaches
- **Testing strategy overview** (Section 3): Shows all 4 tests running together with `nf-test test .`

## Notes
- SVGs use the `.excalidraw.svg` naming convention per CONTRIBUTING.md
- Diagrams are embedded using the `--8<--` snippet syntax with `<figure class="excalidraw">`
- Files are placed in `docs/en/docs/side_quests/img/nf-test/`

## Test plan
- [ ] Preview locally to verify diagrams render correctly in both light and dark mode
- [ ] Check that diagram placement flows naturally with the surrounding text
- [ ] Verify no layout issues on mobile/narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)