### PR TITLE
Fix gremlins in nf-test, essential scripting, and debugging side quests

### DIFF
--- a/docs/en/docs/side_quests/debugging/index.md
+++ b/docs/en/docs/side_quests/debugging/index.md
@@ -512,7 +512,7 @@ If you get a 'No such variable' error, you can fix it by either defining the var
         val sample_name
 
         output:
-        path "${sample_name}_output.txt"
+        path "${sample_name}_processed.txt"
 
         script:
         // Define variables in Groovy code before the script
@@ -887,7 +887,7 @@ The error message clearly states that the call expected 1 argument but received 
 
 process PROCESS_FILES {
     input:
-        val sample_name  // Process expects only 1 input
+        val sample_name  // Process expects only 1 input channel
 
     output:
         path "${sample_name}_output.txt"
@@ -924,7 +924,7 @@ For this specific example, the process expects a single channel and doesn't requ
 
     process PROCESS_FILES {
         input:
-            val sample_name  // Process expects only 1 input
+            val sample_name  // Process expects only 1 input channel
 
         output:
             path "${sample_name}_output.txt"
@@ -953,7 +953,7 @@ For this specific example, the process expects a single channel and doesn't requ
 
     process PROCESS_FILES {
         input:
-            val sample_name  // Process expects only 1 input
+            val sample_name  // Process expects only 1 input channel
 
         output:
             path "${sample_name}_output.txt"
@@ -1006,14 +1006,14 @@ nextflow run exhausted.nf
 
 ??? success "Command output"
 
-```console title="Exhausted channel output"
- N E X T F L O W   ~  version 25.10.4
+    ```console title="Exhausted channel output"
+     N E X T F L O W   ~  version 25.10.4
 
-Launching `exhausted.nf` [extravagant_gauss] DSL2 - revision: 08cff7ba2a
+    Launching `exhausted.nf` [extravagant_gauss] DSL2 - revision: 08cff7ba2a
 
-executor >  local (1)
-[bd/f61fff] PROCESS_FILES (1) [100%] 1 of 1 ✔
-```
+    executor >  local (1)
+    [bd/f61fff] PROCESS_FILES (1) [100%] 1 of 1 ✔
+    ```
 
 This workflow completes without error, but it only processes a single sample!
 
@@ -1715,8 +1715,10 @@ nextflow run bad_resources.nf -profile docker
 
 Let's examine `bad_resources.nf`:
 
-```groovy title="bad_resources.nf" linenums="3" hl_lines="3"
+```groovy title="bad_resources.nf" linenums="3" hl_lines="5"
 process PROCESS_FILES {
+
+    container 'community.wave.seqera.io/library/cowpy:1.1.5--3db457ae1977a273'
 
     time '1 ms'  // ERROR: Unrealistic time limit
 
@@ -2469,7 +2471,7 @@ Now it's time to put the systematic debugging approach into practice. The workfl
             script:
             """
             # Simulate heavy computation
-            for i in {1..1000000}; do
+            for i in {1..10000}; do
                 echo "Heavy computation \$i for ${sample_id}"
             done > ${sample_id}_heavy.txt
             """

--- a/docs/en/docs/side_quests/essential_scripting_patterns/index.md
+++ b/docs/en/docs/side_quests/essential_scripting_patterns/index.md
@@ -81,10 +81,6 @@ SAMPLE_003,human,kidney,45000000,data/sequences/SAMPLE_003_S3_L001_R1_001.fastq,
 
 We'll use this realistic dataset to explore practical programming techniques that you'll encounter in real bioinformatics workflows.
 
-<!-- TODO: Can we make this more domain-agnostic? -->
-
-<!-- TODO: add an assignment statement? #### Review the assignment -->
-
 #### Readiness checklist
 
 Think you're ready to dive in?
@@ -499,7 +495,7 @@ Now let's see the `collect` method on a List in action. Modify `collect.nf` to a
 
 === "After"
 
-    ```groovy title="main.nf" linenums="1" hl_lines="9-13"
+    ```groovy title="collect.nf" linenums="1" hl_lines="9-13"
     def sample_ids = ['sample_001', 'sample_002', 'sample_003']
 
     // channel.collect() - groups multiple channel emissions into one
@@ -517,7 +513,7 @@ Now let's see the `collect` method on a List in action. Modify `collect.nf` to a
 
 === "Before"
 
-    ```groovy title="main.nf" linenums="1"
+    ```groovy title="collect.nf" linenums="1"
     def sample_ids = ['sample_001', 'sample_002', 'sample_003']
 
     // channel.collect() - groups multiple channel emissions into one
@@ -851,7 +847,7 @@ Then modify the `workflow` block to connect the `ch_samples` channel to the `FAS
                 ] : [:]
 
                 def priority = sample_meta.quality > 40 ? 'high' : 'normal'
-                return [sample_meta + file_meta + [priority: priority], file(row.file_path)]
+                return tuple(sample_meta + file_meta + [priority: priority], fastq_path)
             }
             .view()
     }
@@ -1091,12 +1087,21 @@ Include the process in your `main.nf` and add it to the workflow:
 
 Now run the workflow and check the generated reports in `results/reports/`. They should contain basic information about each sample.
 
-<!-- TODO: add the run command -->
+```bash
+nextflow run main.nf
+```
 
 ??? success "Command output"
 
     ```console
-    <!-- TODO: output -->
+    N E X T F L O W  ~  version 25.10.4
+    Launching `main.nf` [dreamy_stonebraker] DSL2 - revision: 8ba7d0c7eb
+    [44/717c58] Submitted process > FASTP (1)
+    [16/426f16] Submitted process > FASTP (2)
+    [7b/846764] Submitted process > GENERATE_REPORT (1)
+    [20/54a02e] Submitted process > FASTP (3)
+    [59/cdba3d] Submitted process > GENERATE_REPORT (2)
+    [33/a0e0da] Submitted process > GENERATE_REPORT (3)
     ```
 
 But what if we want to add information about when and where the processing occurred? Let's modify the process to use **shell** variables and a bit of command substitution to include the current user, hostname, and date in the report:
@@ -1129,8 +1134,8 @@ If you run this, you'll notice an error - Nextflow tries to interpret `#!groovy 
 ??? failure "Command output"
 
     ```console
-    Error modules/generate_report.nf:15:27: `USER` is not defined
-    │  15 |     echo "Processed by: ${USER}" >> ${meta.id}_report.txt
+    Error modules/generate_report.nf:13:27: `USER` is not defined
+    │  13 |     echo "Processed by: ${USER}" >> ${meta.id}_report.txt
     ╰     |                           ^^^^
 
     ERROR ~ Script compilation failed
@@ -1636,7 +1641,8 @@ nextflow run main.nf
     [1f/a1a4ca] Re-submitted process > FASTP (2)
     ```
 
-Because we've chosen a filter that excludes some samples, fewer tasks were executed.
+In this case all three samples satisfy the filter, so every sample continues down the pipeline.
+A stricter threshold would exclude low-depth samples and reduce the number of tasks that run.
 
 The filter expression `meta.id && meta.organism && meta.depth >= 25000000` combines truthiness with explicit comparisons:
 
@@ -1762,7 +1768,18 @@ nextflow run main.nf
 ??? success "Command output"
 
     ```console
-    <!-- TODO: output -->
+    N E X T F L O W  ~  version 25.10.4
+    Launching `main.nf` [lonely_torricelli] DSL2 - revision: 309f496f9a
+    [85/8117bf] Submitted process > TRIMGALORE (1)
+    [20/714ab9] Submitted process > FASTP (1)
+    [ca/de6fd3] Submitted process > GENERATE_REPORT (1)
+    [ca/ff5356] Submitted process > FASTP (2)
+    [10/aa6ea8] Submitted process > GENERATE_REPORT (2)
+    [9f/baa7fb] Submitted process > GENERATE_REPORT (3)
+    [20/714ab9] NOTE: Process `FASTP (1)` terminated with an error exit status (137) -- Execution is retried (1)
+    [ca/ff5356] NOTE: Process `FASTP (2)` terminated with an error exit status (137) -- Execution is retried (1)
+    [f2/2a5d19] Re-submitted process > FASTP (1)
+    [44/b23306] Re-submitted process > FASTP (2)
     ```
 
 No crash! The workflow now handles the missing field gracefully. When `row.run_id` is `null`, the `?.` operator prevents the `.toUpperCase()` call, and `run_id` becomes `null` instead of causing an exception.
@@ -1946,7 +1963,18 @@ nextflow run main.nf --input ./data/samples.csv
 ??? success "Command output"
 
     ```console
-    <!-- TODO: output -->
+    N E X T F L O W  ~  version 25.10.4
+    Launching `main.nf` [dreamy_archimedes] DSL2 - revision: dc24727993
+    [bc/0527b6] Submitted process > FASTP (2)
+    [65/5bb40c] Submitted process > GENERATE_REPORT (1)
+    [b3/aa7df2] Submitted process > GENERATE_REPORT (2)
+    [39/9d740f] Submitted process > GENERATE_REPORT (3)
+    [06/1c0d94] Submitted process > TRIMGALORE (1)
+    [0e/23c643] Submitted process > FASTP (1)
+    [0e/23c643] NOTE: Process `FASTP (1)` terminated with an error exit status (137) -- Execution is retried (1)
+    [bc/0527b6] NOTE: Process `FASTP (2)` terminated with an error exit status (137) -- Execution is retried (1)
+    [12/aa9122] Re-submitted process > FASTP (1)
+    [b5/1eba3b] Re-submitted process > FASTP (2)
     ```
 
 This time it runs successfully.
@@ -2133,7 +2161,9 @@ Let's make it more useful by adding conditional logic:
 
 Now we get an even more informative summary, including a success/failure message and the output directory if specified:
 
-<!-- TODO: add run command -->
+```bash
+nextflow run main.nf
+```
 
 ??? success "Command output"
 

--- a/docs/en/docs/side_quests/nf_test/index.md
+++ b/docs/en/docs/side_quests/nf_test/index.md
@@ -79,7 +79,8 @@ You'll find a main workflow file and a CSV file called `greetings.csv` that cont
 ```console title="Directory contents"
 .
 ├── greetings.csv
-└── main.nf
+├── main.nf
+└── nextflow.config
 ```
 
 For a detailed description of the files, see the [warmup from Hello Nextflow](../../hello_nextflow/00_orientation.md).
@@ -109,21 +110,23 @@ You can see the full workflow code below.
 ??? example "Workflow code"
 
     ```groovy title="main.nf"
+    #!/usr/bin/env nextflow
+
     /*
-    * Pipeline parameters
-    */
+     * Pipeline parameters
+     */
     params.input_file = "greetings.csv"
 
     /*
-    * Use echo to print 'Hello World!' to standard out
-    */
+     * Use echo to print 'Hello World!' to standard out
+     */
     process sayHello {
 
         input:
-            val greeting
+        val greeting
 
         output:
-            path "${greeting}-output.txt"
+        path "${greeting}-output.txt"
 
         script:
         """
@@ -132,15 +135,15 @@ You can see the full workflow code below.
     }
 
     /*
-    * Use a text replace utility to convert the greeting to uppercase
-    */
+     * Use a text replace utility to convert the greeting to uppercase
+     */
     process convertToUpper {
 
         input:
-            path input_file
+        path input_file
 
         output:
-            path "UPPER-${input_file}"
+        path "UPPER-${input_file}"
 
         script:
         """

--- a/side-quests/debugging/buggy_workflow.nf
+++ b/side-quests/debugging/buggy_workflow.nf
@@ -44,7 +44,7 @@ process heavyProcess {
     script:
     """
     # Simulate heavy computation
-    for i in {1..1000000}; do
+    for i in {1..10000}; do
         echo "Heavy computation $i for ${sample_id}"
     done > ${sample_id}.txt
     """

--- a/side-quests/solutions/nf-test/tests/main.converttoupper.nf.test.snap
+++ b/side-quests/solutions/nf-test/tests/main.converttoupper.nf.test.snap
@@ -1,16 +1,16 @@
 {
-    "Should run without failures": {
+    "Should run without failures and produce correct output": {
         "content": [
             {
                 "0": [
-                    "UPPER-greetings.csv:md5,f36624b0e040fa880e61fb1304b4b6b9"
+                    "UPPER-greetings.csv:md5,2985c521c6b7ed5c97946d6356a5fe64"
                 ]
             }
         ],
+        "timestamp": "2026-06-08T10:35:50.126073832",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
-        },
-        "timestamp": "2025-02-19T11:57:20.215132756"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
Walked the nf-test, Essential Scripting Patterns, and Debugging side quests end-to-end as a learner (latest master, Nextflow 25.10.4, strict v2 parser) and fixed the discrepancies found.

## Debugging
- Corrected workflow could time out: `heavyProcess` looped `{1..1000000}` while the only documented fix raised the limit to `100 s`. 1M iterations can exceed 100 s, so following the lesson verbatim left a failing workflow. Reduced to `{1..10000}` (matching the solution) in both the "Complete Corrected Workflow" block and the starter `buggy_workflow.nf`. The `time '1 ms'` bug is preserved for teaching; only the post-fix run is corrected.
- Indented the `exhausted.nf` command-output block so it renders inside its `??? success` collapsible.
- Aligned the no_such_var Before-tab output filename (`_processed.txt`), the "expects only 1 input channel" comments, and the `bad_resources.nf` snippet (added the omitted `container` line, fixed `hl_lines`) with the actual files.

## Essential Scripting Patterns
- Corrected the `.filter()` prose: with `depth >= 25000000` no samples are excluded (the lowest sample is exactly 25000000), so all three pass.
- Fixed the `generate_report.nf` compile-error line number to `13:27`.
- Fixed the `collect.nf` tab titles (were `main.nf`); used `tuple(...)` in the FASTP Before tab.
- Filled the missing run commands and the three empty command-output blocks (which rendered literal `<!-- TODO: output -->` text) with captured output; removed stray author-note placeholders.

## nf-test
- Regenerated the `convertToUpper` solution snapshot: its key did not match the test name, so the snapshot was silently regenerated instead of verified. Key and md5 now match.
- Added `nextflow.config` to the directory listing; aligned the "Workflow code" snippet with `main.nf` (shebang, flush input/output declarations).

Headings validate; no new prettier issues.

### Follow-up (not in this PR)
At Essential 2.3 the prose says reports land in `results/reports/`, but at that point the module has no `publishDir`/output block, so they go to `work/` until the output block is introduced later in the lesson. Flagging for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)