### PR TITLE
Add verbose JSON logging for translation runs

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -75,7 +75,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         working-directory: _scripts
-        run: uv run -q translate.py sync ${{ matrix.language }}
+        run: uv run -q translate.py sync ${{ matrix.language }} --log translate-${{ matrix.language }}.json
 
       - name: Dry run ${{ matrix.language }}
         if: ${{ inputs.dry_run }}
@@ -92,6 +92,15 @@ jobs:
           name: translation-${{ matrix.language }}
           path: docs/${{ matrix.language }}/docs/
           retention-days: 1
+          if-no-files-found: ignore
+
+      - name: Upload translation log
+        if: ${{ !inputs.dry_run && always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: log-${{ matrix.language }}
+          path: _scripts/translate-${{ matrix.language }}.json
+          retention-days: 7
           if-no-files-found: ignore
 
   merge:


### PR DESCRIPTION
## Summary

- Add `--log` flag to `sync` command for detailed per-file logging
- Workflow uploads logs as artifacts for debugging

## Log Contents

**Per-file entries:**
- `filename`, `started_at`, `finished_at`, `duration_s`
- `input_lines`, `input_hash` (English source)
- `output_lines`, `output_hash` (translation after post-processing)
- `changed` (did output differ from existing file?)
- `model`, `input_tokens`, `output_tokens` (API metadata)
- `stop_reason`, `api_calls` (continuation count)
- `error` (if failed)

**Top-level metadata:**
- `baseline`, `language`, `parallel`, `total_files`
- `files_changed`, `files_unchanged`, `files_failed`

## Use Case

Helps debug cases like #852 where `03_hello_workflow.md` showed no changes despite English source being updated. The log will show whether the file was processed and what the `changed` flag was.

Logs are retained for 7 days as workflow artifacts.