### PR TITLE
Updated docs/ko/llm-prompt.md

### DIFF
--- a/docs/ko/llm-prompt.md
+++ b/docs/ko/llm-prompt.md
@@ -118,67 +118,66 @@ Note: Some terms use transliteration (음차) while others use actual Korean tra
 
 ### Transliterations (음차)
 
-| English   | Korean     | Notes                      |
-| --------- | ---------- | -------------------------- |
-| workflow  | 워크플로우 | Common transliteration     |
-| pipeline  | 파이프라인 | Common transliteration     |
-| terminal  | 터미널     | Common transliteration     |
-| container | 컨테이너   | Common transliteration     |
-| sidebar   | 사이드바   | Common transliteration     |
-| module    | 모듈       | Common transliteration     |
-| sample    | 샘플       | Common transliteration     |
-| tuple     | 튜플       | Common transliteration     |
-| index     | 인덱스     | Common transliteration     |
-| core      | 코어       | Common transliteration     |
-| directory | 디렉토리   | Transliteration acceptable |
-| file      | 파일       | Transliteration            |
-| assembling| 구성      | Transliteration            |
-| paired-end| 페어드 엔드 | Transliteration            |
-|genome reference |레퍼런스 게놈 |Common transliteration  |
+| English          | Korean        | Notes                      |
+| ---------------- | ------------- | -------------------------- |
+| workflow         | 워크플로우    | Common transliteration     |
+| pipeline         | 파이프라인    | Common transliteration     |
+| terminal         | 터미널        | Common transliteration     |
+| container        | 컨테이너      | Common transliteration     |
+| sidebar          | 사이드바      | Common transliteration     |
+| module           | 모듈          | Common transliteration     |
+| sample           | 샘플          | Common transliteration     |
+| tuple            | 튜플          | Common transliteration     |
+| index            | 인덱스        | Common transliteration     |
+| core             | 코어          | Common transliteration     |
+| directory        | 디렉토리      | Transliteration acceptable |
+| file             | 파일          | Transliteration            |
+| assembling       | 구성          | Transliteration            |
+| paired-end       | 페어드 엔드   | Transliteration            |
+| genome reference | 레퍼런스 게놈 | Common transliteration     |
 
 ### Actual Translations
 
