### PR TITLE
Add parallel translation support

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -412,6 +412,9 @@ uv run translate.py sync <lang> --dry-run
 # Sync all translations (update outdated + add missing + remove orphaned)
 uv run translate.py sync <lang>
 
+# Sync with lower parallelism (default: 50 concurrent translations)
+uv run translate.py sync <lang> --parallel 10
+
 # Sync with filter pattern
 uv run translate.py sync <lang> --include hello_nextflow
 


### PR DESCRIPTION
Translation is suuuuuper slow when prompts are updated and we need to update all files. This adds a tonne of parallelisation.

## Summary

- Add async parallel translation with `--parallel` flag (default: 50 concurrent)
- Sort files largest-first to avoid long-pole problem at the end
- CI-friendly progress output with 10-second heartbeat showing files/lines remaining
- Jittered exponential backoff for rate limit handling

## Example Output

```
Translating 83 files with parallel=50. Largest files first.

[00:00] Starting: 83 files, 35.4k lines
[00:10] 12/83 files complete, 34.2k lines remaining, 50 files underway
[00:20] 45/83 files complete, 18.5k lines remaining, 38 files underway
[01:30] 80/83 files complete,  1.2k lines remaining,  3 files underway
[01:45] Translation complete: 83/83 files, 0 lines remaining
```

## Performance

For a full language re-translation (83 files):
- **Before**: ~10-15 minutes (sequential)
- **After**: ~2-3 minutes (parallel)

## Technical Details

- Uses `AsyncAnthropic` client with connection pooling (single shared client)
- Semaphore limits concurrent API requests
- Jittered backoff prevents thundering herd on rate limits
- Files sorted by line count (descending) so largest start first
- Progress tracker uses asyncio.Lock for thread-safe updates