### PR TITLE
Updated SQ index and orientation pages

### DIFF
--- a/docs/en/docs/side_quests/index.md
+++ b/docs/en/docs/side_quests/index.md
@@ -2,53 +2,55 @@
 title: Side Quests
 hide:
   - toc
+page_type: index_page
+index_type: course
+additional_information:
+  technical_requirements: true
+  learning_objectives:
+    - Set up and configure a productive Nextflow development environment
+    - Apply advanced scripting patterns for complex data transformations
+    - Handle and propagate metadata through multi-step workflows
+    - Split and group data channels for parallel and serial processing
+    - Test Nextflow workflows using nf-test
+    - Compose complex pipelines from reusable named workflow modules
+    - Work efficiently with files using Nextflow file operations
+    - Debug common workflow issues systematically
+    - Use and build Nextflow plugins
+  audience_prerequisites:
+    - "**Audience:** This collection is designed for learners who have completed the Hello Nextflow beginner course and want to go deeper into specific topics."
+    - "**Skills:** Experience with the command line and familiarity with basic Nextflow concepts and tooling is assumed."
+    - "**Courses:** Must have completed [Hello Nextflow](../hello_nextflow/index.md) or equivalent."
 ---
 
 # Side Quests
 
-This is a collection of standalone training mini-courses that go deeper into specific topics. You can go through them in any order.
+**Side Quests are standalone training mini-courses that go deeper into specific Nextflow topics.**
 
-Let's get started! Click on the "Open in GitHub Codespaces" button below to launch the training environment (preferably in a separate tab), then read on while it loads.
+Each side quest can be taken independently, in any order, based on your interests and needs.
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
+<!-- additional_information -->
 
-## Prerequisites
+## Course overview
 
-The specific prerequisites of each mini-courses vary and are documented in the corresponding pages.
-Nevertheless, they all assume some minimal familiarity with the following:
+If this is your first time exploring the Side Quests, start with the [Orientation](./orientation.md) page for an overview of the training environment and materials.
 
-- Experience with the command line
-- Foundational Nextflow concepts and tooling covered in the [Hello Nextflow](../../hello_nextflow/) beginner training course.
+### Side Quests
 
-For technical requirements and environment setup, see the [Environment Setup](../../envsetup/) mini-course.
+| Side Quest                                                      | Summary                                                                  | Time Estimate |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------- |
+| [Development Environment](./dev_environment/)                   | Set up and configure a productive local Nextflow development environment | 45 mins       |
+| [Essential Scripting Patterns](./essential_scripting_patterns/) | Advanced scripting techniques for common workflow challenges             | 90 mins       |
+| [File Input Processing](./working_with_files/)                  | File handling, path operations, and organizing outputs                   | 45 mins       |
+| [Metadata and Meta Maps](./metadata/)                           | Using metadata maps to track and propagate sample information            | 45 mins       |
+| [Splitting and Grouping](./splitting_and_grouping/)             | Techniques for splitting and regrouping data channels                    | 45 mins       |
+| [Testing with nf-test](./nf_test/)                              | Writing and running tests for Nextflow workflows                         | 1 hour        |
+| [Troubleshooting Workflows](./debugging/)                       | Identifying and fixing common workflow errors                            | 1 hour        |
+| [Workflows of Workflows](./workflows_of_workflows/)             | Composing complex pipelines from reusable named workflow modules         | 30 mins       |
+| [Plugin Development](./plugin_development/)                     | Using and building Nextflow plugins                                      | 3 hours       |
 
-**If this is the first time you delve into the Side Quests, make sure to check out the [Orientation](./orientation.md) page first!**
+[Get started :material-arrow-right:](orientation.md){ .md-button .md-button--primary }
 
-Otherwise, select a side quest from the table below.
+<!-- Clearfix for float -->
+<div style="content: ''; clear: both; display: table;"></div>
 