-| English       | Korean      | Notes                                                                   |
-| ------------- | ----------- | ----------------------------------------------------------------------- |
-| archived      | 아카이브된  | Transliteration, not 보관된 (standard for tech contexts)                 |
-| channel       | 채널        | Transliteration but treated as translation                              |
-| dependency    | 의존성      | Not 종속성 (의존성 is standard in Korean tech community)                 |
-| gradually     | 단계적으로  | Not 점진적으로 (단계적으로 = step-by-step, better for tutorials)          |
-| parser        | 분석기      | Not 파서 (more formal, e.g., AWS uses 로그 분석기 for "Log parser")      |
-| process       | 프로세스    | Transliteration but treated as translation                              |
-| sleep         | 중지(sleep) | Not 절전 (power saving). Context: "Codespace goes to sleep" = 중지 상태  |
-| standalone    | 단독        | Not 독립 (political independence)                                       |
-| mini-course   | 단기 과정   | Not 미니 과정 (too casual)                                               |
-| wrap          | 적용하다    | Not 래핑하다 (sounds like physical packaging)                            |
-| mini-course   | 단기 과정   | Not 미니 과정 (too casual)                                              |
-| wrap          | 적용하다    | Not 래핑하다 (sounds like physical packaging)                           |
-| nested        | 내포된      | Not 중첩된 (sounds like 'overlapped')                                   |
-| training      | 교육        | Actual translation                                                      |
-| environment   | 환경        | Actual translation                                                      |
-| repository    | 저장소      | Actual translation                                                      |
-| file explorer | 파일 탐색기 | Mixed                                                                   |
-| main editor   | 메인 편집기 | Mixed                                                                   |
-| alignment     | 정렬        | Actual translation                                                      |
-| command       | 명령        | Actual translation                                                      |
-| directive     | 지시문      | Actual translation                                                      |
-| input         | 입력        | Actual translation                                                      |
-| output        | 출력        | Actual translation                                                      |
-| operator      | 연산자      | Actual translation                                                      |
-| parameter     | 매개변수    | Actual translation                                                      |
-| reference     | 참조        | Actual translation                                                      |
-| run           | 실행        | Actual translation                                                      |
-| task          | 작업        | Actual translation                                                      |
-| lowercase     | 소문자      | Actual translation                                                      |
-| materials     | 자료        | Actual translation                                                      |
-| course        | 과정        | Actual translation                                                      |
-| Nextflow command | Nextflow 명령어 | Actual translation                                               |
-| aggregate     | 결합        | Actual translation                                                      |
-| list of genomic intervals | 유전체 구간 목록 | Actual translation                                       |
-| germline      | 생식세포     | Actual translation                                                     |
-| guided exercise | 유도형 실습 | Not 안내 연습                                                          |
-| Customizing pipeline behavior | 파이프라인 동작의 맞춤화 | NOT 파이프라인 동작 사용자 정의                |
-| transcriptomics imaging | 전사체 이미지 | Actual translation                                           |
-
+| English                       | Korean                   | Notes                                                                   |
+| ----------------------------- | ------------------------ | ----------------------------------------------------------------------- |
+| archived                      | 아카이브된               | Transliteration, not 보관된 (standard for tech contexts)                |
+| channel                       | 채널                     | Transliteration but treated as translation                              |
+| dependency                    | 의존성                   | Not 종속성 (의존성 is standard in Korean tech community)                |
+| gradually                     | 단계적으로               | Not 점진적으로 (단계적으로 = step-by-step, better for tutorials)        |
+| parser                        | 분석기                   | Not 파서 (more formal, e.g., AWS uses 로그 분석기 for "Log parser")     |
+| process                       | 프로세스                 | Transliteration but treated as translation                              |
+| sleep                         | 중지(sleep)              | Not 절전 (power saving). Context: "Codespace goes to sleep" = 중지 상태 |
+| standalone                    | 단독                     | Not 독립 (political independence)                                       |
+| mini-course                   | 단기 과정                | Not 미니 과정 (too casual)                                              |
+| wrap                          | 적용하다                 | Not 래핑하다 (sounds like physical packaging)                           |
+| mini-course                   | 단기 과정                | Not 미니 과정 (too casual)                                              |
+| wrap                          | 적용하다                 | Not 래핑하다 (sounds like physical packaging)                           |
+| nested                        | 내포된                   | Not 중첩된 (sounds like 'overlapped')                                   |
+| training                      | 교육                     | Actual translation                                                      |
+| environment                   | 환경                     | Actual translation                                                      |
+| repository                    | 저장소                   | Actual translation                                                      |
+| file explorer                 | 파일 탐색기              | Mixed                                                                   |
+| main editor                   | 메인 편집기              | Mixed                                                                   |
+| alignment                     | 정렬                     | Actual translation                                                      |
+| command                       | 명령                     | Actual translation                                                      |
+| directive                     | 지시문                   | Actual translation                                                      |
+| input                         | 입력                     | Actual translation                                                      |
+| output                        | 출력                     | Actual translation                                                      |
+| operator                      | 연산자                   | Actual translation                                                      |
+| parameter                     | 매개변수                 | Actual translation                                                      |
+| reference                     | 참조                     | Actual translation                                                      |
+| run                           | 실행                     | Actual translation                                                      |
+| task                          | 작업                     | Actual translation                                                      |
+| lowercase                     | 소문자                   | Actual translation                                                      |
+| materials                     | 자료                     | Actual translation                                                      |
+| course                        | 과정                     | Actual translation                                                      |
+| Nextflow command              | Nextflow 명령어          | Actual translation                                                      |
+| aggregate                     | 결합                     | Actual translation                                                      |
+| list of genomic intervals     | 유전체 구간 목록         | Actual translation                                                      |
+| germline                      | 생식세포                 | Actual translation                                                      |
+| guided exercise               | 유도형 실습              | Not 안내 연습                                                           |
+| Customizing pipeline behavior | 파이프라인 동작의 맞춤화 | NOT 파이프라인 동작 사용자 정의                                         |
+| transcriptomics imaging       | 전사체 이미지            | Actual translation                                                      |
 
 ### Parsing Note
 
@@ -213,4 +212,3 @@ Note: "parser" is translated as 분석기, but "parsing" is typically transliter
 | Before  | 전     |
 | Gitpod  | Gitpod |
 | Local   | 로컬   |
-


### PR DESCRIPTION
As the result of the nf-core Hacakthon 2026 March from Seoul local hub, I have merged all the PRs from the attendees. 

We have added some translation/transliteration.

I considered updating `glossary.yml` also, but to make it simple we updated the `llm-prompt.md` file only.
