### PR TITLE
Add translation fix mode and post-translation verification

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -13,6 +13,13 @@ on:
   # Manual trigger
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Translation mode"
+        type: choice
+        options:
+          - normal
+          - fix
+        default: normal
       language:
         description: "Language code (empty = all)"
         type: string
@@ -47,10 +54,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           uv run -q translate.py ci-detect \
             ${{ inputs.language && format('--language "{0}"', inputs.language) || '' }} \
             ${{ inputs.since && format('--since "{0}"', inputs.since) || '' }} \
+            ${{ inputs.mode == 'fix' && '--fix' || '' }} \
             >> $GITHUB_OUTPUT
 
   translate:
@@ -75,15 +84,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         working-directory: _scripts
-        run: uv run -q translate.py sync ${{ matrix.language }} --log translate-${{ matrix.language }}.json
+        run: >
+          uv run -q translate.py sync ${{ matrix.language }}
+          --log translate-${{ matrix.language }}.json
+          ${{ inputs.mode == 'fix' && '--fix' || '' }}
 
       - name: Dry run ${{ matrix.language }}
         if: ${{ inputs.dry_run }}
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         working-directory: _scripts
-        run: uv run -q translate.py sync ${{ matrix.language }} --dry-run
+        run: >
+          uv run -q translate.py sync ${{ matrix.language }}
+          --dry-run
+          ${{ inputs.mode == 'fix' && '--fix' || '' }}
 
       - name: Upload translation artifacts
         if: ${{ !inputs.dry_run && success() }}


### PR DESCRIPTION
Try to make the translation scripts better at auto-detecting truncated files and similar, and self-healing.

Also adds a new manual github actions run option to search the translated materials for anything that looks wrong.

<details>

Add a 'fix' mode to the translation workflow that scans all translation files for structural and semantic issues, then re-translates broken ones. Add post-translation verification with automatic retry (up to 2 retries) for files that fail checks after translation.

Verification checks: missing files, code fence wrapping, header/code block count mismatches, frontmatter presence, admonition count, and Claude-based semantic matching of first/last sentences to detect truncation.

Also fixes: silent StructureMismatchError swallowing in post_process_file, pre-existing bug passing language as github_token to get_translation_baseline.

</details>