-## Side Quests
-
-| Side Quest                                                               | Time Estimate for Teaching |
-| ------------------------------------------------------------------------ | -------------------------- |
-| [Nextflow development environment walkthrough](./dev_environment/)       | 45 mins                    |
-| [Essential Nextflow Scripting Patterns](./essential_scripting_patterns/) | 90 mins                    |
-| [Metadata in workflows](./metadata/)                                     | 45 mins                    |
-| [Splitting and Grouping](./splitting_and_grouping/)                      | 45 mins                    |
-| [Testing with nf-test](./nf_test/)                                       | 1 hour                     |
-| [Workflows of workflows](./workflows_of_workflows/)                      | 30 mins                    |
-| [Working with files](./working_with_files/)                              | 45 mins                    |
-| [Debugging workflows](./debugging/)                                      | 1 hour                     |
-
-## Multi-part courses
-
-!!! exercise "Plugin Development"
-
-    !!! tip inline end ""
-
-        :material-run-fast: Learn to use and build Nextflow plugins.
-
-    This course covers using existing plugins in your workflows and building your own from scratch, including custom functions, workflow monitoring, configuration, and distribution.
-
-    [Start the Plugin Development training :material-arrow-right:](plugin_development/){ .md-button .md-button--primary }
-
-Let us know what other domains and use cases you'd like to see covered here by posting in the [Training section](https://community.seqera.io/c/training/) of the community forum.
+Let us know what other topics you'd like to see covered here by posting in the [Training section](https://community.seqera.io/c/training/) of the community forum.

--- a/docs/en/docs/side_quests/orientation.md
+++ b/docs/en/docs/side_quests/orientation.md
@@ -1,51 +1,36 @@
-# Orientation
+# Getting started
 
-The GitHub Codespaces environment contains all the software, code and data necessary to work through this training course, so you don't need to install anything yourself.
-However, you do need a (free) account to log in, and you should take a few minutes to familiarize yourself with the interface.
+## Start a training environment
 
-If you have not yet done so, please follow [this link](../../envsetup/) before going any further.
+To use the pre-built environment we provide on GitHub Codespaces, click the "Open in GitHub Codespaces" button below.
+For other options, see [Environment options](../envsetup/index.md).
 
-## Materials provided
+We recommend opening the training environment in a new browser tab or window (use right-click, ctrl-click or cmd-click depending on your equipment) so that you can read on while the environment loads.
+You will need to keep these instructions open in parallel to work through the course.
 
-Throughout this training course, we'll be working in the `side-quests/` directory.
-This directory contains all the code files, test data and accessory files you will need.
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nextflow-io/training?quickstart=1&ref=master)
 
-Feel free to explore the contents of this directory; the easiest way to do so is to use the file explorer on the left-hand side of the GitHub Codespaces workspace.
-Alternatively, you can use the `tree` command.
-Throughout the course, we use the output of `tree` to represent directory structure and contents in a readable form, sometimes with minor modifications for clarity.
+### Environment basics
 
-Here we generate a table of contents to the second level down:
+This training environment contains all the software, code and data necessary to work through the training course, so you don't need to install anything yourself.
 
-```bash
-tree . -L 2
-```
+The codespace is set up with a VSCode interface, which includes a filesystem explorer, a code editor and a terminal shell.
+All instructions given during the course (e.g. 'open the file', 'edit the code' or 'run this command') refer to those three parts of the VSCode interface unless otherwise specified.
 
-If you run this inside `side-quests`, you should see the following output:
+If you are working through this course by yourself, please acquaint yourself with the [environment basics](../envsetup/01_setup.md) for further details.
 
-```console title="Directory contents"
-.
-├── metadata
-├── nf-core
-├── nf-test
-├── solutions
-├── splitting_and_grouping
-└── workflows_of_workflows
-```
+### Version requirements
 
-**Here's a summary of what you should know to get started:**
+This training works with Nextflow 25.10.2 or later **with the v2 syntax parser ENABLED**.
+If you are using a local or custom environment, please make sure you are using the correct settings as documented [here](../info/nxf_versions.md).
 
-- **Each directory corresponds to an individual side quest.**
-  Their contents are detailed on the corresponding side quest's page.
+## Readiness checklist
 
