### PR TITLE
Bump nf-co2footprint to 1.3.0, remove config-warning workaround

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
         // Nextflow installation version
         "NXF_HOME": "/workspaces/.nextflow",
         "NXF_EDGE": "0",
-        "NXF_VER": "25.10.4",
+        "NXF_VER": "26.04.0",
         "NXF_SYNTAX_PARSER": "v2",
         // Other env vars
         "HOST_PROJECT_PATH": "/workspaces/training",

--- a/docs/en/docs/side_quests/plugin_development/01_plugin_basics.md
+++ b/docs/en/docs/side_quests/plugin_development/01_plugin_basics.md
@@ -509,7 +509,7 @@ Update `nextflow.config`:
     plugins {
         id 'nf-hello@0.5.0'
         id 'nf-schema@2.6.1'
-        id 'nf-co2footprint@1.2.0'
+        id 'nf-co2footprint@1.3.0'
     }
     ```
 
@@ -532,7 +532,7 @@ The plugin produces several INFO and WARN messages during execution.
 These are normal for a small example running on a local machine:
 
 ```console title="Output (partial)"
-nf-co2footprint plugin  ~  version 1.2.0
+nf-co2footprint plugin  ~  version 1.3.0
 WARN - [nf-co2footprint] Target zone null not found. Attempting to retrieve carbon intensity for fallback zone GLOBAL.
 INFO - [nf-co2footprint] Using fallback carbon intensity from GLOBAL from CI table: 480.0 gCO₂eq/kWh.
 WARN - [nf-co2footprint] Executor 'null' not mapped.
@@ -598,7 +598,7 @@ Add a `co2footprint` block to `nextflow.config`:
     plugins {
         id 'nf-hello@0.5.0'
         id 'nf-schema@2.6.1'
-        id 'nf-co2footprint@1.2.0'
+        id 'nf-co2footprint@1.3.0'
     }
 
     co2footprint {
@@ -612,7 +612,7 @@ Add a `co2footprint` block to `nextflow.config`:
     plugins {
         id 'nf-hello@0.5.0'
         id 'nf-schema@2.6.1'
-        id 'nf-co2footprint@1.2.0'
+        id 'nf-co2footprint@1.3.0'
     }
     ```
 
@@ -632,11 +632,6 @@ INFO - [nf-co2footprint] Using fallback carbon intensity from GB from CI table: 
 
 The zone warning is gone.
 The plugin now uses GB-specific carbon intensity (163.92 gCO₂eq/kWh) instead of the global fallback (480.0 gCO₂eq/kWh).
-
-!!! note
-
-    You may also see a `WARN: Unrecognized config option 'co2footprint.location'` message.
-    This is cosmetic and can be safely ignored; the plugin still reads the value correctly.
 
 In Part 6, you'll create a configuration scope for your own plugin.
 


### PR DESCRIPTION
## Summary

- Bump `nf-co2footprint` plugin pin in the plugin-basics side quest from `1.2.0` to `1.3.0`.
- Remove the `!!! note` admonition that told learners to ignore the cosmetic `WARN: Unrecognized config option 'co2footprint.location'` message.
- Bump `NXF_VER` in `.devcontainer/devcontainer.json` from `25.10.4` to `26.04.0` (required by plugin 1.3.0, see below).

The upstream fix landed in [nf-co2footprint 1.3.0](https://github.com/nextflow-io/nf-co2footprint/blob/master/CHANGELOG.md):

> Eliminated `Unrecognized config option` warnings under Nextflow's v2 syntax parser by registering `CO2FootprintConfig` as an extension point and aligning the nested file-config scopes with the v2 `ConfigScope` discovery rules

## Draft - Nextflow version implication

`nf-co2footprint@1.3.0` declares a minimum Nextflow version of `26.04.0`, so the devcontainer pin had to move up too. Confirmed locally:

```
Failed requirement - Plugin nf-co2footprint@1.3.0 requires Nextflow version >=26.04.0 (current 25.10.2)
```

After bumping `NXF_VER=26.04.0`, the plugin loads cleanly and the cosmetic warning is gone.

This is left as draft because bumping `NXF_VER` will affect every other tutorial under `docs/en/`. There are roughly 30+ console-output snippets across `hello_nextflow/`, `nf4_science/`, etc. that show `N E X T F L O W   ~  version 25.10.x`, plus prose like \"This training is designed for Nextflow 25.10.x or later\" in `index.md` and orientation pages. Those will look stale to anyone running the training off this branch.

Open questions for reviewers:

1. Do we want to do a coordinated NXF_VER bump (touching all `25.10.x` references) before merging this?
2. Or split: ship a smaller PR that only updates the side quest, keeping the plugin pin at 1.2.0 and rephrasing the workaround note to point at 1.3.0 + Nextflow 26?
3. Or wait for an org-wide \"bump to 26\" PR and rebase this on top?

## Test plan

- [x] Verified locally with Docker (`ghcr.io/nextflow-io/training:latest`, `NXF_VER=26.04.0`) that `nextflow run hello.nf` against the section 3.4 config emits no `Unrecognized config option` warning.
- [x] Verified the GB-specific carbon intensity (`163.92 gCO₂eq/kWh`) is still applied as documented.
- [ ] CI / docs build
- [ ] Reviewer confirms the broader version-bump strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)