### PR TITLE
Pre-release doc fixes: hl_lines and inline code formatting

### DIFF
--- a/docs/en/docs/hello_nextflow/01_hello_world.md
+++ b/docs/en/docs/hello_nextflow/01_hello_world.md
@@ -212,7 +212,7 @@ nextflow run hello-world.nf
 
 ??? success "Command output"
 
-    ```console hl_lines="7"
+    ```console hl_lines="6"
     N E X T F L O W   ~  version 25.10.4
 
     Launching `hello-world.nf` [goofy_torvalds] DSL2 - revision: c33d41f479

--- a/docs/en/docs/hello_nextflow/02_hello_channels.md
+++ b/docs/en/docs/hello_nextflow/02_hello_channels.md
@@ -227,7 +227,7 @@ Add this tiny line to the workflow block:
 
 === "After"
 
-    ```groovy title="hello-channels.nf" linenums="27" hl_lines="7"
+    ```groovy title="hello-channels.nf" linenums="27" hl_lines="6"
     workflow {
 
         main:
@@ -912,7 +912,7 @@ In the workflow block, make the following code change:
     }
     ```
 
-You see we've added a second `.view` statement, and for each of them, we've replaced the empty parentheses (`()`) with curly braces containing some code, such as `{ greeting -> "Before flatten: $greeting" }`.
+You see we've added a second `.view` statement, and for each of them, we've replaced the empty parentheses (`()`) with curly braces containing some code, such as `#!groovy { greeting -> "Before flatten: $greeting" }`.
 
 These are called _closures_. The code they contain will be executed for each item in the channel.
 We define a temporary variable for the inner value, here called `greeting` (but it could be any arbitrary name), which is only used within the scope of that closure.
@@ -1022,7 +1022,7 @@ Make the following edit to the parameter declaration:
 
 === "Before"
 
-    ```groovy title="hello-channels.nf" linenums="20" hl_lines="5"
+    ```groovy title="hello-channels.nf" linenums="20" hl_lines="4"
     /*
      * Pipeline parameters
      */
@@ -1092,7 +1092,7 @@ nextflow run hello-channels.nf
 
 ??? failure "Command output"
 
-    ```console hl_lines="5 6 9 14"
+    ```console hl_lines="5 6 9 15"
      N E X T F L O W   ~  version 25.10.4
 
     Launching `hello-channels.nf` [peaceful_poisson] DSL2 - revision: a286c08ad5

--- a/docs/en/docs/hello_nextflow/03_hello_workflow.md
+++ b/docs/en/docs/hello_nextflow/03_hello_workflow.md
@@ -563,7 +563,7 @@ In the `output` block, make the following code change:
 
 === "After"
 
