### PR TITLE
fix-typo-in-sidequest-metadata

### DIFF
--- a/docs/de/docs/side_quests/metadata.md
+++ b/docs/de/docs/side_quests/metadata.md
@@ -627,7 +627,7 @@ Wenn du mit dem `+`-Operator noch nicht vertraut bist oder wenn dies verwirrend 
     Wir haben also effektiv transformiert:
 
     ```groovy
-    [id: 'sampleA', character: 'squirrel'], 'it'
+    [id: 'sampleA', character: 'squirrel'], 'fr'
     ```
 
     in:

--- a/docs/en/docs/side_quests/metadata.md
+++ b/docs/en/docs/side_quests/metadata.md
@@ -625,7 +625,7 @@ If you're not yet familiar with the `+` operator, or if this seems confusing, ta
     So we've effectively transformed:
 
     ```groovy
-    [id: 'sampleA', character: 'squirrel'], 'it'
+    [id: 'sampleA', character: 'squirrel'], 'fr'
     ```
 
     into:

--- a/docs/es/docs/side_quests/metadata.md
+++ b/docs/es/docs/side_quests/metadata.md
@@ -627,7 +627,7 @@ Si aún no está familiarizado con el operador `+`, o si esto parece confuso, to
     Entonces efectivamente hemos transformado:
 
     ```groovy
-    [id: 'sampleA', character: 'squirrel'], 'it'
+    [id: 'sampleA', character: 'squirrel'], 'fr'
     ```
 
     en:

--- a/docs/fr/docs/side_quests/metadata.md
+++ b/docs/fr/docs/side_quests/metadata.md
@@ -627,7 +627,7 @@ Si vous n'êtes pas encore familier avec l'opérateur `+`, ou si cela semble dé
     Donc nous avons effectivement transformé :
 
     ```groovy
-    [id: 'sampleA', character: 'squirrel'], 'it'
+    [id: 'sampleA', character: 'squirrel'], 'fr'
     ```
 
     en :

--- a/docs/hi/docs/side_quests/metadata.md
+++ b/docs/hi/docs/side_quests/metadata.md
@@ -627,7 +627,7 @@ nextflow run main.nf
     इसलिए हमने प्रभावी रूप से परिवर्तित किया है:
 
     ```groovy
-    [id: 'sampleA', character: 'squirrel'], 'it'
+    [id: 'sampleA', character: 'squirrel'], 'fr'
     ```
 
     में:

--- a/docs/it/docs/side_quests/metadata.md
+++ b/docs/it/docs/side_quests/metadata.md
@@ -627,7 +627,7 @@ Se non ha ancora familiarità con l'operatore `+`, o se questo sembra confuso, s
     Quindi abbiamo effettivamente trasformato:
 
     ```groovy
-    [id: 'sampleA', character: 'squirrel'], 'it'
+    [id: 'sampleA', character: 'squirrel'], 'fr'
     ```
 
     in:

--- a/docs/ko/docs/side_quests/metadata.md
+++ b/docs/ko/docs/side_quests/metadata.md
@@ -627,7 +627,7 @@ nextflow run main.nf
     따라서 효과적으로 다음을 변환했습니다:
 
     ```groovy
-    [id: 'sampleA', character: 'squirrel'], 'it'
+    [id: 'sampleA', character: 'squirrel'], 'fr'
     ```
 
     다음으로:

--- a/docs/pl/docs/side_quests/metadata.md
+++ b/docs/pl/docs/side_quests/metadata.md
@@ -627,7 +627,7 @@ Jeśli nie jesteś jeszcze zaznajomiony z operatorem `+`, lub jeśli wydaje się
     Więc skutecznie przekształciliśmy:
 
     ```groovy
-    [id: 'sampleA', character: 'squirrel'], 'it'
+    [id: 'sampleA', character: 'squirrel'], 'fr'
     ```
 
     w:

--- a/docs/pt/docs/side_quests/metadata.md
+++ b/docs/pt/docs/side_quests/metadata.md
@@ -627,7 +627,7 @@ Se você ainda não está familiarizado com o operador `+`, ou se isso parece co
     Então, efetivamente transformamos:
 
     ```groovy
-    [id: 'sampleA', character: 'squirrel'], 'it'
+    [id: 'sampleA', character: 'squirrel'], 'fr'
     ```
 
     em:

--- a/docs/tr/docs/side_quests/metadata.md
+++ b/docs/tr/docs/side_quests/metadata.md
@@ -627,7 +627,7 @@ Workflow'da yapmanız gereken düzenlemeler şunlardır:
     Yani etkin bir şekilde şunu dönüştürdük:
 
     ```groovy
-    [id: 'sampleA', character: 'squirrel'], 'it'
+    [id: 'sampleA', character: 'squirrel'], 'fr'
     ```
 
     şuna:


### PR DESCRIPTION
The language variable changed from 'fr' to 'it'. Fixing typo to match context.