### PR TITLE
Experiment: pre-install Seqera AI CLI in training devcontainer

### DIFF
--- a/.devcontainer/codespaces-dev/devcontainer.json
+++ b/.devcontainer/codespaces-dev/devcontainer.json
@@ -16,6 +16,7 @@
             "version": "3.13"
         },
         "ghcr.io/devcontainers/features/java:1": { "version": "21.0.6-ms" },
+        "ghcr.io/devcontainers/features/node:1": { "version": "20" },
         "ghcr.io/rocker-org/devcontainer-features/miniforge:2": {
             "version": "latest"
         },
@@ -24,7 +25,8 @@
         "../local-features/tower-agent": {},
         "../local-features/nextflow": {},
         "../local-features/conda-channels": {},
-        "../local-features/uv-tools": {}
+        "../local-features/uv-tools": {},
+        "../local-features/seqera-ai": {}
     },
     "workspaceFolder": "/workspaces/training",
     "remoteUser": "root",

--- a/.devcontainer/local-features/seqera-ai/devcontainer-feature.json
+++ b/.devcontainer/local-features/seqera-ai/devcontainer-feature.json
@@ -2,7 +2,5 @@
     "id": "seqera-ai",
     "name": "Install Seqera AI CLI",
     "description": "Install the Seqera AI CLI (npm package 'seqera'), the command-line interface to Seqera AI",
-    "installsAfter": [
-        "ghcr.io/devcontainers/features/node"
-    ]
+    "installsAfter": ["ghcr.io/devcontainers/features/node"]
 }

--- a/.devcontainer/local-features/seqera-ai/devcontainer-feature.json
+++ b/.devcontainer/local-features/seqera-ai/devcontainer-feature.json
@@ -1,0 +1,8 @@
+{
+    "id": "seqera-ai",
+    "name": "Install Seqera AI CLI",
+    "description": "Install the Seqera AI CLI (npm package 'seqera'), the command-line interface to Seqera AI",
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/node"
+    ]
+}

--- a/.devcontainer/local-features/seqera-ai/install.sh
+++ b/.devcontainer/local-features/seqera-ai/install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Install Seqera AI CLI (BETA, BUSL-1.1).
+# Tracks the @dev npm channel so the training image picks up fixes quickly.
+# Requires node + npm to be available before this feature runs.
+
+set -euo pipefail
+
+if ! command -v npm >/dev/null 2>&1; then
+    echo "seqera-ai feature: npm not found - skipping install." >&2
+    exit 0
+fi
+
+npm install -g seqera@dev


### PR DESCRIPTION
## Summary

Experiment: pre-install the [Seqera AI CLI](https://docs.seqera.io/platform-cloud/seqera-ai) in the training devcontainer so learners can use it without a separate install step.

- New local feature `.devcontainer/local-features/seqera-ai/` runs `npm install -g seqera@dev` (dev channel; the published stable is marked BETA today).
- Adds `ghcr.io/devcontainers/features/node:1` (Node 20) because the prebuilt training image currently has no `node`/`npm`.
- Wired into `codespaces-dev/devcontainer.json` only (the file that builds the published `ghcr.io/nextflow-io/training:latest` image). The production devcontainer.json keeps using that image, so no change needed there.

## Footprint

- Node 20 feature: ~80 MB
- Seqera AI prebuilt linux-x64 binary pulled by `npm install -g seqera`: ~105 MB unpacked
- Total: roughly **+185 MB** to the image. The current image is ~several GB (Java, Apptainer, conda, MkDocs, nf-core tooling), so single-digit % bump.

Authentication happens on first run (`seqera login`), not at build time, so the image itself stays unauthenticated.

## Things to decide before merge

- [ ] Are we comfortable bundling a **BETA**, **closed-source (BUSL-1.1)** tool into the official training image? This is a policy call, not just a technical one.
- [ ] `@dev` channel was picked for fast iteration. Want to pin to `latest` (stable BETA) instead?
- [ ] No matching mention in any lesson content yet. If we go ahead, a short note in the orientation pages would tell learners it's available.
- [ ] The npm package only ships `darwin-{arm64,x64}` and `linux-x64` prebuilts; if/when ARM Linux training images appear, the install will fail. The install.sh exits gracefully if `npm` is missing, but doesn't yet guard against the missing-arch case.

## Test plan

- [ ] CI builds the codespaces-dev image successfully
- [ ] Open the codespace, run `seqera --version` and `seqera ai --help` to confirm the binary is on PATH
- [ ] Confirm Node 20 doesn't conflict with anything (extension pack, mkdocs preview, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)