-- **The `solutions` directory** contains the completed workflow and/or module scripts that result from running through various steps of each side quest.
-  They are intended to be used as a reference to check your work and troubleshoot any issues.
+Think you're ready to dive in?
 
-!!!tip
+- [ ] I understand the goal of this course and its prerequisites
+- [ ] My environment is up and running
 
-    If for whatever reason you move out of this directory, you can always run this command to return to it:
+If you can check all the boxes, you're good to go.
 
-    ```bash
-    cd /workspaces/training/side-quests
-    ```
-
-Now, to begin the course, click on the arrow in the bottom right corner of this page.
+**To begin, select a Side Quest from the navigation menu.**

--- a/docs/en/mkdocs.yml
+++ b/docs/en/mkdocs.yml
@@ -68,6 +68,10 @@ nav:
       - side_quests/essential_scripting_patterns/index.md
       - side_quests/working_with_files/index.md
       - side_quests/metadata/index.md
+      - side_quests/splitting_and_grouping/index.md
+      - side_quests/nf_test/index.md
+      - side_quests/debugging/index.md
+      - side_quests/workflows_of_workflows/index.md
       - Plugin Development:
           - side_quests/plugin_development/index.md
           - side_quests/plugin_development/01_plugin_basics.md
@@ -78,10 +82,6 @@ nav:
           - side_quests/plugin_development/06_configuration.md
           - side_quests/plugin_development/summary.md
           - side_quests/plugin_development/next_steps.md
-      - side_quests/splitting_and_grouping/index.md
-      - side_quests/nf_test/index.md
-      - side_quests/debugging/index.md
-      - side_quests/workflows_of_workflows/index.md
   - Training Collections:
       - training_collections/index.md
       - training_collections/architects_toolkit_1.md

--- a/docs/en/ui-strings.yml
+++ b/docs/en/ui-strings.yml
@@ -15,7 +15,7 @@ index_page:
 
 defaults:
   technical_requirements: >-
-    You will need a GitHub account OR a local installation of Nextflow.
+    You will need a GitHub account OR a local installation of Nextflow. Our training courses are compatible with Nextflow version 25.10.2 or later and require the use of the v2 parser **EXCEPT the Hello nf-core course**, which requires the v1 parser.
     See [Environment options](../envsetup/index.md) for more details.
   videos: >-
     Videos are available for each chapter, featuring an instructor working


### PR DESCRIPTION
## Side Quests landing page and orientation overhaul                                                                               
                                                                                                                                     
  ### `docs/en/docs/side_quests/index.md`                                                                                            
                                                                                                                                     
  Complete rewrite to match the standard course landing page structure used by other modules:                                        
                                                                                                                                     
  - Added `page_type: index_page` / `index_type: course` frontmatter with learning objectives and audience prerequisites — these populate the "Additional information" box automatically                                                                            
  - Replaced the old freeform prerequisite section with a structured course overview table listing all nine side quests with title, summary, and time estimate                                                                                                         
  - Titles and order now match the navigation menu (Plugin Development moved to the end)
  - Added the standard CTA button (`Get started`)                                                                                    
  - Removed the embedded Codespaces button (environment setup is now handled in orientation)
                                                                                                                                     
  ### `docs/en/docs/side_quests/orientation.md`                                                                                      
   
  Rewritten to match the hello_nextflow orientation structure:                                                                       
                                                         
  - Renamed from "Orientation" to "Getting started"
  - Structured into: **Start a training environment** (Codespaces button, environment basics, version requirements) and **Readiness checklist**                                                                                                                        
  - Removed the old "Materials provided" section (working directory, `tree` output, solutions directory explanation)
                                                                                                                                     
  ### `docs/en/mkdocs.yml`                               

  - Moved Plugin Development sub-section to the end of the Side Quests nav (after Workflows of Workflows)                            
   
  ### `docs/en/ui-strings.yml`                                                                                                       
                                                         
  - Expanded the default `technical_requirements` string to specify the compatible Nextflow version (25.10.2+), v2 parser
  requirement, and the Hello nf-core exception