-    ```groovy title="hello-workflow.nf" linenums="82" hl_lines="9-12"
+    ```groovy title="hello-workflow.nf" linenums="82" hl_lines="10-13"
     output {
         first_output {
             path 'hello_workflow'

--- a/docs/en/docs/hello_nextflow/06_hello_config.md
+++ b/docs/en/docs/hello_nextflow/06_hello_config.md
@@ -41,7 +41,7 @@ By learning to utilize these configuration options effectively, you can enhance 
 We're going to use the workflow script `hello-config.nf` as a starting point.
 It is equivalent to the script produced by working through Part 5 of this training course, except we've changed the output destinations:
 
-```groovy title="hello-config.nf" linenums="37" hl_lines="3 7 11 15"
+```groovy title="hello-config.nf" linenums="37" hl_lines="3 7 11 15 19"
 output {
     first_output {
         path 'hello_config/intermediates'
@@ -743,7 +743,7 @@ Let's put that back, and also put the files in a `params.batch` subdirectory.
 
     Including `params.batch` in the output block `path`, instead of the `outputDir` config, means that it won't be overwritten with `-output-dir` on the CLI.
 
-First, update the config file to remove `${params.batch}` from `outputDir` (since we're moving it to the path declarations):
+First, update the config file to remove `#!groovy ${params.batch}` from `outputDir` (since we're moving it to the path declarations):
 
 === "After"
 

--- a/docs/en/docs/hello_nf-core/02_rewrite_hello.md
+++ b/docs/en/docs/hello_nf-core/02_rewrite_hello.md
@@ -1561,8 +1561,8 @@ Now we can update the `test.config` file as follows:
 
 Key points:
 
-- **Using `${projectDir}`**: This is a Nextflow implicit variable that points to the directory where the main workflow script is located (the pipeline root). Using it ensures the path works regardless of where the pipeline is run from.
-- **Absolute paths**: By using `${projectDir}`, we create an absolute path, which is important for test data that ships with the pipeline.
+- **Using `#!groovy ${projectDir}`**: This is a Nextflow implicit variable that points to the directory where the main workflow script is located (the pipeline root). Using it ensures the path works regardless of where the pipeline is run from.
+- **Absolute paths**: By using `#!groovy ${projectDir}`, we create an absolute path, which is important for test data that ships with the pipeline.
 - **Test data location**: nf-core pipelines typically store test data in the `assets/` directory within the pipeline repository for small test files, or reference external test datasets for larger files.
 
 And while we're at it, let's tighten the default resource limits to ensure this will run on very basic machines (like the minimal VMs in Github Codespaces):

--- a/docs/en/docs/hello_nf-core/03_use_module.md
+++ b/docs/en/docs/hello_nf-core/03_use_module.md
@@ -487,7 +487,7 @@ This is the relevant code:
 prefix = task.ext.prefix ?: "${meta.id}${file_extensions[0]}"
 ```
 
-This translates roughly as follows: if a `prefix` is provided via the external task parameter system (`task.ext`), use that to name the output file; otherwise create one using `${meta.id}`, which corresponds to the `id` field in the metamap.
+This translates roughly as follows: if a `prefix` is provided via the external task parameter system (`task.ext`), use that to name the output file; otherwise create one using `#!groovy ${meta.id}`, which corresponds to the `id` field in the metamap.
 
 You can imagine the input channel coming into this module with contents like this:
 

--- a/docs/en/docs/hello_nf-core/04_make_module.md
+++ b/docs/en/docs/hello_nf-core/04_make_module.md
@@ -547,7 +547,7 @@ withName: 'COWPY' {
 }
 ```
 
-The `withName:` syntax assigns this configuration to the `COWPY` process only, and `ext.args = { "-c ${params.character}" }` simply composes a string that will include the value of the `character` parameter.
+The `withName:` syntax assigns this configuration to the `COWPY` process only, and `#!groovy ext.args = { "-c ${params.character}" }` simply composes a string that will include the value of the `character` parameter.
 Note the use of curly braces, which tell Nextflow to evaluate the value of the parameter at runtime.
 
 Makes sense? Let's add it in.
@@ -786,14 +786,14 @@ Open the `cowpy.nf` module file (under `core-hello/modules/local/`) and modify i
 
 You can see we made three changes.
 
-1. **In the `script:` block, we added the line `prefix = task.ext.prefix ?: "${meta.id}"`.**
+1. **In the `script:` block, we added the line `#!groovy prefix = task.ext.prefix ?: "${meta.id}"`.**
    That line uses the `?:` operator to determine the value of the `prefix` variable: the content of `task.ext.prefix` if it is not empty, or the identifier from the metamap (`meta.id`) if it is.
    Note that while we generally refer to `ext.prefix`, this code must reference `task.ext.prefix` to pull out the module-level `ext.prefix` configuration.
 
-2. **In the command line, we replaced `cowpy-${input_file}` with `${prefix}.txt`.**
+2. **In the command line, we replaced `#!groovy cowpy-${input_file}` with `#!groovy ${prefix}.txt`.**
    This is where Nextflow will inject the value of `prefix` determined by the line above.
 
-3. **In the `output:` block, we replaced `path("cowpy-${input_file}")` with `path("${prefix}.txt")`.**
+3. **In the `output:` block, we replaced `#!groovy path("cowpy-${input_file}")` with `#!groovy path("${prefix}.txt")`.**
    This simply reiterates what the file path will be according to what is written in the command line.
 
 As a result, the output file name is now constructed using a sensible default (the identifier from the metamap) combined with the appropriate file format extension.
@@ -1079,7 +1079,7 @@ This may look complicated, so let's look at each of the three components:
 - **`path:`** Determines the output directory based on the process name.
   The full name of a process contained in `task.process` includes the hierarchy of workflow and module imports (such as `CORE_HELLO:HELLO:FIND_CONCATENATE`).
   The `tokenize` operations strip away that hierarchy to get just the process name, then take the first part before any underscore (if applicable), and convert it to lowercase.
-  This is what determines that the results of `FIND_CONCATENATE` get published to `${params.outdir}/find/`.
+  This is what determines that the results of `FIND_CONCATENATE` get published to `#!groovy ${params.outdir}/find/`.
 - **`mode:`** Controls how files are published (copy, symlink, etc.).
   This is configurable via the `params.publish_dir_mode` parameter.
 - **`saveAs:`** Filters which files to publish.
@@ -1449,10 +1449,10 @@ Update the input and output blocks:
 This specifies:
 
 - The input file parameter name (`input_file` instead of generic `input`)
-- The output filename using the configurable prefix pattern (`${prefix}.txt` instead of wildcard `*`)
+- The output filename using the configurable prefix pattern (`#!groovy ${prefix}.txt` instead of wildcard `*`)
 - A descriptive emit name (`cowpy_output` instead of generic `output`)
 
-If you're using the Nextflow language server to validate syntax, the `${prefix}` part will be flagged as an error at this stage because we haven't added it to the script block yet.
+If you're using the Nextflow language server to validate syntax, the `#!groovy ${prefix}` part will be flagged as an error at this stage because we haven't added it to the script block yet.
 Let's get to that now.
 
 #### 2.3.2. The script block
@@ -1488,7 +1488,7 @@ Based on the module we wrote manually earlier, we should make the following edit
 Key changes:
 
 - Change `def prefix` to just `prefix` (without `def`) to make it accessible in the output block
-- Fill in the actual `cowpy` command that uses both `$args` and `${prefix}.txt`
+- Fill in the actual `cowpy` command that uses both `$args` and `#!groovy ${prefix}.txt`
 
 Note that if we hadn't already done the work of adding the `ext.args` and `ext.prefix` configuration for the `COWPY` process to the `modules.config` file, we would need to do that now.
 
@@ -1529,7 +1529,7 @@ Key changes:
 
 - Change `def prefix` to just `prefix` to match the script block
 - Remove the `echo $args` line (which was just template placeholder code)
-- The stub creates an empty `${prefix}.txt` file matching what the script block produces
+- The stub creates an empty `#!groovy ${prefix}.txt` file matching what the script block produces
 
 This allows you to test workflow logic and file handling without waiting for the actual tool to run.
 

--- a/docs/en/docs/hello_nf-core/05_input_validation.md
+++ b/docs/en/docs/hello_nf-core/05_input_validation.md
@@ -625,7 +625,7 @@ Now update the channel creation code:
 
 Let's break down what changed:
 
-1. **`samplesheetToList(params.input, "${projectDir}/assets/schema_input.json")`**: Validates the input file against our schema and returns a list
+1. **`#!groovy samplesheetToList(params.input, "${projectDir}/assets/schema_input.json")`**: Validates the input file against our schema and returns a list
 2. **`channel.fromList(...)`**: Converts the list into a Nextflow channel
 
 This completes the implementation of input data validation using `samplesheetToList` and JSON schemas.

--- a/docs/en/docs/side_quests/essential_scripting_patterns/index.md
+++ b/docs/en/docs/side_quests/essential_scripting_patterns/index.md
@@ -641,7 +641,7 @@ The spread operator is particularly useful when you need to extract a single pro
 !!! tip "When to Use Spread vs Collect"
 
     - **Use spread (`*.`)** for simple property access: `samples*.id`, `files*.name`
-    - **Use collect** for transformations or complex logic: `samples.collect { it.id.toUpperCase() }`, `samples.collect { [it.id, it.quality > 40] }`
+    - **Use collect** for transformations or complex logic: `#!groovy samples.collect { it.id.toUpperCase() }`, `#!groovy samples.collect { [it.id, it.quality > 40] }`
 
 ### Takeaway
 
@@ -1868,7 +1868,7 @@ Create a validation function before your workflow block, call it from the workfl
 
 === "After"
 
-    ```groovy title="main.nf" linenums="1" hl_lines="5-20 23-24"
+    ```groovy title="main.nf" linenums="1" hl_lines="5-15 18-19"
     include { FASTP } from './modules/fastp.nf'
     include { TRIMGALORE } from './modules/trimgalore.nf'
     include { GENERATE_REPORT } from './modules/generate_report.nf'

--- a/docs/en/docs/side_quests/metadata/index.md
+++ b/docs/en/docs/side_quests/metadata/index.md
@@ -1158,8 +1158,8 @@ For a more detailed explanation, see the box below.
 
     This does the following:
 
-    - `map1, lang_id ->` takes the two items in the tuple
-    - `map1 + [lang: lang_id]` creates the new map as detailed above
+    - `#!groovy map1, lang_id ->` takes the two items in the tuple
+    - `#!groovy map1 + [lang: lang_id]` creates the new map as detailed above
 
     The output is a single unnamed map with the same contents as `new_map` in our example above.
     So we've effectively transformed:
@@ -1188,7 +1188,7 @@ For a more detailed explanation, see the box below.
     }
     ```
 
-    If you're having a hard time following why the `file` seems to be moving around in the `map` operation, imagine that instead of `[meta + [lang: lang_id], file]`, that line reads `[new_map, file]`.
+    If you're having a hard time following why the `file` seems to be moving around in the `map` operation, imagine that instead of `#!groovy [meta + [lang: lang_id], file]`, that line reads `[new_map, file]`.
     This should make it more clear that we're simply leaving the `file` in its original place in second position in the tuple. We've just taken the `new_info` value and folded it into the map that's in first position.
 
     **And this brings us back to the `tuple val(meta), path(file)` channel structure!**

--- a/docs/en/docs/side_quests/workflows_of_workflows/index.md
+++ b/docs/en/docs/side_quests/workflows_of_workflows/index.md
@@ -290,7 +290,7 @@ The solution is an entry workflow in `main.nf` that imports and calls `GREETING_
 
 ### 1.3. Update and test the main workflow
 
-Now , let's update the main workflow to call the greeting workflow.
+Now let's update the main workflow to call the greeting workflow.
 
 #### 1.3.1. Include the greeting workflow and call it
 
@@ -492,7 +492,7 @@ The transform workflow is now composable and ready to be imported into the main 
 
 ### 2.3. Update and test the main workflow
 
-Now , let's update the main workflow to call the transformation workflow.
+Now let's update the main workflow to call the transformation workflow.
 
 #### 2.3.1. Include the transformation workflow and call it
 

--- a/docs/en/docs/side_quests/working_with_files/index.md
+++ b/docs/en/docs/side_quests/working_with_files/index.md
@@ -1634,7 +1634,7 @@ In order to feed the remapped contents to the `ANALYZE_READS` process (and do so
 
 We can do that using the [`set`](https://www.nextflow.io/docs/latest/reference/operator.html#set) operator.
 
-In the main workflow, replace the `.view()` operator with `.set { ch_samples }`, and add a line testing that we can refer to the channel by name.
+In the main workflow, replace the `.view()` operator with `#!groovy .set { ch_samples }`, and add a line testing that we can refer to the channel by name.
 
 === "After"
 


### PR DESCRIPTION
Fix incorrect hl_lines values in hello_nextflow and side quests (metadata, workflows_of_workflows, essential_scripting_patterns, working_with_files). Add missing #!groovy syntax highlighting to inline code with string interpolation and closures across hello_nf-core lessons.